### PR TITLE
TAC calibration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,10 @@ $(LB)/MModuleDiagnostics.o \
 $(LB)/MModuleDiagnosticsEnergyPerStrip.o \
 $(LB)/MGUIExpoDiagnosticsEnergyPerStrip.o \
 $(LB)/MGUIExpoDiagnostics.o \
+$(LB)/MModuleTACcut.o \
+$(LB)/MGUIExpoTACcut.o \
+$(LB)/MGUIOptionsTACcut.o \
+
 
 
 

--- a/include/MAssembly.h
+++ b/include/MAssembly.h
@@ -53,24 +53,26 @@ class MAssembly
   static const uint64_t c_EventLoaderMeasurement   = (1 << 2);  // = 4
   static const uint64_t c_EventOrdering            = (1 << 3);  // = 8
   static const uint64_t c_Coincidence              = (1 << 4);  // = 16
-  static const uint64_t c_DetectorEffectsEngine    = (1 << 5);  // = 32
-  static const uint64_t c_EventFilter              = (1 << 6);  // = 64
-  static const uint64_t c_EnergyCalibration        = (1 << 7);  // = 128
-  static const uint64_t c_ChargeSharingCorrection  = (1 << 8);  // = 256
-  static const uint64_t c_DepthCorrection          = (1 << 9);  // = 512
-  static const uint64_t c_StripPairing             = (1 << 10); // = 1024
-  static const uint64_t c_Aspect                   = (1 << 11); // = 2048
-  static const uint64_t c_CrosstalkCorrection      = (1 << 12); // = 4096
-  static const uint64_t c_EventReconstruction      = (1 << 13); // = 8196
-  static const uint64_t c_Else                     = (1 << 14);
-  static const uint64_t c_NoRestriction            = (1 << 15);
-  static const uint64_t c_EventSaver               = (1 << 16);
-  static const uint64_t c_EventTransmitter         = (1 << 17);
-  static const uint64_t c_PositionDetermiation     = (1 << 18);
-  static const uint64_t c_Statistics               = (1 << 19);
-  static const uint64_t c_FlagHits                 = (1 << 20);
-  static const uint64_t c_Diagnostics              = (1 << 21);
-  static const uint64_t c_ResponseGeneration       = (1 << 22);
+  static const uint64_t c_TACcut                   = (1 << 5);  // = 32
+  static const uint64_t c_DetectorEffectsEngine    = (1 << 6);
+  static const uint64_t c_EventFilter              = (1 << 7);  // = 64
+  static const uint64_t c_EnergyCalibration        = (1 << 8);  // = 128
+  static const uint64_t c_ChargeSharingCorrection  = (1 << 9);  // = 256
+  static const uint64_t c_DepthCorrection          = (1 << 10);  // = 512
+  static const uint64_t c_StripPairing             = (1 << 11); // = 1024
+  static const uint64_t c_Aspect                   = (1 << 12); // = 2048
+  static const uint64_t c_CrosstalkCorrection      = (1 << 13); // = 4096
+  static const uint64_t c_EventReconstruction      = (1 << 14); // = 8196
+  static const uint64_t c_Else                     = (1 << 15);
+  static const uint64_t c_NoRestriction            = (1 << 16);
+  static const uint64_t c_EventSaver               = (1 << 17);
+  static const uint64_t c_EventTransmitter         = (1 << 18);
+  static const uint64_t c_PositionDetermiation     = (1 << 19);
+  static const uint64_t c_Statistics               = (1 << 20);
+  static const uint64_t c_FlagHits                 = (1 << 21);
+  static const uint64_t c_Diagnostics              = (1 << 22);
+  static const uint64_t c_ResponseGeneration       = (1 << 23);
+
 
   // IMPORTANT:
   // If you add one analysis level, make sure you also handle it in:

--- a/include/MGUIExpoTACcut.h
+++ b/include/MGUIExpoTACcut.h
@@ -1,0 +1,124 @@
+/*
+ * MGUIExpoTACcut.h
+ *    
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIExpoTACcut__
+#define __MGUIExpoTACcut__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TString.h>
+#include <TGClient.h>
+#include <TRootEmbeddedCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+
+// NuSTAR libs
+#include "MGUIExpo.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIExpoTACcut : public MGUIExpo
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIExpoTACcut(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIExpoTACcut();
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  //! Update the frame
+  virtual void Update();
+
+  //! Reset the data in the UI
+  virtual void Reset();
+
+  //! Export the data in the UI
+  virtual void Export(const MString& FileName);
+
+  //! Set the arrangment of the TAC histogram
+  //!  0    1    2    3 
+  //!  4    5    6    7
+  //!  8    9   10   11
+  void SetTACHistogramArrangement(vector<unsigned int>* DetIDs);
+  
+  //! Set the energy histogram parameters 
+  void SetTACHistogramParameters(unsigned int DetID, unsigned int NBins, double TACMin, double TACMax);
+  
+  //! Set the energy histogram parameters 
+  void SetTACHistogramName(unsigned int DetID, MString Name);
+
+  //! Add data to the TAC histogram
+  //!  0    1    2    3 
+  //!  4    5    6    7
+  //!  8    9   10   11
+  void AddTAC(unsigned int DetID, double TAC);
+
+  // protected methods:
+ protected:
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+  //! TAC canvas
+  unordered_map<unsigned int, TRootEmbeddedCanvas*> m_TACCanvases;
+  //! TAC vs detector ID histogram
+  unordered_map<unsigned int, TH1D*> m_TACHistograms;
+
+  //! Detectors in x direction
+  unsigned int m_NColumns;
+  //! Detectors in y direction
+  unsigned int m_NRows;
+
+  // Map the detector ID to the x,y position of histograms.
+  vector<vector<unsigned int>> m_DetectorMap;
+  
+  //! The number of bins of the histogram
+  unordered_map<unsigned int, unsigned int> m_NBins;
+  //! The minimum TAC
+  unordered_map<unsigned int, double> m_Min;
+  //! The maximum TAC
+  unordered_map<unsigned int, double> m_Max;
+  
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIExpoTACcut, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MGUIExpoTACcut.h
+++ b/include/MGUIExpoTACcut.h
@@ -67,7 +67,7 @@ class MGUIExpoTACcut : public MGUIExpo
   //!  0    1    2    3 
   //!  4    5    6    7
   //!  8    9   10   11
-  void SetTACHistogramArrangement(vector<unsigned int>* DetIDs);
+  void SetTACHistogramArrangement(const vector<unsigned int> DetIDs);
   
   //! Set the energy histogram parameters 
   void SetTACHistogramParameters(unsigned int DetID, unsigned int NBins, double TACMin, double TACMax);

--- a/include/MGUIOptionsDepthCalibration2024.h
+++ b/include/MGUIOptionsDepthCalibration2024.h
@@ -74,9 +74,6 @@ class MGUIOptionsDepthCalibration2024 : public MGUIOptions
   //! Select spline file to load, splines will convert CTD->Depth
   MGUIEFileSelector* m_SplinesFileSelector;
 
-  //! Select TAC Calibration file to load, converts readout timing to nanoseconds
-  MGUIEFileSelector* m_TACCalFileSelector;
-
   //! Check button if working with the Card Cage at UCSD
   TGCheckButton* m_UCSDOverride;
 

--- a/include/MGUIOptionsTACcut.h
+++ b/include/MGUIOptionsTACcut.h
@@ -73,8 +73,6 @@ class MGUIOptionsTACcut : public MGUIOptions
 
   //! Select TAC Calibration file to load, converts readout timing to nanoseconds
   MGUIEFileSelector* m_TACCalFileSelector;
-
-  TGCheckButton* m_SingleSiteOnly;
 	
   // private members:
  private:

--- a/include/MGUIOptionsTACcut.h
+++ b/include/MGUIOptionsTACcut.h
@@ -1,0 +1,93 @@
+/*
+ * MGUIOptionsTACcut.h
+ *
+ * Copyright (C) 2008-2010 by Jau-Shian Liang.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIOptionsTACcut__
+#define __MGUIOptionsTACcut__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TGButtonGroup.h>
+#include <MString.h>
+#include <TGClient.h>
+#include <TGNumberEntry.h>
+#include <TGTextEntry.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+#include "MModule.h"
+#include "MGUIOptions.h"
+
+// Forward declarations:
+class MGUIEFileSelector;
+class MGUIEMinMaxEntry;
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIOptionsTACcut : public MGUIOptions
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIOptionsTACcut(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIOptionsTACcut();
+
+  //! Process all button, etc. messages
+  virtual bool ProcessMessage(long Message, long Parameter1, long Parameter2);
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  // protected methods:
+ protected:
+
+  //! Actions after the Apply or OK button has been pressed
+  virtual bool OnApply();
+
+
+  // protected members:
+ protected:
+  //! The detector IDs as a string
+  TGTextEntry* m_Detectors;
+  //! The total TAC selection
+  MGUIEMinMaxEntry* m_TAC;
+
+  //! Select TAC Calibration file to load, converts readout timing to nanoseconds
+  MGUIEFileSelector* m_TACCalFileSelector;
+
+  TGCheckButton* m_SingleSiteOnly;
+	
+  // private members:
+ private:
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIOptionsTACcut, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MModuleDepthCalibration2024.h
+++ b/include/MModuleDepthCalibration2024.h
@@ -72,11 +72,6 @@ class MModuleDepthCalibration2024 : public MModule
   //! Get filename for CTD->Depth splines
   MString GetSplinesFileName() const {return m_SplinesFile;}
 
-  //! Set filename for TAC Calibration
-  void SetTACCalFileName( const MString& FileName) {m_TACCalFile = FileName;}
-  //! Get filename for TAC Calibration
-  MString GetTACCalFileName() const {return m_TACCalFile;}
-
   //! Set whether the data came from the card cage at UCSD
   void SetUCSDOverride( bool Override ) {m_UCSDOverride = Override;}
   //! Get whether the data came from the card cage at UCSD
@@ -112,8 +107,6 @@ class MModuleDepthCalibration2024 : public MModule
   vector<double>* GetPixelCoeffs(int pixel_code);
   //! Load the splines file
   bool LoadSplinesFile(MString FName);
-  //! Load the TAC Calibration file
-  bool LoadTACCalFile(MString FName);
   //! Get the timing FWHM noise for the specified pixel and Energy
   double GetTimingNoiseFWHM(int pixel_code, double Energy);
 
@@ -127,11 +120,8 @@ class MModuleDepthCalibration2024 : public MModule
 
   unordered_map<int, vector<double>> m_Coeffs;
   double m_Coeffs_Energy;
-  unordered_map<int, unordered_map<int, vector<double>>> m_HVTACCal;
-  unordered_map<int, unordered_map<int, vector<double>>> m_LVTACCal;
   MString m_CoeffsFile;
   MString m_SplinesFile;
-  MString m_TACCalFile;
   unordered_map<int, MString> m_DetectorNames;
   unordered_map<int, double> m_Thicknesses;
   unordered_map<int, int> m_NXStrips;
@@ -156,7 +146,6 @@ class MModuleDepthCalibration2024 : public MModule
   unordered_map<int, vector<double>> m_DepthGrid;
   bool m_SplinesFileIsLoaded;
   bool m_CoeffsFileIsLoaded;
-  bool m_TACCalFileIsLoaded;
 
   // boolean for use with the card cage at UCSD since it tags all events as detector 11
   bool m_UCSDOverride;

--- a/include/MModuleTACcut.h
+++ b/include/MModuleTACcut.h
@@ -1,0 +1,131 @@
+/*
+ * MModuleTACcut.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MModuleTACcut__
+#define __MModuleTACcut__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Standard libs:
+#include <algorithm>
+
+// ROOT libs:
+#include "TGClient.h"
+#include "TH1.h"
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MModule.h"
+#include "MGUIExpoTACcut.h"
+
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MModuleTACcut : public MModule
+{
+  // public interface:
+ public:
+  //! Default constructor
+  MModuleTACcut();
+  //! Default destructor
+  virtual ~MModuleTACcut();
+  
+  //! Create a new object of this class 
+  virtual MModuleTACcut* Clone() { return new MModuleTACcut(); }
+
+  //! Initialize the module
+  virtual bool Initialize();
+
+  //! Create expos 
+  virtual void CreateExpos();
+
+  //! Finalize the module
+  virtual void Finalize();
+
+  //! Main data analysis routine, which updates the event to a new level 
+  virtual bool AnalyzeEvent(MReadOutAssembly* Event);
+
+  //! Show the options GUI
+  virtual void ShowOptionsGUI();
+
+
+  //! Read the configuration data from an XML node
+  virtual bool ReadXmlConfiguration(MXmlNode* Node);
+  //! Create an XML node tree from the configuration
+  virtual MXmlNode* CreateXmlConfiguration();
+
+  ///////////// Creating functions that will update and get the min/max TAC values //////////////////////////
+
+ //! Set the minimum TAC value!
+  void SetMinimumTAC(unsigned int MinimumTAC) { m_MinimumTAC = MinimumTAC; }
+  //! Get the minimum TAC value!
+  unsigned int GetMinimumTAC() const { return m_MinimumTAC; }
+
+  //! Set the maximum TAC value!
+  void SetMaximumTAC(unsigned int MaximumTAC) { m_MaximumTAC = MaximumTAC; }
+  //! Get the maximum TAC value!
+  unsigned int GetMaximumTAC() const { return m_MaximumTAC; }
+
+  //! Set filename for TAC Calibration
+  void SetTACCalFileName( const MString& FileName) {m_TACCalFile = FileName;}
+  //! Get filename for TAC Calibration
+  MString GetTACCalFileName() const {return m_TACCalFile;}
+
+  //! Load the TAC calibration file
+  bool LoadTACCalFile(MString FName);
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ 
+
+
+  // protected methods:
+ protected:
+
+  
+  // private methods:
+ private:
+
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+
+// declare min and max TAC variables here
+unsigned int m_MinimumTAC, m_MaximumTAC;
+MString m_TACCalFile;
+unordered_map<int, unordered_map<int, vector<double>>> m_HVTACCal;
+unordered_map<int, unordered_map<int, vector<double>>> m_LVTACCal;
+
+vector<unsigned int> m_DetectorIDs;
+
+MGUIExpoTACcut* m_ExpoTACcut;
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MModuleTACcut, 0) // no description
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -101,10 +101,25 @@ class MStripHit
   //! Return the calibrated energy
   double GetEnergyResolution() const { return m_EnergyResolution; }
 
-  //! Set the Timing of the top side
+  //! Set the TAC
+  void SetTAC(double TAC) { m_TAC = TAC; }
+  //! Return the TAC
+  double GetTAC() const { return m_TAC; }
+
+  //! Set the TAC resolution
+  void SetTACResolution(double TACResolution) { m_TACResolution = TACResolution; }
+  //! Return the TAC resolution
+  double GetTACResolution() const { return m_TACResolution; }
+
+  //! Set the Timing in nanoseconds
   void SetTiming(double Timing) { m_Timing = Timing; }
-  //! Return the Timing of the top side
+  //! Return the Timing in nanoseconds
   double GetTiming() const { return m_Timing; }
+
+  //! Set the Timing resolution
+  void SetTimingResolution(double TimingResolution) { m_TimingResolution = TimingResolution; }
+  //! Return the Timing resolution
+  double GetTimingResolution() const { return m_TimingResolution; }
 
   //! Set the Temperature of the relavent preamp (in degrees C)
   void SetPreampTemp(double PreampTemp) { m_PreampTemp = PreampTemp; }
@@ -152,8 +167,14 @@ class MStripHit
   double m_Energy;
   //! The energy resolution
   double m_EnergyResolution;
-  //! Timing of the top side
+  //! TAC timing
+  double m_TAC;
+  //! TAC timing resolution
+  double m_TACResolution;
+  //! Timing in ns
   double m_Timing;
+  //! Timing resolution in ns
+  double m_TimingResolution;
   //! Temperature of Preamp
   double m_PreampTemp;
   

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -74,6 +74,9 @@ using namespace std;
 #include "MModuleEventFilter.h"
 #include "MModuleEventSaver.h"
 #include "MModuleResponseGenerator.h"
+
+#include "MModuleTACcut.h"
+
 #include "MModuleDiagnostics.h"
 #include "MModuleDiagnosticsEnergyPerStrip.h"
 
@@ -130,6 +133,7 @@ MAssembly::MAssembly()
   m_Supervisor->AddAvailableModule(new MModuleEventSaver());
   m_Supervisor->AddAvailableModule(new MModuleTransmitterRealta());
   m_Supervisor->AddAvailableModule(new MModuleResponseGenerator());
+  m_Supervisor->AddAvailableModule(new MModuleTACcut());
 
   m_Supervisor->AddAvailableModule(new MModuleDiagnostics());
   m_Supervisor->AddAvailableModule(new MModuleDiagnosticsEnergyPerStrip());

--- a/src/MGUIExpoTACcut.cxx
+++ b/src/MGUIExpoTACcut.cxx
@@ -100,9 +100,9 @@ void MGUIExpoTACcut::SetTACHistogramArrangement(const vector<unsigned int> DetID
   unsigned int NDetectors = DetIDs.size();
   cout<<"MGUIExpoTACcut::SetTACHistogramArrangement: Number of detectors:"<< NDetectors<<endl;
 
-  for (unsigned int i=0; i < NDetectors; ++i){
+  for (unsigned int i=0; i < NDetectors; ++i) {
     // iterate over detector IDs, make the map from ID to plot position, and initialize the histograms
-    if ( (i % max_columns) == 0 ){
+    if ((i % max_columns) == 0) {
       ++row;
       vector<unsigned int> new_row;
       m_DetectorMap.push_back(new_row);
@@ -125,7 +125,7 @@ void MGUIExpoTACcut::SetTACHistogramArrangement(const vector<unsigned int> DetID
 
   if (NDetectors < max_columns) {
     m_NColumns = NDetectors; 
-  } else{
+  } else {
     m_NColumns=max_columns;
   }
 
@@ -233,7 +233,7 @@ void MGUIExpoTACcut::Update()
 
   double Max = 0;
   // for (auto H : m_TACHistograms) {
-  for ( const auto dethistpair : m_TACHistograms ){
+  for (const auto dethistpair : m_TACHistograms) {
     TH1D* H = dethistpair.second;
     for (int bx = 2; bx < H->GetNbinsX(); ++bx) { // Skip first and last
       if (Max < H->GetBinContent(bx)) {
@@ -242,7 +242,7 @@ void MGUIExpoTACcut::Update()
     }
   }
   Max *= 1.1;
-  for ( const auto dethistpair : m_TACHistograms ){
+  for (const auto dethistpair : m_TACHistograms) {
     TH1D* H = dethistpair.second;
     H->SetMaximum(Max);
   }

--- a/src/MGUIExpoTACcut.cxx
+++ b/src/MGUIExpoTACcut.cxx
@@ -1,0 +1,284 @@
+/*
+ * MGUIExpoTACcut.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+// Include the header:
+#include "MGUIExpoTACcut.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include <TSystem.h>
+#include <TString.h>
+#include <TGLabel.h>
+#include <TGResourcePool.h>
+#include <TCanvas.h>
+
+// MEGAlib libs:
+#include "MStreams.h"
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MGUIExpoTACcut)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoTACcut::MGUIExpoTACcut(MModule* Module) : MGUIExpo(Module)
+{
+  // standard constructor
+
+  // Set the new title of the tab here:
+  m_TabTitle = "TAC Calibration";
+  
+  // Set the histogram arrangment
+  // SetTACHistogramArrangement(1, 1);
+
+  // use hierarchical cleaning
+  SetCleanup(kDeepCleanup);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoTACcut::~MGUIExpoTACcut()
+{
+  // kDeepCleanup is activated 
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::Reset()
+{
+  //! Reset the data in the UI
+
+  m_Mutex.Lock();
+  for (auto H: m_TACHistograms) {  
+    (H.second)->Reset();
+  }
+  m_Mutex.UnLock();
+}
+  
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::SetTACHistogramArrangement(vector<unsigned int>* DetIDs)
+{
+  // Take in the list of detector IDs and determine the number in X and number in Y
+  // Update the variable m_DetectorMap.
+  m_Mutex.Lock();
+
+  unsigned int column = 0;
+  unsigned int row = 0;
+
+  unsigned int max_columns = 4;
+
+  unsigned int NDetectors = DetIDs->size();
+  cout<<"MGUIExpoTACcut::SetTACHistogramArrangement: Number of detectors:" << NDetectors<<endl;
+
+  for ( unsigned int i=0; i< NDetectors; ++i ){
+    // iterate over detector IDs, make the map from ID to plot position, and initialize the histograms
+    if ( (i % max_columns) == 0 ){
+      ++row;
+      vector<unsigned int> new_row;
+      m_DetectorMap.push_back(new_row);
+      column = 1;
+    }
+
+    unsigned int DetID = DetIDs->at(i);
+    m_DetectorMap[row-1].push_back(DetID);
+
+    TH1D* TAC = new TH1D("", "TAC", m_NBins[DetID], m_Min[DetID], m_Max[DetID]);
+    TAC->SetXTitle("TAC [cm]");
+    TAC->SetYTitle("counts");
+    TAC->SetFillColor(kAzure+7);
+    
+    m_TACHistograms[DetID] = TAC;
+    // m_TACCanvases[DetID] = 0;
+
+    ++column;
+  }
+
+  if ( NDetectors < max_columns ){
+    m_NColumns = NDetectors; 
+  }
+  else{
+    m_NColumns=max_columns;
+  }
+
+  m_NRows = (NDetectors/max_columns) + 1; 
+  
+  m_Mutex.UnLock();
+}
+
+  
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::SetTACHistogramParameters(unsigned int DetID, unsigned int NBins, double MinimumTAC, double MaximumTAC)
+{
+  // Set the energy histogram parameters 
+
+  m_Mutex.Lock();
+
+  m_NBins[DetID] = NBins;
+  m_Min[DetID] = MinimumTAC;
+  m_Max[DetID] = MaximumTAC;
+  TH1D* H = m_TACHistograms[DetID];
+  H->SetBins(NBins, MinimumTAC, MaximumTAC);
+
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::SetTACHistogramName(unsigned int DetID, MString Name) 
+{
+  // Set the title of the histogram
+  
+  m_Mutex.Lock();
+
+  if (m_TACHistograms.find(DetID) != m_TACHistograms.end()) {
+    m_TACHistograms[DetID]->SetTitle(Name);
+  }
+
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::AddTAC(unsigned int DetID, double TAC)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+
+  if (m_TACHistograms.find(DetID) != m_TACHistograms.end()) {
+    m_TACHistograms[DetID]->Fill(TAC);
+  }
+
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::Create()
+{
+  // Add the GUI options here
+
+  // Do not create it twice!
+  if (m_IsCreated == true) return;
+  
+  m_Mutex.Lock();
+  
+  TGLayoutHints* CanvasLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX | kLHintsExpandY, 2, 2, 2, 2);
+
+  for (unsigned int y = 0; y < m_DetectorMap.size(); ++y) {
+    TGHorizontalFrame* HFrame = new TGHorizontalFrame(this);
+    AddFrame(HFrame, CanvasLayout);
+
+    for (unsigned int x = 0; x < m_DetectorMap[y].size(); ++x) {
+      unsigned int DetID = m_DetectorMap[y][x];
+      TRootEmbeddedCanvas* TACCanvas = new TRootEmbeddedCanvas("TAC", HFrame, 100, 100);
+      HFrame->AddFrame(TACCanvas, CanvasLayout);
+      m_TACCanvases[DetID] = TACCanvas;
+
+      TACCanvas->GetCanvas()->cd();
+      m_TACHistograms[DetID]->Draw("colz");
+      TACCanvas->GetCanvas()->Update();
+    }
+  }
+  
+  m_IsCreated = true;
+
+  m_Mutex.UnLock();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::Update()
+{
+  //! Update the frame
+
+  m_Mutex.Lock();
+
+  double Max = 0;
+  // for (auto H : m_TACHistograms) {
+  for ( const auto dethistpair : m_TACHistograms ){
+    TH1D* H = dethistpair.second;
+    for (int bx = 2; bx < H->GetNbinsX(); ++bx) { // Skip first and last
+      if (Max < H->GetBinContent(bx)) {
+        Max = H->GetBinContent(bx);
+      }
+    }
+  }
+  Max *= 1.1;
+  for ( const auto dethistpair : m_TACHistograms ){
+    TH1D* H = dethistpair.second;
+    H->SetMaximum(Max);
+  }
+  
+  for (auto C : m_TACCanvases) {
+
+    (C.second)->GetCanvas()->Modified();
+    (C.second)->GetCanvas()->Update();
+  }
+
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoTACcut::Export(const MString& FileName)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+
+  TCanvas* P = new TCanvas();
+  P->Divide(m_NColumns, m_NRows);
+  for (unsigned int y = 0; y < m_DetectorMap.size(); ++y) {
+    for (unsigned int x = 0; x < m_DetectorMap[y].size(); ++x) {
+      unsigned int DetID = m_DetectorMap[y][x];
+      P->cd((x+1) + m_NColumns*y);
+      m_TACHistograms[DetID]->DrawCopy("colz");
+    }
+  }
+  P->SaveAs(FileName);
+  delete P;
+
+  m_Mutex.UnLock();
+}

--- a/src/MGUIExpoTACcut.cxx
+++ b/src/MGUIExpoTACcut.cxx
@@ -86,7 +86,7 @@ void MGUIExpoTACcut::Reset()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoTACcut::SetTACHistogramArrangement(vector<unsigned int>* DetIDs)
+void MGUIExpoTACcut::SetTACHistogramArrangement(const vector<unsigned int> DetIDs)
 {
   // Take in the list of detector IDs and determine the number in X and number in Y
   // Update the variable m_DetectorMap.
@@ -97,10 +97,10 @@ void MGUIExpoTACcut::SetTACHistogramArrangement(vector<unsigned int>* DetIDs)
 
   unsigned int max_columns = 4;
 
-  unsigned int NDetectors = DetIDs->size();
-  cout<<"MGUIExpoTACcut::SetTACHistogramArrangement: Number of detectors:" << NDetectors<<endl;
+  unsigned int NDetectors = DetIDs.size();
+  cout<<"MGUIExpoTACcut::SetTACHistogramArrangement: Number of detectors:"<< NDetectors<<endl;
 
-  for ( unsigned int i=0; i< NDetectors; ++i ){
+  for (unsigned int i=0; i < NDetectors; ++i){
     // iterate over detector IDs, make the map from ID to plot position, and initialize the histograms
     if ( (i % max_columns) == 0 ){
       ++row;
@@ -109,11 +109,11 @@ void MGUIExpoTACcut::SetTACHistogramArrangement(vector<unsigned int>* DetIDs)
       column = 1;
     }
 
-    unsigned int DetID = DetIDs->at(i);
+    unsigned int DetID = DetIDs.at(i);
     m_DetectorMap[row-1].push_back(DetID);
 
     TH1D* TAC = new TH1D("", "TAC", m_NBins[DetID], m_Min[DetID], m_Max[DetID]);
-    TAC->SetXTitle("TAC [cm]");
+    TAC->SetXTitle("TAC");
     TAC->SetYTitle("counts");
     TAC->SetFillColor(kAzure+7);
     
@@ -123,15 +123,13 @@ void MGUIExpoTACcut::SetTACHistogramArrangement(vector<unsigned int>* DetIDs)
     ++column;
   }
 
-  if ( NDetectors < max_columns ){
+  if (NDetectors < max_columns) {
     m_NColumns = NDetectors; 
-  }
-  else{
+  } else{
     m_NColumns=max_columns;
   }
 
   m_NRows = (NDetectors/max_columns) + 1; 
-  
   m_Mutex.UnLock();
 }
 

--- a/src/MGUIOptionsDepthCalibration2024.cxx
+++ b/src/MGUIOptionsDepthCalibration2024.cxx
@@ -78,12 +78,6 @@ void MGUIOptionsDepthCalibration2024::Create()
   TGLayoutHints* Label2Layout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
   m_OptionsFrame->AddFrame(m_SplinesFileSelector, Label2Layout);
 
-  m_TACCalFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Select a TAC Calibration file:",
-      dynamic_cast<MModuleDepthCalibration2024*>(m_Module)->GetTACCalFileName());
-  m_TACCalFileSelector->SetFileType("TAC", "*.csv");
-  TGLayoutHints* Label3Layout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
-  m_OptionsFrame->AddFrame(m_TACCalFileSelector, Label3Layout);
-
   m_UCSDOverride = new TGCheckButton(m_OptionsFrame, "Check this box if you're using the card cage at UCSD", 1);
   m_UCSDOverride->SetOn(dynamic_cast<MModuleDepthCalibration2024*>(m_Module)->GetUCSDOverride());
   TGLayoutHints* Label4Layout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
@@ -133,7 +127,6 @@ bool MGUIOptionsDepthCalibration2024::OnApply()
 
   dynamic_cast<MModuleDepthCalibration2024*>(m_Module)->SetCoeffsFileName(m_CoeffsFileSelector->GetFileName());
   dynamic_cast<MModuleDepthCalibration2024*>(m_Module)->SetSplinesFileName(m_SplinesFileSelector->GetFileName());
-  dynamic_cast<MModuleDepthCalibration2024*>(m_Module)->SetTACCalFileName(m_TACCalFileSelector->GetFileName());
   dynamic_cast<MModuleDepthCalibration2024*>(m_Module)->SetUCSDOverride(m_UCSDOverride->IsOn());
 
   return true;

--- a/src/MGUIOptionsTACcut.cxx
+++ b/src/MGUIOptionsTACcut.cxx
@@ -1,0 +1,158 @@
+/*
+ * MGUIOptionsTACcut
+.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Jau-Shian Liang.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+// Include the header:
+#include "MGUIOptionsTACcut.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include <TSystem.h>
+#include <TGLabel.h>
+#include <TGResourcePool.h>
+#include <TGNumberEntry.h>
+#include <TGTextEntry.h>
+
+// MEGAlib libs:
+#include "MStreams.h"
+#include "MString.h"
+#include "MGUIEFileSelector.h"
+#include "MGUIEMinMaxEntry.h"
+
+// Nuclearizer libs:
+#include "MModuleTACcut.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MGUIOptionsTACcut
+)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIOptionsTACcut::MGUIOptionsTACcut(MModule* Module) 
+  : MGUIOptions(Module)
+{
+  // standard constructor
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIOptionsTACcut::~MGUIOptionsTACcut()
+{
+  // kDeepCleanup is activated 
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIOptionsTACcut::Create()
+{
+  PreCreate();
+
+  // Modify here
+
+  TGLayoutHints* TACLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
+  m_TAC = new MGUIEMinMaxEntry(m_OptionsFrame, 
+                                       "Choose the minimum and maximum TAC cut (in imaginary TAC units):", 
+                                       false,
+                                       dynamic_cast<MModuleTACcut
+                                      *>(m_Module)->GetMinimumTAC(),
+                                       dynamic_cast<MModuleTACcut
+                                      *>(m_Module)->GetMaximumTAC(),
+                                       true, 0.0);
+  m_OptionsFrame->AddFrame(m_TAC, TACLayout);
+
+  m_TACCalFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Select a TAC Calibration file:", 
+    dynamic_cast<MModuleTACcut*>(m_Module)->GetTACCalFileName());
+  m_TACCalFileSelector->SetFileType("TAC", "*.csv");
+  TGLayoutHints* Label3Layout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
+  m_OptionsFrame->AddFrame(m_TACCalFileSelector, Label3Layout);
+
+
+  // TGLabel* TACLabel = new TGLabel(m_OptionsFrame, 
+  //   "This is a TAC cut and this text is here because.\n"
+  //   "I'm not sure if I can remove it yet");
+  // m_OptionsFrame->AddFrame(TACLabel, TACLayout);
+  
+  
+  PostCreate();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MGUIOptionsTACcut::ProcessMessage(long Message, long Parameter1, long Parameter2)
+{
+  // Modify here if you have more buttons
+
+  bool Status = true;
+  
+  switch (GET_MSG(Message)) {
+  case kC_COMMAND:
+    switch (GET_SUBMSG(Message)) {
+    case kCM_BUTTON:
+      break;
+    default:
+      break;
+    }
+    break;
+  default:
+    break;
+  }
+  
+  if (Status == false) {
+    return false;
+  }
+
+  // Call also base class
+  return MGUIOptions::ProcessMessage(Message, Parameter1, Parameter2);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MGUIOptionsTACcut::OnApply()
+{
+  // Store the data in the module
+
+  dynamic_cast<MModuleTACcut
+*>(m_Module)->SetMinimumTAC(m_TAC->GetMinValue());
+  dynamic_cast<MModuleTACcut
+*>(m_Module)->SetMaximumTAC(m_TAC->GetMaxValue());
+
+  dynamic_cast<MModuleTACcut*>(m_Module)->SetTACCalFileName(m_TACCalFileSelector->GetFileName());
+
+
+  return true;
+}
+
+
+// MGUIOptionsTACcut: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MGUIOptionsTACcut.cxx
+++ b/src/MGUIOptionsTACcut.cxx
@@ -77,14 +77,7 @@ void MGUIOptionsTACcut::Create()
   // Modify here
 
   TGLayoutHints* TACLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
-  m_TAC = new MGUIEMinMaxEntry(m_OptionsFrame, 
-                                       "Choose the minimum and maximum TAC cut (in imaginary TAC units):", 
-                                       false,
-                                       dynamic_cast<MModuleTACcut
-                                      *>(m_Module)->GetMinimumTAC(),
-                                       dynamic_cast<MModuleTACcut
-                                      *>(m_Module)->GetMaximumTAC(),
-                                       true, 0.0);
+  m_TAC = new MGUIEMinMaxEntry(m_OptionsFrame, "Choose the minimum and maximum TAC cut (in imaginary TAC units):", false, dynamic_cast<MModuleTACcut*>(m_Module)->GetMinimumTAC(), dynamic_cast<MModuleTACcut*>(m_Module)->GetMaximumTAC(), true, 0.0);
   m_OptionsFrame->AddFrame(m_TAC, TACLayout);
 
   m_TACCalFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Select a TAC Calibration file:", 
@@ -142,13 +135,9 @@ bool MGUIOptionsTACcut::OnApply()
 {
   // Store the data in the module
 
-  dynamic_cast<MModuleTACcut
-*>(m_Module)->SetMinimumTAC(m_TAC->GetMinValue());
-  dynamic_cast<MModuleTACcut
-*>(m_Module)->SetMaximumTAC(m_TAC->GetMaxValue());
-
+  dynamic_cast<MModuleTACcut*>(m_Module)->SetMinimumTAC(m_TAC->GetMinValue());
+  dynamic_cast<MModuleTACcut*>(m_Module)->SetMaximumTAC(m_TAC->GetMaxValue());
   dynamic_cast<MModuleTACcut*>(m_Module)->SetTACCalFileName(m_TACCalFileSelector->GetFileName());
-
 
   return true;
 }

--- a/src/MModuleDepthCalibration2024.cxx
+++ b/src/MModuleDepthCalibration2024.cxx
@@ -63,6 +63,7 @@ MModuleDepthCalibration2024::MModuleDepthCalibration2024() : MModule()
   AddPreceedingModuleType(MAssembly::c_EventLoader, true);
   AddPreceedingModuleType(MAssembly::c_EnergyCalibration, true);
   AddPreceedingModuleType(MAssembly::c_StripPairing, true);
+  AddPreceedingModuleType(MAssembly::c_TACcut, true);
 //  AddPreceedingModuleType(MAssembly::c_CrosstalkCorrection, false); // Soft requirement
 
   // Set all types this modules handles

--- a/src/MModuleDepthCalibration2024.cxx
+++ b/src/MModuleDepthCalibration2024.cxx
@@ -120,10 +120,6 @@ bool MModuleDepthCalibration2024::Initialize()
   // ie DetID=0 should be the 0th detector in m_Detectors, DetID=1 should the 1st, etc.
   m_Detectors = m_Geometry->GetDetectorList();
 
-  if( LoadTACCalFile(m_TACCalFile) == false ){
-    cout << "No TAC Calibration file loaded. Proceeding without TAC Calibration." << endl;
-  }
-
   // Look through the Geometry and get the names and thicknesses of all the detectors.
   for(unsigned int i = 0; i < m_Detectors.size(); ++i){
     // For now, DetID is in order of detectors, which puts contraints on how the geometry file should be written.
@@ -279,28 +275,6 @@ bool MModuleDepthCalibration2024::AnalyzeEvent(MReadOutAssembly* Event)
       // TODO: For Card Cage, may need to add noise
       double XTiming = XSH->GetTiming();
       double YTiming = YSH->GetTiming();
-      if ( !m_UCSDOverride ) {
-        if ( m_TACCalFileIsLoaded ) {
-          if ( XSH->IsLowVoltageStrip() ){
-            XTiming = XTiming*m_LVTACCal[DetID][XStripID][0] + m_LVTACCal[DetID][XStripID][1];
-            YTiming = YTiming*m_HVTACCal[DetID][YStripID][0] + m_HVTACCal[DetID][YStripID][1];
-          }
-          else {
-            XTiming = XTiming*m_HVTACCal[DetID][XStripID][0] + m_HVTACCal[DetID][XStripID][1];
-            YTiming = YTiming*m_LVTACCal[DetID][YStripID][0] + m_LVTACCal[DetID][YStripID][1];
-          }
-        }
-        else { 
-          if ( XSH->IsLowVoltageStrip() ){
-            XTiming = XTiming*0.405 - 525.;
-            YTiming = YTiming*0.43 - 500.;
-          }
-          else {
-            XTiming = XTiming*0.43 - 500.;
-            YTiming = YTiming*0.405 -525.;
-          }
-        }
-      }
 
       // cout << "Got the coefficients: " << Coeffs << endl;
 
@@ -513,54 +487,6 @@ bool MModuleDepthCalibration2024::LoadCoeffsFile(MString FName)
   return true;
 
 }
-
-bool MModuleDepthCalibration2024::LoadTACCalFile(MString FName)
-{
-  // Read in the TAC Calibration file, which should contain for each strip:
-  //  DetID, h or l for high or low voltage, TAC cal, TAC cal error, TAC cal offset, TAC offset error
-  MFile F;
-  if( F.Open(FName) == false ){
-    cout << "MModuleDepthCalibration2024: failed to open TAC Calibration file." << endl;
-    m_TACCalFileIsLoaded = false;
-    return false;
-  } else {
-    for(unsigned int i = 0; i < m_Detectors.size(); ++i){
-      unordered_map<int, vector<double>> temp_map_HV;
-      m_HVTACCal[i] = temp_map_HV;
-      unordered_map<int, vector<double>> temp_map_LV;
-      m_LVTACCal[i] = temp_map_LV;
-    }
-    MString Line;
-    while( F.ReadLine( Line ) ){
-      if( !Line.BeginsWith("#") ){
-        std::vector<MString> Tokens = Line.Tokenize(",");
-        if( Tokens.size() == 7 ){
-          int DetID = Tokens[0].ToInt();
-          int StripID = Tokens[2].ToInt();
-          double taccal = Tokens[3].ToDouble();
-          double taccal_err = Tokens[4].ToDouble();
-          double offset = Tokens[5].ToDouble();
-          double offset_err = Tokens[6].ToDouble();
-          vector<double> cal_vals;
-          cal_vals.push_back(taccal); cal_vals.push_back(offset); cal_vals.push_back(taccal_err); cal_vals.push_back(offset_err);
-          if ( Tokens[1] == "l" ){
-            m_LVTACCal[DetID][StripID] = cal_vals;
-          }
-          else if ( Tokens[1] == "h" ){
-            m_HVTACCal[DetID][StripID] = cal_vals;
-          }
-        }
-      }
-    }
-    F.Close();
-  }
-
-  m_TACCalFileIsLoaded = true;
-
-  return true;
-
-}
-
 
 std::vector<double>* MModuleDepthCalibration2024::GetPixelCoeffs(int pixel_code)
 {
@@ -871,11 +797,6 @@ bool MModuleDepthCalibration2024::ReadXmlConfiguration(MXmlNode* Node)
   m_SplinesFile = SplinesFileNameNode->GetValue();
   }
 
-  MXmlNode* TACCalFileNameNode = Node->GetNode("TACCalFileName");
-  if (TACCalFileNameNode != 0) {
-    m_TACCalFile = TACCalFileNameNode->GetValue();
-  }
-
   return true;
 }
 
@@ -889,8 +810,7 @@ MXmlNode* MModuleDepthCalibration2024::CreateXmlConfiguration()
   MXmlNode* Node = new MXmlNode(0,m_XmlTag);
   new MXmlNode(Node, "CoeffsFileName", m_CoeffsFile);
   new MXmlNode(Node, "SplinesFileName", m_SplinesFile);
-  new MXmlNode(Node, "TACCalFileName", m_TACCalFile);
-
+  
   return Node;
 }
 

--- a/src/MModuleEnergyCalibrationUniversal.cxx
+++ b/src/MModuleEnergyCalibrationUniversal.cxx
@@ -397,8 +397,7 @@ bool MModuleEnergyCalibrationUniversal::AnalyzeEvent(MReadOutAssembly* Event)
 
   for (unsigned int i = 0; i < Event->GetNStripHits(); ) {
     MStripHit* SH = Event->GetStripHit(i);
-    if (SH->GetEnergy() < 8 || SH->GetTiming() < 8700 || SH->GetTiming() > 12000) {
-      // cout<<"HACK: Removing strip hit due to TAC "<<SH->GetTiming()<<" cut or energy "<<SH->GetEnergy()<<endl;
+    if (SH->GetEnergy() < 8) {
       Event->RemoveStripHit(i);
       delete SH;
     } else {

--- a/src/MModuleEnergyCalibrationUniversal.cxx
+++ b/src/MModuleEnergyCalibrationUniversal.cxx
@@ -74,6 +74,7 @@ MModuleEnergyCalibrationUniversal::MModuleEnergyCalibrationUniversal() : MModule
   
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EventLoader);
+  AddPreceedingModuleType(MAssembly::c_TACcut);
   
   // Set all types this modules handles
   AddModuleType(MAssembly::c_EnergyCalibration);

--- a/src/MModuleLoaderMeasurementsROA.cxx
+++ b/src/MModuleLoaderMeasurementsROA.cxx
@@ -195,7 +195,7 @@ bool MModuleLoaderMeasurementsROA::ReadNextEvent(MReadOutAssembly* Event)
     SH->SetStripID(Strip->GetStripID());
     
     if (Timing != nullptr) {
-      SH->SetTiming(Timing->GetTiming());
+      SH->SetTAC(Timing->GetTiming());
     } else {
       cout<<m_Name<<": Warning: Event without timing found"<<endl;
     }

--- a/src/MModuleStripPairingChiSquare.cxx
+++ b/src/MModuleStripPairingChiSquare.cxx
@@ -62,6 +62,7 @@ MModuleStripPairingChiSquare::MModuleStripPairingChiSquare() : MModule()
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EventLoader);
   AddPreceedingModuleType(MAssembly::c_EnergyCalibration);
+  AddPreceedingModuleType(MAssembly::c_TACcut);
 
   // Set all types this modules handles
   AddModuleType(MAssembly::c_StripPairing);

--- a/src/MModuleStripPairingGreedy.cxx
+++ b/src/MModuleStripPairingGreedy.cxx
@@ -61,6 +61,7 @@ MModuleStripPairingGreedy::MModuleStripPairingGreedy() : MModule()
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EventLoader);
   AddPreceedingModuleType(MAssembly::c_EnergyCalibration);
+  AddPreceedingModuleType(MAssembly::c_TACcut);
   //AddPreceedingModuleType(MAssembly::c_CrosstalkCorrection);
   
   // Set all types this modules handles

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -1,0 +1,290 @@
+/*
+ * MModuleTACcut.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// MModuleTACcut
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Include the header:
+#include "MModuleTACcut.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include "TGClient.h"
+
+// MEGAlib libs:
+#include "MModule.h"
+#include "MGUIOptionsTACcut.h"
+#include "MGUIExpoTACcut.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MModuleTACcut)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleTACcut::MModuleTACcut() : MModule()
+{
+  // Construct an instance of MModuleTACcut
+
+  // Set all module relevant information
+
+  // Set the module name --- has to be unique
+  m_Name = "TAC Cut";
+
+  // Set the XML tag --- has to be unique --- no spaces allowed
+  m_XmlTag = "XmlTagTACcut";
+
+  // Set all modules, which have to be done before this module
+  AddPreceedingModuleType(MAssembly::c_EventLoader);
+  //AddPreceedingModuleType(MAssembly::c_DetectorEffectsEngine);
+
+  // AddPreceedingModuleType(MAssembly::c_EnergyCalibration);
+  // AddPreceedingModuleType(MAssembly::c_ChargeSharingCorrection);
+  // AddPreceedingModuleType(MAssembly::c_DepthCorrection);
+  // AddPreceedingModuleType(MAssembly::c_StripPairing);
+
+  // Set all types this modules handles
+  AddModuleType(MAssembly::c_TACcut);
+
+
+  // Set all modules, which can follow this module
+  AddSucceedingModuleType(MAssembly::c_StripPairing);
+  AddSucceedingModuleType(MAssembly::c_DepthCorrection);
+
+  // Set if this module has an options GUI
+  // Overwrite ShowOptionsGUI() with the call to the GUI!
+  m_HasOptionsGUI = true;
+  // If true, you have to derive a class from MGUIOptions (use MGUIOptionsTACcut)
+  // and implement all your GUI options
+
+  // Can the program be run multi-threaded
+  m_AllowMultiThreading = true;
+
+  // Can we use multiple instances of this class
+  m_AllowMultipleInstances = false;
+
+  //initialize a min and max TAC value 
+  m_MinimumTAC = 0;
+  m_MaximumTAC = 20000;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleTACcut::~MModuleTACcut()
+{
+  // Delete this instance of MModuleTACcut
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleTACcut::Initialize()
+{
+  // Initialize the module 
+
+  if( LoadTACCalFile(m_TACCalFile) == false ){
+    cout << "TAC Calibration file could not be loaded." << endl;
+    return false;
+  }
+
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MModuleTACcut::CreateExpos()
+{
+  // Create all expos
+
+  if (HasExpos() == true) return;
+
+  // Set the histogram display
+  m_ExpoTACcut = new MGUIExpoTACcut(this);
+  m_ExpoTACcut->SetTACHistogramArrangement(&m_DetectorIDs);
+  for(unsigned int i = 0; i < m_DetectorIDs.size(); ++i){
+    unsigned int DetID = m_DetectorIDs[i];
+    m_ExpoTACcut->SetTACHistogramParameters(DetID, 120, 0, 20000);
+  }
+  m_Expos.push_back(m_ExpoTACcut);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event) 
+{
+  // Main data analysis routine, which updates the event to a new level 
+
+  // Apply cuts to the TAC values:
+  for (unsigned int i = 0; i < Event->GetNStripHits(); ) {
+    MStripHit* SH = Event->GetStripHit(i);
+
+    if ( HasExpos()==true ){
+      m_ExpoTACcut->AddTAC(SH->GetDetectorID(), SH->GetTiming());
+    }
+    // takes inputted min and max TAC values from the GUI module to make cuts 
+    if ( SH->GetTiming() < m_MinimumTAC || SH->GetTiming() > m_MaximumTAC) {
+      // cout<<"HACK: Removing strip ht due to TAC "<<SH->GetTiming()<<" cut or energy "<<SH->GetEnergy()<<endl;
+      Event->RemoveStripHit(i);
+      delete SH;
+    } else {
+      ++i;
+    }
+  }
+
+  for (unsigned int i = 0; i < Event->GetNStripHits(); ++i){
+    MStripHit* SH = Event->GetStripHit(i);
+    double TAC_timing = SH->GetTiming();
+    double ns_timing;
+    int DetID = SH->GetDetectorID();
+    int StripID = SH->GetStripID();
+    if ( SH->IsLowVoltageStrip() == true ){
+      ns_timing = (TAC_timing*m_LVTACCal[DetID][StripID][0] + m_LVTACCal[DetID][StripID][1]);
+    }
+    else{
+      ns_timing = TAC_timing*m_HVTACCal[DetID][StripID][0] + m_HVTACCal[DetID][StripID][1];
+    }
+    SH->SetTiming(ns_timing);
+  }
+
+  Event->SetAnalysisProgress(MAssembly::c_TACcut);
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleTACcut::Finalize()
+{
+  MModule::Finalize();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleTACcut::ShowOptionsGUI()
+{
+  //! Show the options GUI --- has to be overwritten!
+
+  MGUIOptionsTACcut* Options = new MGUIOptionsTACcut(this);
+  Options->Create();
+  gClient->WaitForUnmap(Options);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleTACcut::ReadXmlConfiguration(MXmlNode* Node)
+{
+  //! Read the configuration data from an XML node
+
+  /*
+  MXmlNode* SomeTagNode = Node->GetNode("SomeTag");
+  if (SomeTagNode != 0) {
+    m_SomeTagValue = SomeTagNode->GetValue();
+  }
+  */
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MXmlNode* MModuleTACcut::CreateXmlConfiguration() 
+{
+  //! Create an XML node tree from the configuration
+
+  MXmlNode* Node = new MXmlNode(0, m_XmlTag);
+  
+  /*
+  MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
+  */
+
+  return Node;
+}
+
+bool MModuleTACcut::LoadTACCalFile(MString FName)
+{
+  // Read in the TAC Calibration file, which should contain for each strip:
+  //  DetID, h or l for high or low voltage, TAC cal, TAC cal error, TAC cal offset, TAC offset error
+  MFile F;
+  if (F.Open(FName) == false) {
+    cout << "MModuleTACcut: failed to open TAC Calibration file." << endl;
+    return false;
+  } else {
+    MString Line;
+    while( F.ReadLine( Line ) ){
+      if( !Line.BeginsWith("#") ){
+        std::vector<MString> Tokens = Line.Tokenize(",");
+        if( Tokens.size() == 7 ){
+          int DetID = Tokens[0].ToInt();
+          int StripID = Tokens[2].ToInt();
+          double taccal = Tokens[3].ToDouble();
+          double taccal_err = Tokens[4].ToDouble();
+          double offset = Tokens[5].ToDouble();
+          double offset_err = Tokens[6].ToDouble();
+          vector<double> cal_vals;
+          cal_vals.push_back(taccal); cal_vals.push_back(offset); cal_vals.push_back(taccal_err); cal_vals.push_back(offset_err);
+          
+          if (find(m_DetectorIDs.begin(), m_DetectorIDs.end(), DetID) == m_DetectorIDs.end()) {
+            unordered_map<int, vector<double>> temp_map_HV;
+            m_HVTACCal[DetID] = temp_map_HV;
+            unordered_map<int, vector<double>> temp_map_LV;
+            m_LVTACCal[DetID] = temp_map_LV;
+            m_DetectorIDs.push_back(DetID);
+          }
+          
+          if ( Tokens[1] == "l" ){
+            m_LVTACCal[DetID][StripID] = cal_vals;
+          }
+          else if ( Tokens[1] == "h" ){
+            m_HVTACCal[DetID][StripID] = cal_vals;
+          }
+        }
+      }
+    }
+    F.Close();
+    sort(m_DetectorIDs.begin(), m_DetectorIDs.end());
+  }
+
+  return true;
+
+}
+
+
+// MModuleTACcut.cxx: the end...

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -149,11 +149,10 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
     MStripHit* SH = Event->GetStripHit(i);
 
     if (HasExpos()==true) {
-      m_ExpoTACcut->AddTAC(SH->GetDetectorID(), SH->GetTiming());
+      m_ExpoTACcut->AddTAC(SH->GetDetectorID(), SH->GetTAC());
     }
     // takes inputted min and max TAC values from the GUI module to make cuts 
-    if (SH->GetTiming() < m_MinimumTAC || SH->GetTiming() > m_MaximumTAC) {
-      // cout<<"HACK: Removing strip ht due to TAC "<<SH->GetTiming()<<" cut or energy "<<SH->GetEnergy()<<endl;
+    if (SH->GetTAC() < m_MinimumTAC || SH->GetTAC() > m_MaximumTAC) {
       Event->RemoveStripHit(i);
       delete SH;
     } else {
@@ -163,7 +162,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
 
   for (unsigned int i = 0; i < Event->GetNStripHits(); ++i) {
     MStripHit* SH = Event->GetStripHit(i);
-    double TAC_timing = SH->GetTiming();
+    double TAC_timing = SH->GetTAC();
     double ns_timing;
     int DetID = SH->GetDetectorID();
     int StripID = SH->GetStripID();

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -55,7 +55,7 @@ MModuleTACcut::MModuleTACcut() : MModule()
   // Set all module relevant information
 
   // Set the module name --- has to be unique
-  m_Name = "TAC Cut";
+  m_Name = "TAC Calibration";
 
   // Set the XML tag --- has to be unique --- no spaces allowed
   m_XmlTag = "XmlTagTACcut";
@@ -76,7 +76,7 @@ MModuleTACcut::MModuleTACcut() : MModule()
   // Set all modules, which can follow this module
   AddSucceedingModuleType(MAssembly::c_StripPairing);
   AddSucceedingModuleType(MAssembly::c_DepthCorrection);
-
+  AddSucceedingModuleType(MAssembly::c_EnergyCalibration);
   // Set if this module has an options GUI
   // Overwrite ShowOptionsGUI() with the call to the GUI!
   m_HasOptionsGUI = true;
@@ -129,7 +129,7 @@ void MModuleTACcut::CreateExpos()
 
   // Set the histogram display
   m_ExpoTACcut = new MGUIExpoTACcut(this);
-  m_ExpoTACcut->SetTACHistogramArrangement(&m_DetectorIDs);
+  m_ExpoTACcut->SetTACHistogramArrangement(m_DetectorIDs);
   for(unsigned int i = 0; i < m_DetectorIDs.size(); ++i){
     unsigned int DetID = m_DetectorIDs[i];
     m_ExpoTACcut->SetTACHistogramParameters(DetID, 120, 0, 20000);

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -111,7 +111,7 @@ bool MModuleTACcut::Initialize()
 {
   // Initialize the module 
 
-  if( LoadTACCalFile(m_TACCalFile) == false ){
+  if (LoadTACCalFile(m_TACCalFile) == false) {
     cout << "TAC Calibration file could not be loaded." << endl;
     return false;
   }
@@ -130,7 +130,7 @@ void MModuleTACcut::CreateExpos()
   // Set the histogram display
   m_ExpoTACcut = new MGUIExpoTACcut(this);
   m_ExpoTACcut->SetTACHistogramArrangement(m_DetectorIDs);
-  for(unsigned int i = 0; i < m_DetectorIDs.size(); ++i){
+  for (unsigned int i = 0; i < m_DetectorIDs.size(); ++i) {
     unsigned int DetID = m_DetectorIDs[i];
     m_ExpoTACcut->SetTACHistogramParameters(DetID, 120, 0, 20000);
   }
@@ -145,14 +145,14 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
   // Main data analysis routine, which updates the event to a new level 
 
   // Apply cuts to the TAC values:
-  for (unsigned int i = 0; i < Event->GetNStripHits(); ) {
+  for (unsigned int i = 0; i < Event->GetNStripHits();) {
     MStripHit* SH = Event->GetStripHit(i);
 
-    if ( HasExpos()==true ){
+    if (HasExpos()==true) {
       m_ExpoTACcut->AddTAC(SH->GetDetectorID(), SH->GetTiming());
     }
     // takes inputted min and max TAC values from the GUI module to make cuts 
-    if ( SH->GetTiming() < m_MinimumTAC || SH->GetTiming() > m_MaximumTAC) {
+    if (SH->GetTiming() < m_MinimumTAC || SH->GetTiming() > m_MaximumTAC) {
       // cout<<"HACK: Removing strip ht due to TAC "<<SH->GetTiming()<<" cut or energy "<<SH->GetEnergy()<<endl;
       Event->RemoveStripHit(i);
       delete SH;
@@ -161,16 +161,15 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
     }
   }
 
-  for (unsigned int i = 0; i < Event->GetNStripHits(); ++i){
+  for (unsigned int i = 0; i < Event->GetNStripHits(); ++i) {
     MStripHit* SH = Event->GetStripHit(i);
     double TAC_timing = SH->GetTiming();
     double ns_timing;
     int DetID = SH->GetDetectorID();
     int StripID = SH->GetStripID();
-    if ( SH->IsLowVoltageStrip() == true ){
+    if (SH->IsLowVoltageStrip() == true) {
       ns_timing = (TAC_timing*m_LVTACCal[DetID][StripID][0] + m_LVTACCal[DetID][StripID][1]);
-    }
-    else{
+    } else {
       ns_timing = TAC_timing*m_HVTACCal[DetID][StripID][0] + m_HVTACCal[DetID][StripID][1];
     }
     SH->SetTiming(ns_timing);
@@ -248,10 +247,10 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
     return false;
   } else {
     MString Line;
-    while( F.ReadLine( Line ) ){
-      if( !Line.BeginsWith("#") ){
+    while (F.ReadLine(Line)) {
+      if (!Line.BeginsWith("#")) {
         std::vector<MString> Tokens = Line.Tokenize(",");
-        if( Tokens.size() == 7 ){
+        if (Tokens.size() == 7) {
           int DetID = Tokens[0].ToInt();
           int StripID = Tokens[2].ToInt();
           double taccal = Tokens[3].ToDouble();
@@ -269,10 +268,9 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
             m_DetectorIDs.push_back(DetID);
           }
           
-          if ( Tokens[1] == "l" ){
+          if (Tokens[1] == "l") {
             m_LVTACCal[DetID][StripID] = cal_vals;
-          }
-          else if ( Tokens[1] == "h" ){
+          } else if (Tokens[1] == "h") {
             m_HVTACCal[DetID][StripID] = cal_vals;
           }
         }

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -116,7 +116,7 @@ bool MModuleTACcut::Initialize()
     return false;
   }
 
-  return true;
+  return MModule::Initialize();
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -81,7 +81,10 @@ void MStripHit::Clear()
   m_ADCUnits = 0;
   m_Energy = 0;
   m_EnergyResolution = 0;
+  m_TAC = 0;
+  m_TACResolution = 0;
   m_Timing = 0;
+  m_TimingResolution = 0;
   m_PreampTemp = 0;
   m_Origins.clear();
 }
@@ -190,7 +193,7 @@ void MStripHit::StreamRoa(ostream& S)
    <<m_ReadOutElement->GetStripID()<<" "
    <<((m_ReadOutElement->IsLowVoltageStrip() == true) ? "l" : "h")<<" "
    <<m_ADCUnits<<" "
-   <<m_Timing<<" "
+   <<m_TAC<<" "
    <<m_PreampTemp<<" ";
   for (unsigned int i = 0; i < m_Origins.size(); ++i) {
     if (i != 0) S<<";";


### PR DESCRIPTION
Calibration from TAC to nanoseconds has been moved from MModuleDepthCalibration2024 into its own module, MModuleTACcut. This module also applies a TAC cut, which was previously applied by MModuleUniversalEnergyCalibration. GUIExpo and GUIOptions classes have also been added for the TAC Calibration module. 

As part of updating nuclearizer to properly handle TAC and timing, MStripHit has also been updated to hold an m_TAC variable and m_TACResolution variable, and corresponding setters and getters.