### PR TITLE
Charge Trapping apps

### DIFF
--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -291,7 +291,7 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
     Option = argv[i];
     if (Option == "-h" || Option == "--help" || Option == "?" || Option == "-?") {
       cout<<Usage.str()<<endl;
-      return false;
+      return true;
     }
   }
 
@@ -481,9 +481,9 @@ bool TrappingCorrection::Analyze()
     if (TACCalibrator->Initialize() == false) return false;
     cout<<"Initializing Energy calibrator"<<endl;
     if (EnergyCalibrator->Initialize() == false) return false;
-    cout<<"Initializing Pairing"<<endl;
     cout<<"Initializing Event filter"<<endl;
     if (EventFilter->Initialize() == false) return false;
+    cout<<"Initializing Pairing"<<endl;
     if (Pairing->Initialize() == false) return false;
 
     bool IsFinished = false;

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -2,12 +2,12 @@
  * TrappingCorrection.cxx
  *
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Sean Pike.
  * All rights reserved.
  *
  *
  * This code implementation is the intellectual property of
- * Andreas Zoglauer.
+ * Sean Pike.
  *
  * By copying, distributing or modifying the Program (or any work
  * based on the Program) you indicate your acceptance of this statement,

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -459,7 +459,7 @@ bool TrappingCorrection::Analyze()
     ++MNumber;
 
     cout<<"Creating Event filter"<<endl;
-    //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
+    //! Only use events with 1 to 3 Strip Hits on each side to avoid strip pairing complications
     EventFilter = new MModuleEventFilter();
     EventFilter->SetMinimumLVStrips(1);
     EventFilter->SetMaximumLVStrips(3);

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -291,7 +291,7 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
     Option = argv[i];
     if (Option == "-h" || Option == "--help" || Option == "?" || Option == "-?") {
       cout<<Usage.str()<<endl;
-      return true;
+      return false;
     }
   }
 
@@ -481,9 +481,9 @@ bool TrappingCorrection::Analyze()
     if (TACCalibrator->Initialize() == false) return false;
     cout<<"Initializing Energy calibrator"<<endl;
     if (EnergyCalibrator->Initialize() == false) return false;
+    cout<<"Initializing Pairing"<<endl;
     cout<<"Initializing Event filter"<<endl;
     if (EventFilter->Initialize() == false) return false;
-    cout<<"Initializing Pairing"<<endl;
     if (Pairing->Initialize() == false) return false;
 
     bool IsFinished = false;

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -160,6 +160,7 @@ private:
   //! option to do a pixel-by-pixel calibration (instead of detector-by-detector)
   bool m_PixelCorrect;
   bool m_GreedyPairing;
+  bool m_ExcludeNN;
 
   double m_MinEnergy;
   double m_MaxEnergy;
@@ -280,6 +281,7 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
   Usage<<"         -p:   do pixel-by-pixel correction"<<endl;
   Usage<<"         -m:   strip map file name (.map)"<<endl;
   Usage<<"         -g:   greedy strip pairing (default is chi-square)"<<endl;
+  Usage<<"         -n:   exclude nearest neighbors"<<endl;
   Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS)"<<endl;
   Usage<<"         -h:   print this help"<<endl;
   Usage<<endl;
@@ -297,6 +299,7 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
   m_PixelCorrect = false;
   m_GreedyPairing = false;
+  m_ExcludeNN = false;
   m_MinEnergy = 40;
   m_MaxEnergy = 5000;
   
@@ -369,6 +372,10 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
     if (Option == "-g"){
       m_GreedyPairing = true;
+    }
+
+    if (Option == "-n"){
+      m_ExcludeNN = true;
     }
 
   }
@@ -535,14 +542,16 @@ bool TrappingCorrection::Analyze()
               for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
                 MStripHit* SH = H->GetStripHit(sh);
 
-                if (SH->IsLowVoltageStrip()==true) {
-                  LVEnergy += SH->GetEnergy();
-                  LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
-                  LVStrips.push_back(SH);
-                } else {
-                  HVEnergy += SH->GetEnergy();
-                  HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
-                  HVStrips.push_back(SH);
+                if ((m_ExcludeNN==false) || ((m_ExcludeNN==true) && (SH->IsNearestNeighbor()==false))) {
+                  if (SH->IsLowVoltageStrip()==true) {
+                    LVEnergy += SH->GetEnergy();
+                    LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+                    LVStrips.push_back(SH);
+                  } else {
+                    HVEnergy += SH->GetEnergy();
+                    HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+                    HVStrips.push_back(SH);
+                  }
                 }
               }
 

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -1,0 +1,759 @@
+/* 
+ * TrappingCorrection.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+// Standard
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <csignal>
+#include <cstdlib>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <ctime>
+#include <cstdio>
+using namespace std;
+
+// ROOT
+#include <TROOT.h>
+#include <TEnv.h>
+#include <TSystem.h>
+#include <TApplication.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TStopwatch.h>
+#include <TProfile.h>
+#include <Minuit2/FCNBase.h>
+#include <Minuit2/MnMigrad.h>
+#include <Minuit2/MnMinos.h>
+#include <Minuit2/FunctionMinimum.h>
+#include <Minuit2/MnUserParameters.h>
+#include <Minuit2/MnApplication.h>
+#include <Minuit2/MnStrategy.h>
+using namespace ROOT::Minuit2;
+
+// MEGAlib
+#include "MGlobal.h"
+#include "MFile.h"
+#include "MReadOutElementDoubleStrip.h"
+#include "MFileReadOuts.h"
+#include "MReadOutAssembly.h"
+#include "MStripHit.h"
+#include "MReadOutSequence.h"
+#include "MSupervisor.h"
+#include "MModuleLoaderMeasurementsROA.h"
+#include "MModuleEnergyCalibrationUniversal.h"
+#include "MModuleEventFilter.h"
+#include "MModuleStripPairingGreedy.h"
+#include "MModuleStripPairingChiSquare.h"
+#include "MModuleTACcut.h"
+#include "MAssembly.h"
+
+
+int g_HistBins = 75;
+double g_MinCTD = -200;
+double g_MaxCTD = 200;
+double g_MinRatio = 0.94;
+double g_MaxRatio = 1.06;
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class SymmetryFCN : public FCNBase
+{
+public:
+  //! Operator which returns the symmetry of m_CTDHistogram given the parameters passed
+  double operator()(vector<double> const &v) const override;
+  double Up() const override { return 1; }
+
+  void AddCTD(double CTD){ m_CTD.push_back(CTD); }
+  void AddHVEnergy(double HVEnergy, double HVEnergyResolution){ m_HVEnergy.push_back(HVEnergy); m_HVEnergyResolution.push_back(HVEnergyResolution); }
+  void AddLVEnergy(double LVEnergy, double LVEnergyResolution){ m_LVEnergy.push_back(LVEnergy); m_LVEnergyResolution.push_back(LVEnergyResolution); }
+
+  vector<double> GetCTD(){ return m_CTD; }
+  vector<double> GetHVEnergy(){ return m_HVEnergy; }
+  vector<double> GetLVEnergy(){ return m_LVEnergy; }
+  vector<double> GetHVEnergyResolution(){ return m_HVEnergyResolution; }
+  vector<double> GetLVEnergyResolution(){ return m_LVEnergyResolution; }
+
+  void SetCTD(vector<double> CTD){ m_CTD = CTD; }
+  void SetHVEnergy(vector<double> HVEnergy, vector<double> HVEnergyResolution){ m_HVEnergy = HVEnergy; m_HVEnergyResolution = HVEnergyResolution; }
+  void SetLVEnergy(vector<double> LVEnergy, vector<double> LVEnergyResolution){ m_LVEnergy = LVEnergy; m_LVEnergyResolution = LVEnergyResolution; }
+
+  //! The measured CTD and HV/LV energies
+  vector<double> m_CTD;
+  vector<double> m_HVEnergy;
+  vector<double> m_LVEnergy;
+  vector<double> m_HVEnergyResolution;
+  vector<double> m_LVEnergyResolution;
+
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class ChiSquaredFCN : public SymmetryFCN
+{
+public:
+  //! Operator which returns the symmetry of m_CTDHistogram given the parameters passed
+  double operator()(vector<double> const &v) const override;
+  double Up() const override { return 1; }
+
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+//! A standalone program based on MEGAlib and ROOT
+class TrappingCorrection
+{
+public:
+  //! Default constructor
+  TrappingCorrection();
+  //! Default destructor
+  ~TrappingCorrection();
+  
+  //! Parse the command line
+  bool ParseCommandLine(int argc, char** argv);
+  //! Analyze what eveer needs to be analyzed...
+  bool Analyze();
+  //!load cross talk correction
+  vector<vector<vector<float> > > LoadCrossTalk();
+  //! Interrupt the analysis
+  void Interrupt() { m_Interrupt = true; }
+
+  void dummy_func() { return; }
+
+  MStripHit* GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction);
+
+private:
+  //! True, if the analysis needs to be interrupted
+  bool m_Interrupt;
+  //! The input file name
+  MString m_FileName;
+  MString m_EcalFile;
+  MString m_TACFile;
+  //! output file names
+  MString m_OutFile;
+  //! energy E0
+  // float m_E0;
+  //! option to correct charge loss or not
+  // bool m_CorrectCL;
+  //! option to do a pixel-by-pixel calibration (instead of detector-by-detector)
+  bool m_PixelCorrect;
+  bool m_GreedyPairing;
+  bool m_CardCageOverride;
+
+  double m_MinEnergy;
+  double m_MaxEnergy;
+
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+double SymmetryFCN::operator()(vector<double> const &v) const
+{
+  double HVSlope = v[0];
+  double HVIntercept = v[1];
+  double LVSlope = v[2];
+  double LVIntercept = v[3];
+
+  char name[64]; sprintf(name,"name");
+  int HistBins = g_HistBins;
+  if (HistBins%2 == 0) {
+    HistBins += 1;
+  }
+  TH2D CorrectedHistogram(name, name, HistBins, g_MinCTD, g_MaxCTD, HistBins, g_MinRatio, g_MaxRatio);
+
+  for (unsigned int i = 0; i < m_CTD.size(); ++i) {
+    double CTDHVShift = m_CTD[i] + g_MaxCTD;
+    double CTDLVShift = m_CTD[i] + g_MinCTD;
+    // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
+    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
+    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+    CorrectedHistogram.Fill(m_CTD[i], CorrectedHVEnergy/CorrectedLVEnergy);
+  }
+
+  vector<vector<double>> BinValues;
+  vector<vector<double>> ReflectedBinValues;
+  double Asymmetry = 0;
+
+  for (unsigned int y = 0; y < CorrectedHistogram.GetNbinsY(); ++y) {
+    
+    vector<double> XValues;
+
+    for (unsigned int x = 0; x < CorrectedHistogram.GetNbinsX(); ++x) {
+      XValues.push_back(CorrectedHistogram.GetBinContent(x,y));
+    }
+
+    // BinValues.push_back(XValues);
+    vector<double> ReflectedXValues = XValues;
+    reverse(ReflectedXValues.begin(), ReflectedXValues.end());
+
+    for (unsigned int x = 0; x < XValues.size(); ++x) {
+      Asymmetry += pow(XValues[x] - ReflectedXValues[x], 2)/(XValues[x] + ReflectedXValues[x]);
+    }
+  }
+
+  return Asymmetry;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+double ChiSquaredFCN::operator()(vector<double> const &v) const
+{
+  double HVSlope = v[0];
+  double HVIntercept = v[1];
+  double LVSlope = v[2];
+  double LVIntercept = v[3];
+
+  double ChiSquare = 0;
+
+  for (unsigned int i = 0; i < m_CTD.size(); ++i) {
+    double CTDHVShift = m_CTD[i] + g_MaxCTD;
+    double CTDLVShift = m_CTD[i] + g_MinCTD;
+    // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
+    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
+    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+
+    ChiSquare += pow(CorrectedHVEnergy - CorrectedLVEnergy, 2)/(m_HVEnergyResolution[i] + m_LVEnergyResolution[i]);
+  }
+
+  // ChiSquare /= m_CTD.size();
+
+  return ChiSquare;
+
+}
+
+
+//! Default constructor
+TrappingCorrection::TrappingCorrection() : m_Interrupt(false)
+{
+  gStyle->SetPalette(1, 0);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Default destructor
+TrappingCorrection::~TrappingCorrection()
+{
+  // Intentionally left blank
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Parse the command line
+bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
+{
+  ostringstream Usage;
+  Usage<<endl;
+  Usage<<"  Usage: TrappingCorrection <options>"<<endl;
+  Usage<<"    General options:"<<endl;
+  Usage<<"         -i:   input file name (.roa)"<<endl;
+  Usage<<"         --emin:   minimum Event energy"<<endl;
+  Usage<<"         --emax:   maximum Event energy"<<endl;
+  Usage<<"         -t:   TAC calibration file"<<endl;
+  Usage<<"         -p:   do pixel-by-pixel correction"<<endl;
+  Usage<<"         -g:   greedy strip pairing (default is chi-square)"<<endl;
+  Usage<<"         -c:   Card cage data (i.e. no TAC calibration required)"<<endl;
+  Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS"<<endl;
+  Usage<<"         -h:   print this help"<<endl;
+  Usage<<endl;
+
+  string Option;
+
+  // Check for help
+  for (int i = 1; i < argc; i++) {
+    Option = argv[i];
+    if (Option == "-h" || Option == "--help" || Option == "?" || Option == "-?") {
+      cout<<Usage.str()<<endl;
+      return false;
+    }
+  }
+
+  m_PixelCorrect = false;
+  m_GreedyPairing = false;
+  m_MinEnergy = 0;
+  m_MaxEnergy = 5000;
+  
+  time_t rawtime;
+  tm* timeinfo;
+  time(&rawtime);
+  timeinfo = gmtime(&rawtime);
+
+  char buffer [80];
+  strftime(buffer,80,"%Y%m%d%H%M%S",timeinfo);
+
+  m_OutFile = MString(buffer);
+
+  // Now parse the command line options:
+  for (int i = 1; i < argc; i++) {
+    Option = argv[i];
+
+    // First check if each option has sufficient arguments:
+    // Single argument
+    if (Option == "-i" || Option == "-e" || Option == "-t" || Option == "-o" || Option == "--emin" || Option == "--emax") {
+      if (!((argc > i+1) && 
+            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0))){
+        cout<<"Error: Option "<<argv[i][1]<<" needs a second argument!"<<endl;
+        cout<<Usage.str()<<endl;
+        return false;
+      }
+    } 
+    // Multiple arguments template
+    /*
+    else if (Option == "-??") {
+      if (!((argc > i+2) && 
+            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0) && 
+            (argv[i+2][0] != '-' || isalpha(argv[i+2][1]) == 0))){
+        cout<<"Error: Option "<<argv[i][1]<<" needs two arguments!"<<endl;
+        cout<<Usage.str()<<endl;
+        return false;
+      }
+    }
+    */
+
+    // Then fulfill the options:
+    if (Option == "-i") {
+      m_FileName = argv[++i];
+      cout<<"Accepting file name: "<<m_FileName<<endl;
+    } 
+
+    if (Option == "-e") {
+      m_EcalFile = argv[++i];
+      cout<<"Accepting file name: "<<m_EcalFile<<endl;
+    } 
+
+    if (Option == "--emin") {
+      m_MinEnergy = stod(argv[++i]);
+    } 
+
+    if (Option == "--emax") {
+      m_MaxEnergy = stod(argv[++i]);
+    } 
+
+    if (Option == "-t") {
+      m_TACFile = argv[++i];
+      cout<<"Accepting file name: "<<m_TACFile<<endl;
+    } 
+
+    if (Option == "-o"){
+      m_OutFile = argv[++i];
+      cout<<"Accepting file name: "<<m_OutFile<<endl;
+    }
+
+    if (Option == "-c"){
+      m_CardCageOverride = true;
+    }
+
+    if (Option == "-p"){
+      m_PixelCorrect = true;
+    }
+
+    if (Option == "-g"){
+      m_GreedyPairing = true;
+    }
+
+  }
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Do whatever analysis is necessary
+bool TrappingCorrection::Analyze()
+{
+
+/*  TH2D* h2 = new TH2D("fracmap","fracmap",356*2,-356,356,35,356-30,356+5);
+//  for (int i=-662; i<662; i++){
+//    for (int j=662-30; j<662+5; j++){
+  for (int i=0; i<356*2; i++){
+    for (int j=0; j<35; j++){
+      float c = ((float)i-356)/((float)j+356-30);
+      cout<<c<<endl;
+      h2->SetBinContent(i,j,c);
+    }
+  }
+  TCanvas *ctemp = new TCanvas();
+  h2->Draw("colz");
+  ctemp->Print("frac_map.pdf");
+*/  
+  //time code just to see
+  TStopwatch watch;
+  watch.Start();
+
+  if (m_Interrupt == true) return false;
+
+  MSupervisor* S = MSupervisor::GetSupervisor();
+  
+	MModuleLoaderMeasurementsROA* Loader;
+	MModuleTACcut* TACCalibrator;
+	MModuleEnergyCalibrationUniversal* EnergyCalibrator;
+	MModuleEventFilter* EventFilter;
+
+  unsigned int MNumber = 0;
+  cout<<"Creating ROA loader"<<endl;
+  Loader = new MModuleLoaderMeasurementsROA();
+  Loader->SetFileName(m_FileName);
+  S->SetModule(Loader, MNumber);
+  ++MNumber;
+
+  if (m_CardCageOverride==false) {
+	  cout<<"Creating TAC calibrator"<<endl;
+	  TACCalibrator = new MModuleTACcut();
+	  TACCalibrator->SetTACCalFileName(m_TACFile);
+	  S->SetModule(TACCalibrator, MNumber);
+	  ++MNumber;
+  }
+ 
+  cout<<"Creating energy calibrator"<<endl;
+  EnergyCalibrator = new MModuleEnergyCalibrationUniversal();
+  EnergyCalibrator->SetFileName(m_EcalFile);
+  EnergyCalibrator->EnablePreampTempCorrection(false);
+  S->SetModule(EnergyCalibrator, MNumber);
+  ++MNumber;
+
+  cout<<"Creating Event filter"<<endl;
+  //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
+  EventFilter = new MModuleEventFilter();
+  EventFilter->SetMinimumLVStrips(1);
+  EventFilter->SetMaximumLVStrips(1);
+  EventFilter->SetMinimumHVStrips(1);
+  EventFilter->SetMaximumHVStrips(1);
+  EventFilter->SetMinimumTotalEnergy(m_MinEnergy);
+  EventFilter->SetMaximumTotalEnergy(m_MaxEnergy);
+  S->SetModule(EventFilter, MNumber);
+  ++MNumber;
+  
+  cout<<"Creating strip pairing"<<endl;
+  MModule* Pairing;
+  if (m_GreedyPairing == true){
+    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
+    Pairing = new MModuleStripPairingGreedy();
+  }
+  else {
+    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
+    Pairing = new MModuleStripPairingChiSquare();
+  }
+  S->SetModule(Pairing, MNumber);
+
+  cout<<"Initializing Loader"<<endl;
+  if (Loader->Initialize() == false) return false;
+  if (m_CardCageOverride==false) {
+  	cout<<"Initializing TAC calibrator"<<endl;
+  	if (TACCalibrator->Initialize() == false) return false;
+  }
+  cout<<"Initializing Energy calibrator"<<endl;
+  if (EnergyCalibrator->Initialize() == false) return false;
+  cout<<"Initializing Event filter"<<endl;
+  if (EventFilter->Initialize() == false) return false;
+  cout<<"Initializing Pairing"<<endl;
+  if (Pairing->Initialize() == false) return false;
+
+  map<int, TH2D*> Histograms;
+  map<int, SymmetryFCN*> FCNs;
+
+  bool IsFinished = false;
+  MReadOutAssembly* Event = new MReadOutAssembly();
+
+  cout<<"Analyzing..."<<endl;
+  while (IsFinished == false && m_Interrupt == false) {
+    Event->Clear();
+
+    if (Loader->IsReady() ){
+      Loader->AnalyzeEvent(Event);
+
+      if (m_CardCageOverride==false) {
+      	TACCalibrator->AnalyzeEvent(Event);
+      }
+
+      EnergyCalibrator->AnalyzeEvent(Event);
+      bool Unfiltered = EventFilter->AnalyzeEvent(Event);
+      Pairing->AnalyzeEvent(Event);
+
+      if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true)) {
+        for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
+          double HVEnergy = 0.0;
+          double LVEnergy = 0.0;
+          double HVEnergyResolution = 0.0;
+          double LVEnergyResolution = 0.0;
+          vector<MStripHit*> HVStrips;
+          vector<MStripHit*> LVStrips;
+
+          MHit* H = Event->GetHit(h);
+          
+          int DetID = H->GetStripHit(0)->GetDetectorID();
+          TH2D* Hist = Histograms[DetID];
+          SymmetryFCN* FCN = FCNs[DetID]; 
+          
+          if (Hist == nullptr) {
+            char name[64]; sprintf(name,"Detector %d (Uncorrected)",DetID);
+            Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
+            Hist->SetXTitle("CTD (ns)");
+            Hist->SetYTitle("HV/LV Energy Ratio");
+            Histograms[DetID] = Hist;
+          }
+
+          if (FCN == nullptr) {
+            FCN = new SymmetryFCN();
+            FCNs[DetID] = FCN;
+          }
+
+          for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
+            MStripHit* SH = H->GetStripHit(sh);
+
+            if (SH->IsLowVoltageStrip()==true) {
+              LVEnergy += SH->GetEnergy();
+              LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+              LVStrips.push_back(SH);
+            } else {
+              HVEnergy += SH->GetEnergy();
+              HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+              HVStrips.push_back(SH);
+            }
+          }
+
+          double HVEnergyFraction = 0;
+          double LVEnergyFraction = 0;
+          MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
+          MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
+          double EnergyFraction = HVEnergy/LVEnergy;
+          double CTD = LVSH->GetTiming() - HVSH->GetTiming();
+          if (m_CardCageOverride == true) {
+            CTD *= -1;
+          }
+          Hist->Fill(CTD, EnergyFraction);
+          FCN->AddCTD(CTD);
+          FCN->AddHVEnergy(HVEnergy, HVEnergyResolution);
+          FCN->AddLVEnergy(LVEnergy, LVEnergyResolution);
+        }
+      }
+    }
+    IsFinished = Loader->IsFinished();
+  }
+
+  //setup output file
+  ofstream OutputCalFile;
+  OutputCalFile.open(m_OutFile+MString("_parameters.txt"));
+  OutputCalFile<<"Det"<<'\t'<<"HV Slope"<<'\t'<<"HV Intercept"<<'\t'<<"LV Slope"<<'\t'<<"LV Intercept"<<endl<<endl;
+
+  for (auto H: Histograms) {
+    
+    int DetID = H.first;
+    TFile f(m_OutFile+MString("_Det")+DetID+MString("_Hist_Uncorr.root"),"recreate");
+
+    TCanvas* C = new TCanvas();
+    C->SetLogz();
+    C->cd();
+    H.second->Draw("colz");
+
+    H.second->Write();
+    f.Close();
+
+  }
+
+  for (auto F: FCNs) {
+
+    int DetID = F.first;
+    MnUserParameters* InitialStateSym = new MnUserParameters();
+    InitialStateSym->Add("HVSlope", 1e-3, 1e-4, 0, 3e-1);
+    InitialStateSym->Add("HVIntercept", 0, 0.01, -2, 2);
+    InitialStateSym->Add("LVSlope", 0, 1e-4, -3e-2, 0);
+    InitialStateSym->Add("LVIntercept", 0, 0.01, -2, 2);
+
+    InitialStateSym->Fix("LVSlope");
+    InitialStateSym->Fix("LVIntercept");
+    InitialStateSym->Fix("HVIntercept");
+
+
+    MnMigrad migradSym(*F.second, *InitialStateSym);
+     // Minimize
+    FunctionMinimum MinimumSym = migradSym();
+
+    MnUserParameters ParametersSym = MinimumSym.UserParameters();
+    // double HVSlope = ParametersSym.Value("HVSlope");
+    // double HVIntercept = ParametersSym.Value("HVIntercept");
+    // double LVSlope = ParametersSym.Value("LVSlope");
+    // double LVIntercept = ParametersSym.Value("LVIntercept");
+
+    // output
+    cout<<MinimumSym<<endl;
+
+    MnUserParameters* InitialStateChi = new MnUserParameters();
+    InitialStateChi->Add("HVSlope", ParametersSym.Value("HVSlope"), ParametersSym.Error("HVSlope"));
+    InitialStateChi->Add("HVIntercept", 0, 0.01, -2, 2);
+    InitialStateChi->Add("LVSlope", 0, 1e-4, -3e-2, 0);
+    InitialStateChi->Add("LVIntercept", 0, 0.01, -2, 2);
+
+    InitialStateChi->Fix("LVSlope");
+    InitialStateChi->Fix("LVIntercept");
+    InitialStateChi->Fix("HVSlope");
+
+
+    ChiSquaredFCN* ChiSquaredF = new ChiSquaredFCN();
+    ChiSquaredF->SetCTD(F.second->GetCTD());
+    ChiSquaredF->SetHVEnergy(F.second->GetHVEnergy(), F.second->GetHVEnergyResolution());
+    ChiSquaredF->SetLVEnergy(F.second->GetLVEnergy(), F.second->GetLVEnergyResolution());
+    MnMigrad migradChi(*ChiSquaredF, *InitialStateChi);
+     // Minimize
+    FunctionMinimum MinimumChi = migradChi();
+
+    MnUserParameters ParametersChi = MinimumChi.UserParameters();
+    double HVSlope = ParametersChi.Value("HVSlope");
+    double HVIntercept = ParametersChi.Value("HVIntercept");
+    double LVSlope = ParametersChi.Value("LVSlope");
+    double LVIntercept = ParametersChi.Value("LVIntercept");
+    // output
+    cout<<MinimumChi<<endl;
+
+    char name[64]; sprintf(name,"Detector %d (Corrected)",DetID);
+    TH2D* Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
+    Hist->SetXTitle("CTD (ns)");
+    Hist->SetYTitle("HV/LV Energy Ratio");
+
+    vector<double> CTDList = F.second->GetCTD();
+    vector<double> HVEnergyList = F.second->GetHVEnergy();
+    vector<double> LVEnergyList = F.second->GetLVEnergy();
+    for (unsigned int i=0; i<CTDList.size(); ++i) {
+      
+      double CTDHVShift = CTDList[i] + g_MaxCTD;
+      double CTDLVShift = CTDList[i] + g_MinCTD;
+      // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
+      double CorrectedHVEnergy = HVEnergyList[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
+      double CorrectedLVEnergy = LVEnergyList[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+      
+      Hist->Fill(CTDList[i], CorrectedHVEnergy/CorrectedLVEnergy);
+    }
+
+    TCanvas* C = new TCanvas();
+    C->SetLogz();
+    C->cd();
+    Hist->Draw("colz");
+
+    TFile f(m_OutFile+MString("_Det")+DetID+MString("_Hist_Corr.root"),"recreate");
+    Hist->Write();
+    f.Close();
+
+    OutputCalFile<<to_string(DetID)<<'\t'<<to_string(HVSlope)<<'\t'<<to_string(HVIntercept)<<'\t'<<to_string(LVSlope)<<'\t'<<to_string(LVIntercept)<<endl<<endl;
+
+  }
+  OutputCalFile.close();
+
+  watch.Stop();
+  cout<<"total time (s): "<<watch.CpuTime()<<endl;
+ 
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+TrappingCorrection* g_Prg = 0;
+int g_NInterruptCatches = 1;
+
+MStripHit* TrappingCorrection::GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction)
+{
+  double MaxEnergy = -numeric_limits<double>::max(); // AZ: When both energies are zero (which shouldn't happen) we still pick one
+  double TotalEnergy = 0.0;
+  MStripHit* MaxStrip = nullptr;
+
+  // Iterate through strip hits and get the strip with highest energy
+  for (const auto SH : Strips) {
+    double Energy = SH->GetEnergy();
+    TotalEnergy += Energy;
+    if (Energy > MaxEnergy) {
+      MaxStrip = SH;
+      MaxEnergy = Energy;
+    }
+  }
+  if (TotalEnergy == 0) {
+    EnergyFraction = 0;
+  } else {
+    EnergyFraction = MaxEnergy/TotalEnergy;
+  }
+  return MaxStrip;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Called when an interrupt signal is flagged
+//! All catched signals lead to a well defined exit of the program
+void CatchSignal(int a)
+{
+  if (g_Prg != 0 && g_NInterruptCatches-- > 0) {
+    cout<<"Catched signal Ctrl-C (ID="<<a<<"):"<<endl;
+    g_Prg->Interrupt();
+  } else {
+    abort();
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Main program
+int main(int argc, char** argv)
+{
+  // Catch a user interupt for graceful shutdown
+  signal(SIGINT, CatchSignal);
+
+  // Initialize global MEGALIB variables, especially mgui, etc.
+  MGlobal::Initialize("Standalone", "a standalone example program");
+
+  TApplication TrappingCorrectionApp("TrappingCorrectionApp", 0, 0);
+
+  g_Prg = new TrappingCorrection();
+
+  if (g_Prg->ParseCommandLine(argc, argv) == false) {
+    cerr<<"Error during parsing of command line!"<<endl;
+    return -1;
+  } 
+  if (g_Prg->Analyze() == false) {
+    cerr<<"Error during analysis!"<<endl;
+    return -2;
+  } 
+
+  TrappingCorrectionApp.Run();
+
+  cout<<"Program exited normally!"<<endl;
+
+  return 0;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -67,8 +67,8 @@ using namespace ROOT::Minuit2;
 
 
 int g_HistBins = 75;
-double g_MinCTD = -200;
-double g_MaxCTD = 200;
+double g_MinCTD = -250;
+double g_MaxCTD = 250;
 double g_MinRatio = 0.94;
 double g_MaxRatio = 1.06;
 
@@ -135,10 +135,8 @@ public:
   
   //! Parse the command line
   bool ParseCommandLine(int argc, char** argv);
-  //! Analyze what eveer needs to be analyzed...
+  //! Analyze what ever needs to be analyzed...
   bool Analyze();
-  //!load cross talk correction
-  vector<vector<vector<float> > > LoadCrossTalk();
   //! Interrupt the analysis
   void Interrupt() { m_Interrupt = true; }
 
@@ -152,17 +150,13 @@ private:
   //! The input file name
   MString m_FileName;
   MString m_EcalFile;
-  MString m_TACFile;
+  MString m_TACCalFile;
+  MString m_TACCutFile;
   //! output file names
   MString m_OutFile;
-  //! energy E0
-  // float m_E0;
-  //! option to correct charge loss or not
-  // bool m_CorrectCL;
   //! option to do a pixel-by-pixel calibration (instead of detector-by-detector)
   bool m_PixelCorrect;
   bool m_GreedyPairing;
-  bool m_CardCageOverride;
 
   double m_MinEnergy;
   double m_MaxEnergy;
@@ -175,9 +169,7 @@ private:
 double SymmetryFCN::operator()(vector<double> const &v) const
 {
   double HVSlope = v[0];
-  double HVIntercept = v[1];
-  double LVSlope = v[2];
-  double LVIntercept = v[3];
+  double LVSlope = v[1];
 
   char name[64]; sprintf(name,"name");
   int HistBins = g_HistBins;
@@ -190,8 +182,8 @@ double SymmetryFCN::operator()(vector<double> const &v) const
     double CTDHVShift = m_CTD[i] + g_MaxCTD;
     double CTDLVShift = m_CTD[i] + g_MinCTD;
     // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
-    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
-    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift)/100);
+    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift)/100);
     CorrectedHistogram.Fill(m_CTD[i], CorrectedHVEnergy/CorrectedLVEnergy);
   }
 
@@ -216,7 +208,7 @@ double SymmetryFCN::operator()(vector<double> const &v) const
     }
   }
 
-  return Asymmetry;
+  return Asymmetry*Asymmetry;
 
 }
 
@@ -226,10 +218,9 @@ double SymmetryFCN::operator()(vector<double> const &v) const
 
 double ChiSquaredFCN::operator()(vector<double> const &v) const
 {
-  double HVSlope = v[0];
-  double HVIntercept = v[1];
+  double HVLVFactor = v[0];
+  double HVSlope = v[1];
   double LVSlope = v[2];
-  double LVIntercept = v[3];
 
   double ChiSquare = 0;
 
@@ -237,8 +228,8 @@ double ChiSquaredFCN::operator()(vector<double> const &v) const
     double CTDHVShift = m_CTD[i] + g_MaxCTD;
     double CTDLVShift = m_CTD[i] + g_MinCTD;
     // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
-    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
-    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+    double CorrectedHVEnergy = m_HVEnergy[i]/((1 - (HVSlope*CTDHVShift)/100)*HVLVFactor);
+    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift)/100);
 
     ChiSquare += pow(CorrectedHVEnergy - CorrectedLVEnergy, 2)/(m_HVEnergyResolution[i] + m_LVEnergyResolution[i]);
   }
@@ -277,14 +268,15 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
   Usage<<endl;
   Usage<<"  Usage: TrappingCorrection <options>"<<endl;
   Usage<<"    General options:"<<endl;
-  Usage<<"         -i:   input file name (.roa)"<<endl;
-  Usage<<"         --emin:   minimum Event energy"<<endl;
-  Usage<<"         --emax:   maximum Event energy"<<endl;
-  Usage<<"         -t:   TAC calibration file"<<endl;
+  Usage<<"         -i:   input file name (.roa or .txt with list of ROAs)"<<endl;
+  Usage<<"         --emin:   minimum Event energy (default 30 keV)"<<endl;
+  Usage<<"         --emax:   maximum Event energy (default 5000 kev)"<<endl;
+  Usage<<"         -e:   energy calibration file (.ecal)"<<endl;
+  Usage<<"         --tcal:   TAC calibration file"<<endl;
+  Usage<<"         --tcut:   TAC cut file"<<endl;
   Usage<<"         -p:   do pixel-by-pixel correction"<<endl;
   Usage<<"         -g:   greedy strip pairing (default is chi-square)"<<endl;
-  Usage<<"         -c:   Card cage data (i.e. no TAC calibration required)"<<endl;
-  Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS"<<endl;
+  Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS)"<<endl;
   Usage<<"         -h:   print this help"<<endl;
   Usage<<endl;
 
@@ -301,7 +293,7 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
   m_PixelCorrect = false;
   m_GreedyPairing = false;
-  m_MinEnergy = 0;
+  m_MinEnergy = 30;
   m_MaxEnergy = 5000;
   
   time_t rawtime;
@@ -320,26 +312,13 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
     // First check if each option has sufficient arguments:
     // Single argument
-    if (Option == "-i" || Option == "-e" || Option == "-t" || Option == "-o" || Option == "--emin" || Option == "--emax") {
-      if (!((argc > i+1) && 
-            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0))){
+    if ((Option == "-i") || (Option == "-o") || (Option == "--emin") || (Option == "--emax") || (Option == "--tcal") || (Option == "--tcut")) {
+      if (!((argc > i+1) && (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0))){
         cout<<"Error: Option "<<argv[i][1]<<" needs a second argument!"<<endl;
         cout<<Usage.str()<<endl;
         return false;
       }
     } 
-    // Multiple arguments template
-    /*
-    else if (Option == "-??") {
-      if (!((argc > i+2) && 
-            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0) && 
-            (argv[i+2][0] != '-' || isalpha(argv[i+2][1]) == 0))){
-        cout<<"Error: Option "<<argv[i][1]<<" needs two arguments!"<<endl;
-        cout<<Usage.str()<<endl;
-        return false;
-      }
-    }
-    */
 
     // Then fulfill the options:
     if (Option == "-i") {
@@ -360,18 +339,19 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
       m_MaxEnergy = stod(argv[++i]);
     } 
 
-    if (Option == "-t") {
-      m_TACFile = argv[++i];
-      cout<<"Accepting file name: "<<m_TACFile<<endl;
+    if (Option == "--tcal") {
+      m_TACCalFile = argv[++i];
+      cout<<"Accepting file name: "<<m_TACCalFile<<endl;
+    } 
+
+    if (Option == "--tcut") {
+      m_TACCutFile = argv[++i];
+      cout<<"Accepting file name: "<<m_TACCutFile<<endl;
     } 
 
     if (Option == "-o"){
       m_OutFile = argv[++i];
       cout<<"Accepting file name: "<<m_OutFile<<endl;
-    }
-
-    if (Option == "-c"){
-      m_CardCageOverride = true;
     }
 
     if (Option == "-p"){
@@ -394,179 +374,178 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 //! Do whatever analysis is necessary
 bool TrappingCorrection::Analyze()
 {
-
-/*  TH2D* h2 = new TH2D("fracmap","fracmap",356*2,-356,356,35,356-30,356+5);
-//  for (int i=-662; i<662; i++){
-//    for (int j=662-30; j<662+5; j++){
-  for (int i=0; i<356*2; i++){
-    for (int j=0; j<35; j++){
-      float c = ((float)i-356)/((float)j+356-30);
-      cout<<c<<endl;
-      h2->SetBinContent(i,j,c);
-    }
-  }
-  TCanvas *ctemp = new TCanvas();
-  h2->Draw("colz");
-  ctemp->Print("frac_map.pdf");
-*/  
   //time code just to see
   TStopwatch watch;
   watch.Start();
 
   if (m_Interrupt == true) return false;
 
-  MSupervisor* S = MSupervisor::GetSupervisor();
-  
-	MModuleLoaderMeasurementsROA* Loader;
-	MModuleTACcut* TACCalibrator;
-	MModuleEnergyCalibrationUniversal* EnergyCalibrator;
-	MModuleEventFilter* EventFilter;
+  vector<MString> FileNames;
 
-  unsigned int MNumber = 0;
-  cout<<"Creating ROA loader"<<endl;
-  Loader = new MModuleLoaderMeasurementsROA();
-  Loader->SetFileName(m_FileName);
-  S->SetModule(Loader, MNumber);
-  ++MNumber;
-
-  if (m_CardCageOverride==false) {
-	  cout<<"Creating TAC calibrator"<<endl;
-	  TACCalibrator = new MModuleTACcut();
-	  TACCalibrator->SetTACCalFileName(m_TACFile);
-	  S->SetModule(TACCalibrator, MNumber);
-	  ++MNumber;
-  }
- 
-  cout<<"Creating energy calibrator"<<endl;
-  EnergyCalibrator = new MModuleEnergyCalibrationUniversal();
-  EnergyCalibrator->SetFileName(m_EcalFile);
-  EnergyCalibrator->EnablePreampTempCorrection(false);
-  S->SetModule(EnergyCalibrator, MNumber);
-  ++MNumber;
-
-  cout<<"Creating Event filter"<<endl;
-  //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
-  EventFilter = new MModuleEventFilter();
-  EventFilter->SetMinimumLVStrips(1);
-  EventFilter->SetMaximumLVStrips(1);
-  EventFilter->SetMinimumHVStrips(1);
-  EventFilter->SetMaximumHVStrips(1);
-  EventFilter->SetMinimumTotalEnergy(m_MinEnergy);
-  EventFilter->SetMaximumTotalEnergy(m_MaxEnergy);
-  S->SetModule(EventFilter, MNumber);
-  ++MNumber;
-  
-  cout<<"Creating strip pairing"<<endl;
-  MModule* Pairing;
-  if (m_GreedyPairing == true){
-    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
-    Pairing = new MModuleStripPairingGreedy();
-  }
-  else {
-    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
-    Pairing = new MModuleStripPairingChiSquare();
-  }
-  S->SetModule(Pairing, MNumber);
-
-  cout<<"Initializing Loader"<<endl;
-  if (Loader->Initialize() == false) return false;
-  if (m_CardCageOverride==false) {
-  	cout<<"Initializing TAC calibrator"<<endl;
-  	if (TACCalibrator->Initialize() == false) return false;
-  }
-  cout<<"Initializing Energy calibrator"<<endl;
-  if (EnergyCalibrator->Initialize() == false) return false;
-  cout<<"Initializing Event filter"<<endl;
-  if (EventFilter->Initialize() == false) return false;
-  cout<<"Initializing Pairing"<<endl;
-  if (Pairing->Initialize() == false) return false;
-
-  map<int, TH2D*> Histograms;
-  map<int, SymmetryFCN*> FCNs;
-
-  bool IsFinished = false;
-  MReadOutAssembly* Event = new MReadOutAssembly();
-
-  cout<<"Analyzing..."<<endl;
-  while (IsFinished == false && m_Interrupt == false) {
-    Event->Clear();
-
-    if (Loader->IsReady() ){
-      Loader->AnalyzeEvent(Event);
-
-      if (m_CardCageOverride==false) {
-      	TACCalibrator->AnalyzeEvent(Event);
-      }
-
-      EnergyCalibrator->AnalyzeEvent(Event);
-      bool Unfiltered = EventFilter->AnalyzeEvent(Event);
-      Pairing->AnalyzeEvent(Event);
-
-      if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true)) {
-        for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
-          double HVEnergy = 0.0;
-          double LVEnergy = 0.0;
-          double HVEnergyResolution = 0.0;
-          double LVEnergyResolution = 0.0;
-          vector<MStripHit*> HVStrips;
-          vector<MStripHit*> LVStrips;
-
-          MHit* H = Event->GetHit(h);
-          
-          int DetID = H->GetStripHit(0)->GetDetectorID();
-          TH2D* Hist = Histograms[DetID];
-          SymmetryFCN* FCN = FCNs[DetID]; 
-          
-          if (Hist == nullptr) {
-            char name[64]; sprintf(name,"Detector %d (Uncorrected)",DetID);
-            Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
-            Hist->SetXTitle("CTD (ns)");
-            Hist->SetYTitle("HV/LV Energy Ratio");
-            Histograms[DetID] = Hist;
-          }
-
-          if (FCN == nullptr) {
-            FCN = new SymmetryFCN();
-            FCNs[DetID] = FCN;
-          }
-
-          for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
-            MStripHit* SH = H->GetStripHit(sh);
-
-            if (SH->IsLowVoltageStrip()==true) {
-              LVEnergy += SH->GetEnergy();
-              LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
-              LVStrips.push_back(SH);
-            } else {
-              HVEnergy += SH->GetEnergy();
-              HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
-              HVStrips.push_back(SH);
-            }
-          }
-
-          double HVEnergyFraction = 0;
-          double LVEnergyFraction = 0;
-          MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
-          MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
-          double EnergyFraction = HVEnergy/LVEnergy;
-          double CTD = LVSH->GetTiming() - HVSH->GetTiming();
-          if (m_CardCageOverride == true) {
-            CTD *= -1;
-          }
-          Hist->Fill(CTD, EnergyFraction);
-          FCN->AddCTD(CTD);
-          FCN->AddHVEnergy(HVEnergy, HVEnergyResolution);
-          FCN->AddLVEnergy(LVEnergy, LVEnergyResolution);
-        }
+  if ((m_FileName.GetSubString(m_FileName.Length() - 3)) == "roa"){
+    FileNames.push_back(m_FileName);
+  } else if ((m_FileName.GetSubString(m_FileName.Length() - 3)) == "txt") {
+    MFile F;
+    if (F.Open(m_FileName)==false) {
+      cout<<"Error: Failed to open input file."<<endl;
+    } else {
+      MString Line;
+      while (F.ReadLine(Line)) {
+        FileNames.push_back(Line.Trim());
       }
     }
-    IsFinished = Loader->IsFinished();
+  }
+
+  map<unsigned int, TH2D*> Histograms;
+  map<unsigned int, SymmetryFCN*> FCNs;
+
+  for (unsigned int f = 0; f<FileNames.size(); ++f) {
+
+    MString ROAFile = FileNames[f];
+
+    cout<<"Beginning analysis of file "<<ROAFile<<endl;
+
+    MSupervisor* S = MSupervisor::GetSupervisor();
+    
+  	MModuleLoaderMeasurementsROA* Loader;
+  	MModuleTACcut* TACCalibrator;
+  	MModuleEnergyCalibrationUniversal* EnergyCalibrator;
+  	MModuleEventFilter* EventFilter;
+
+    unsigned int MNumber = 0;
+    cout<<"Creating ROA loader"<<endl;
+    Loader = new MModuleLoaderMeasurementsROA();
+    Loader->SetFileName(ROAFile);
+    S->SetModule(Loader, MNumber);
+    ++MNumber;
+
+    cout<<"Creating TAC calibrator"<<endl;
+    TACCalibrator = new MModuleTACcut();
+    TACCalibrator->SetTACCalFileName(m_TACCalFile);
+    TACCalibrator->SetTACCutFileName(m_TACCutFile);
+    S->SetModule(TACCalibrator, MNumber);
+    ++MNumber;
+   
+    cout<<"Creating energy calibrator"<<endl;
+    EnergyCalibrator = new MModuleEnergyCalibrationUniversal();
+    EnergyCalibrator->SetFileName(m_EcalFile);
+    EnergyCalibrator->EnablePreampTempCorrection(false);
+    S->SetModule(EnergyCalibrator, MNumber);
+    ++MNumber;
+
+    cout<<"Creating Event filter"<<endl;
+    //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
+    EventFilter = new MModuleEventFilter();
+    EventFilter->SetMinimumLVStrips(1);
+    EventFilter->SetMaximumLVStrips(1);
+    EventFilter->SetMinimumHVStrips(1);
+    EventFilter->SetMaximumHVStrips(1);
+    EventFilter->SetMinimumHits(0);
+    EventFilter->SetMaximumHits(3);
+    EventFilter->SetMinimumTotalEnergy(m_MinEnergy);
+    EventFilter->SetMaximumTotalEnergy(m_MaxEnergy);
+    S->SetModule(EventFilter, MNumber);
+    ++MNumber;
+    
+    cout<<"Creating strip pairing"<<endl;
+    MModule* Pairing;
+    if (m_GreedyPairing == true){
+      Pairing = new MModuleStripPairingGreedy();
+    }
+    else {
+      Pairing = new MModuleStripPairingChiSquare();
+    }
+    S->SetModule(Pairing, MNumber);
+
+    cout<<"Initializing Loader"<<endl;
+    if (Loader->Initialize() == false) return false;
+    cout<<"Initializing TAC calibrator"<<endl;
+    if (TACCalibrator->Initialize() == false) return false;
+    cout<<"Initializing Energy calibrator"<<endl;
+    if (EnergyCalibrator->Initialize() == false) return false;
+    cout<<"Initializing Event filter"<<endl;
+    if (EventFilter->Initialize() == false) return false;
+    cout<<"Initializing Pairing"<<endl;
+    if (Pairing->Initialize() == false) return false;
+
+    bool IsFinished = false;
+    MReadOutAssembly* Event = new MReadOutAssembly();
+
+    cout<<"Analyzing..."<<endl;
+    while ((IsFinished == false) && (m_Interrupt == false)) {
+      Event->Clear();
+
+      if (Loader->IsReady()){
+
+        Loader->AnalyzeEvent(Event);
+        TACCalibrator->AnalyzeEvent(Event);
+        EnergyCalibrator->AnalyzeEvent(Event);
+        bool Unfiltered = EventFilter->AnalyzeEvent(Event);
+        Pairing->AnalyzeEvent(Event);
+
+        if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true)) {
+          for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
+            double HVEnergy = 0.0;
+            double LVEnergy = 0.0;
+            double HVEnergyResolution = 0.0;
+            double LVEnergyResolution = 0.0;
+            vector<MStripHit*> HVStrips;
+            vector<MStripHit*> LVStrips;
+
+            MHit* H = Event->GetHit(h);
+            
+            int DetID = H->GetStripHit(0)->GetDetectorID();
+            TH2D* Hist = Histograms[DetID];
+            SymmetryFCN* FCN = FCNs[DetID]; 
+            
+            if (Hist == nullptr) {
+              char name[64]; sprintf(name,"Detector %d (Uncorrected)",DetID);
+              Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
+              Hist->SetXTitle("CTD (ns)");
+              Hist->SetYTitle("HV/LV Energy Ratio");
+              Histograms[DetID] = Hist;
+            }
+
+            if (FCN == nullptr) {
+              FCN = new SymmetryFCN();
+              FCNs[DetID] = FCN;
+            }
+
+            for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
+              MStripHit* SH = H->GetStripHit(sh);
+
+              if (SH->IsLowVoltageStrip()==true) {
+                LVEnergy += SH->GetEnergy();
+                LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+                LVStrips.push_back(SH);
+              } else {
+                HVEnergy += SH->GetEnergy();
+                HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+                HVStrips.push_back(SH);
+              }
+            }
+
+            double HVEnergyFraction = 0;
+            double LVEnergyFraction = 0;
+            MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
+            MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
+            double EnergyFraction = HVEnergy/LVEnergy;
+            double CTD = LVSH->GetTiming() - HVSH->GetTiming();
+            Hist->Fill(CTD, EnergyFraction);
+            FCN->AddCTD(CTD);
+            FCN->AddHVEnergy(HVEnergy, HVEnergyResolution);
+            FCN->AddLVEnergy(LVEnergy, LVEnergyResolution);
+          }
+        }
+      }
+      IsFinished = Loader->IsFinished();
+    }
   }
 
   //setup output file
   ofstream OutputCalFile;
   OutputCalFile.open(m_OutFile+MString("_parameters.txt"));
-  OutputCalFile<<"Det"<<'\t'<<"HV Slope"<<'\t'<<"HV Intercept"<<'\t'<<"LV Slope"<<'\t'<<"LV Intercept"<<endl<<endl;
+  OutputCalFile<<"Det"<<'\t'<<"HV Slope"<<'\t'<<"LV Slope"<<'\t'<<"HV/LV Factor"<<endl<<endl;
 
   for (auto H: Histograms) {
     
@@ -587,55 +566,44 @@ bool TrappingCorrection::Analyze()
 
     int DetID = F.first;
     MnUserParameters* InitialStateSym = new MnUserParameters();
-    InitialStateSym->Add("HVSlope", 1e-3, 1e-4, 0, 3e-1);
-    InitialStateSym->Add("HVIntercept", 0, 0.01, -2, 2);
+    InitialStateSym->Add("HVSlope", 2e-3, 1e-4, 0, 3e-1);
     InitialStateSym->Add("LVSlope", 0, 1e-4, -3e-2, 0);
-    InitialStateSym->Add("LVIntercept", 0, 0.01, -2, 2);
 
     InitialStateSym->Fix("LVSlope");
-    InitialStateSym->Fix("LVIntercept");
-    InitialStateSym->Fix("HVIntercept");
-
 
     MnMigrad migradSym(*F.second, *InitialStateSym);
      // Minimize
     FunctionMinimum MinimumSym = migradSym();
 
     MnUserParameters ParametersSym = MinimumSym.UserParameters();
-    // double HVSlope = ParametersSym.Value("HVSlope");
-    // double HVIntercept = ParametersSym.Value("HVIntercept");
-    // double LVSlope = ParametersSym.Value("LVSlope");
-    // double LVIntercept = ParametersSym.Value("LVIntercept");
+    double HVSlope = ParametersSym.Value("HVSlope");
+    double LVSlope = ParametersSym.Value("LVSlope");
 
     // output
     cout<<MinimumSym<<endl;
 
-    MnUserParameters* InitialStateChi = new MnUserParameters();
-    InitialStateChi->Add("HVSlope", ParametersSym.Value("HVSlope"), ParametersSym.Error("HVSlope"));
-    InitialStateChi->Add("HVIntercept", 0, 0.01, -2, 2);
-    InitialStateChi->Add("LVSlope", 0, 1e-4, -3e-2, 0);
-    InitialStateChi->Add("LVIntercept", 0, 0.01, -2, 2);
+    // MnUserParameters* InitialStateChi = new MnUserParameters();
+    // InitialStateChi->Add("HVLVFactor", 1.0, 0.01, 0.95, 1.05);
+    // InitialStateChi->Add("HVSlope", ParametersSym.Value("HVSlope"), ParametersSym.Error("HVSlope"));
+    // InitialStateChi->Add("LVSlope", ParametersSym.Value("LVSlope"), ParametersSym.Error("LVSlope"));
 
-    InitialStateChi->Fix("LVSlope");
-    InitialStateChi->Fix("LVIntercept");
-    InitialStateChi->Fix("HVSlope");
+    // InitialStateChi->Fix("HVSlope");
+    // InitialStateChi->Fix("LVSlope");
 
 
-    ChiSquaredFCN* ChiSquaredF = new ChiSquaredFCN();
-    ChiSquaredF->SetCTD(F.second->GetCTD());
-    ChiSquaredF->SetHVEnergy(F.second->GetHVEnergy(), F.second->GetHVEnergyResolution());
-    ChiSquaredF->SetLVEnergy(F.second->GetLVEnergy(), F.second->GetLVEnergyResolution());
-    MnMigrad migradChi(*ChiSquaredF, *InitialStateChi);
-     // Minimize
-    FunctionMinimum MinimumChi = migradChi();
+    // ChiSquaredFCN* ChiSquaredF = new ChiSquaredFCN();
+    // ChiSquaredF->SetCTD(F.second->GetCTD());
+    // ChiSquaredF->SetHVEnergy(F.second->GetHVEnergy(), F.second->GetHVEnergyResolution());
+    // ChiSquaredF->SetLVEnergy(F.second->GetLVEnergy(), F.second->GetLVEnergyResolution());
+    // MnMigrad migradChi(*ChiSquaredF, *InitialStateChi);
+    //  // Minimize
+    // FunctionMinimum MinimumChi = migradChi();
 
-    MnUserParameters ParametersChi = MinimumChi.UserParameters();
-    double HVSlope = ParametersChi.Value("HVSlope");
-    double HVIntercept = ParametersChi.Value("HVIntercept");
-    double LVSlope = ParametersChi.Value("LVSlope");
-    double LVIntercept = ParametersChi.Value("LVIntercept");
-    // output
-    cout<<MinimumChi<<endl;
+    // MnUserParameters ParametersChi = MinimumChi.UserParameters();
+    // double HVLVFactor = ParametersChi.Value("HVLVFactor");
+    double HVLVFactor = 1;
+    // // output
+    // cout<<MinimumChi<<endl;
 
     char name[64]; sprintf(name,"Detector %d (Corrected)",DetID);
     TH2D* Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
@@ -650,8 +618,8 @@ bool TrappingCorrection::Analyze()
       double CTDHVShift = CTDList[i] + g_MaxCTD;
       double CTDLVShift = CTDList[i] + g_MinCTD;
       // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
-      double CorrectedHVEnergy = HVEnergyList[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
-      double CorrectedLVEnergy = LVEnergyList[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+      double CorrectedHVEnergy = HVEnergyList[i]/((1 - (HVSlope*CTDHVShift)/100)*HVLVFactor);
+      double CorrectedLVEnergy = LVEnergyList[i]/(1 - (LVSlope*CTDLVShift)/100);
       
       Hist->Fill(CTDList[i], CorrectedHVEnergy/CorrectedLVEnergy);
     }
@@ -665,7 +633,7 @@ bool TrappingCorrection::Analyze()
     Hist->Write();
     f.Close();
 
-    OutputCalFile<<to_string(DetID)<<'\t'<<to_string(HVSlope)<<'\t'<<to_string(HVIntercept)<<'\t'<<to_string(LVSlope)<<'\t'<<to_string(LVIntercept)<<endl<<endl;
+    OutputCalFile<<to_string(DetID)<<'\t'<<to_string(HVSlope)<<'\t'<<to_string(LVSlope)<<'\t'<<to_string(HVLVFactor)<<endl<<endl;
 
   }
   OutputCalFile.close();

--- a/apps/TrappingCorrection.cxx
+++ b/apps/TrappingCorrection.cxx
@@ -481,9 +481,9 @@ bool TrappingCorrection::Analyze()
     if (TACCalibrator->Initialize() == false) return false;
     cout<<"Initializing Energy calibrator"<<endl;
     if (EnergyCalibrator->Initialize() == false) return false;
-    cout<<"Initializing Pairing"<<endl;
     cout<<"Initializing Event filter"<<endl;
     if (EventFilter->Initialize() == false) return false;
+    cout<<"Initializing Pairing"<<endl;
     if (Pairing->Initialize() == false) return false;
 
     bool IsFinished = false;

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -371,7 +371,7 @@ bool TrappingCorrectionAm241::Analyze()
       ++MNumber;
 
       cout<<"Creating Event filter"<<endl;
-      //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
+      //! Only use events with 1 to 3 Strip Hits on each side
       EventFilter = new MModuleEventFilter();
       EventFilter->SetMinimumLVStrips(1);
       EventFilter->SetMaximumLVStrips(3);
@@ -422,6 +422,7 @@ bool TrappingCorrectionAm241::Analyze()
             
             Pairing->AnalyzeEvent(Event);
 
+            // Only look at events with 1 Hit since we're interested in the 60keV photopeak.
             if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true) && (Event->GetNHits()==1)) {
               
               for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
@@ -634,6 +635,7 @@ bool TrappingCorrectionAm241::Analyze()
       }
     }
 
+    // Fit and plot the detector-level histograms
     for (auto H: FullDetCTDHistograms) {
 
       int DetID = H.first;
@@ -732,6 +734,8 @@ bool TrappingCorrectionAm241::Analyze()
   map<int, TH1D*> DeltaHVHist;
   map<int, TH1D*> DeltaLVHist;
 
+  // Write the results of good fits to the output file and produce summary plots.
+  // If an individual pixel did not produce a good fit, default to the detector-level parameters.
   for (auto E: FullDetEndpoints) {
     
     int DetID = E.first;
@@ -830,6 +834,7 @@ bool TrappingCorrectionAm241::Analyze()
 
   OutputCalFile.close();
 
+  // Save and plot the summary figures.
   if (m_PixelCorrect==true) {
     for (auto H: DeltaHVMap) {
       

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -1,13 +1,13 @@
 /* 
- * TrappingCorrection.cxx
+ * TrappingCorrectionAm241.cxx
  *
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Sean Pike.
  * All rights reserved.
  *
  *
  * This code implementation is the intellectual property of
- * Andreas Zoglauer.
+ * Sean Pike.
  *
  * By copying, distributing or modifying the Program (or any work
  * based on the Program) you indicate your acceptance of this statement,
@@ -37,16 +37,10 @@ using namespace std;
 #include <TCanvas.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TFitResultPtr.h>
+#include <TFitResult.h>
 #include <TStopwatch.h>
 #include <TProfile.h>
-#include <Minuit2/FCNBase.h>
-#include <Minuit2/MnMigrad.h>
-#include <Minuit2/MnMinos.h>
-#include <Minuit2/FunctionMinimum.h>
-#include <Minuit2/MnUserParameters.h>
-#include <Minuit2/MnApplication.h>
-#include <Minuit2/MnStrategy.h>
-using namespace ROOT::Minuit2;
 
 // MEGAlib
 #include "MGlobal.h"
@@ -57,7 +51,7 @@ using namespace ROOT::Minuit2;
 #include "MStripHit.h"
 #include "MReadOutSequence.h"
 #include "MSupervisor.h"
-#include "MModuleLoaderMeasurementsROA.h"
+#include "MModuleLoaderMeasurementsHDF.h"
 #include "MModuleEnergyCalibrationUniversal.h"
 #include "MModuleEventFilter.h"
 #include "MModuleStripPairingGreedy.h"
@@ -66,83 +60,27 @@ using namespace ROOT::Minuit2;
 #include "MAssembly.h"
 
 
-int g_HistBins = 75;
-double g_MinCTD = -250;
-double g_MaxCTD = 250;
-// double g_MinRatio = 0.94;
-// double g_MaxRatio = 1.06;
-
+double g_MinCTD = -300;
+double g_MaxCTD = 300;
 
 ////////////////////////////////////////////////////////////////////////////////
-
-
-class SymmetryFCN : public FCNBase
-{
-public:
-  //! Operator which returns the symmetry of m_CTDHistogram given the parameters passed
-  double operator()(vector<double> const &v) const override;
-  double Up() const override { return 1; }
-
-  void AddCTD(double CTD){ m_CTD.push_back(CTD); }
-  void AddHVEnergy(double HVEnergy, double HVEnergyResolution){ m_HVEnergy.push_back(HVEnergy); m_HVEnergyResolution.push_back(HVEnergyResolution); }
-  void AddLVEnergy(double LVEnergy, double LVEnergyResolution){ m_LVEnergy.push_back(LVEnergy); m_LVEnergyResolution.push_back(LVEnergyResolution); }
-
-  vector<double> GetCTD(){ return m_CTD; }
-  vector<double> GetHVEnergy(){ return m_HVEnergy; }
-  vector<double> GetLVEnergy(){ return m_LVEnergy; }
-  vector<double> GetHVEnergyResolution(){ return m_HVEnergyResolution; }
-  vector<double> GetLVEnergyResolution(){ return m_LVEnergyResolution; }
-
-  void SetCTD(vector<double> CTD){ m_CTD = CTD; }
-  void SetHVEnergy(vector<double> HVEnergy, vector<double> HVEnergyResolution){ m_HVEnergy = HVEnergy; m_HVEnergyResolution = HVEnergyResolution; }
-  void SetLVEnergy(vector<double> LVEnergy, vector<double> LVEnergyResolution){ m_LVEnergy = LVEnergy; m_LVEnergyResolution = LVEnergyResolution; }
-
-  //! The measured CTD and HV/LV energies
-  vector<double> m_CTD;
-  vector<double> m_HVEnergy;
-  vector<double> m_LVEnergy;
-  vector<double> m_HVEnergyResolution;
-  vector<double> m_LVEnergyResolution;
-
-};
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-
-class ChiSquaredFCN : public SymmetryFCN
-{
-public:
-  //! Operator which returns the symmetry of m_CTDHistogram given the parameters passed
-  double operator()(vector<double> const &v) const override;
-  double Up() const override { return 1; }
-
-};
-
-
-////////////////////////////////////////////////////////////////////////////////
-
 
 
 //! A standalone program based on MEGAlib and ROOT
-class TrappingCorrection
+class TrappingCorrectionAm241
 {
 public:
   //! Default constructor
-  TrappingCorrection();
+  TrappingCorrectionAm241();
   //! Default destructor
-  ~TrappingCorrection();
+  ~TrappingCorrectionAm241();
   
   //! Parse the command line
   bool ParseCommandLine(int argc, char** argv);
-  //! Analyze what eveer needs to be analyzed...
+  //! Analyze what ever needs to be analyzed...
   bool Analyze();
-  //!load cross talk correction
-  vector<vector<vector<float> > > LoadCrossTalk();
   //! Interrupt the analysis
   void Interrupt() { m_Interrupt = true; }
-
-  void dummy_func() { return; }
 
   MStripHit* GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction);
 
@@ -150,19 +88,18 @@ private:
   //! True, if the analysis needs to be interrupted
   bool m_Interrupt;
   //! The input file name
-  MString m_FileName;
+  MString m_HVFileName;
+  MString m_LVFileName;
   MString m_EcalFile;
-  MString m_TACFile;
+  MString m_TACCalFile;
+  MString m_TACCutFile;
+  MString m_StripMapFile;
   //! output file names
   MString m_OutFile;
-  //! energy E0
-  // float m_E0;
-  //! option to correct charge loss or not
-  // bool m_CorrectCL;
   //! option to do a pixel-by-pixel calibration (instead of detector-by-detector)
   bool m_PixelCorrect;
   bool m_GreedyPairing;
-  bool m_CardCageOverride;
+  bool m_ExcludeNN;
 
   double m_MinEnergy;
   double m_MaxEnergy;
@@ -172,86 +109,8 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 
-double SymmetryFCN::operator()(vector<double> const &v) const
-{
-  double HVSlope = v[0];
-  double HVIntercept = v[1];
-  double LVSlope = v[2];
-  double LVIntercept = v[3];
-
-  char name[64]; sprintf(name,"name");
-  int HistBins = g_HistBins;
-  if (HistBins%2 == 0) {
-    HistBins += 1;
-  }
-  TH2D CorrectedHistogram(name, name, HistBins, g_MinCTD, g_MaxCTD, HistBins, g_MinRatio, g_MaxRatio);
-
-  for (unsigned int i = 0; i < m_CTD.size(); ++i) {
-    double CTDHVShift = m_CTD[i] + g_MaxCTD;
-    double CTDLVShift = m_CTD[i] + g_MinCTD;
-    // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
-    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
-    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
-    CorrectedHistogram.Fill(m_CTD[i], CorrectedHVEnergy/CorrectedLVEnergy);
-  }
-
-  vector<vector<double>> BinValues;
-  vector<vector<double>> ReflectedBinValues;
-  double Asymmetry = 0;
-
-  for (unsigned int y = 0; y < CorrectedHistogram.GetNbinsY(); ++y) {
-    
-    vector<double> XValues;
-
-    for (unsigned int x = 0; x < CorrectedHistogram.GetNbinsX(); ++x) {
-      XValues.push_back(CorrectedHistogram.GetBinContent(x,y));
-    }
-
-    // BinValues.push_back(XValues);
-    vector<double> ReflectedXValues = XValues;
-    reverse(ReflectedXValues.begin(), ReflectedXValues.end());
-
-    for (unsigned int x = 0; x < XValues.size(); ++x) {
-      Asymmetry += pow(XValues[x] - ReflectedXValues[x], 2)/(XValues[x] + ReflectedXValues[x]);
-    }
-  }
-
-  return Asymmetry;
-
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-
-double ChiSquaredFCN::operator()(vector<double> const &v) const
-{
-  double HVSlope = v[0];
-  double HVIntercept = v[1];
-  double LVSlope = v[2];
-  double LVIntercept = v[3];
-
-  double ChiSquare = 0;
-
-  for (unsigned int i = 0; i < m_CTD.size(); ++i) {
-    double CTDHVShift = m_CTD[i] + g_MaxCTD;
-    double CTDLVShift = m_CTD[i] + g_MinCTD;
-    // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
-    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
-    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
-
-    ChiSquare += pow(CorrectedHVEnergy - CorrectedLVEnergy, 2)/(m_HVEnergyResolution[i] + m_LVEnergyResolution[i]);
-  }
-
-  // ChiSquare /= m_CTD.size();
-
-  return ChiSquare;
-
-}
-
-
 //! Default constructor
-TrappingCorrection::TrappingCorrection() : m_Interrupt(false)
+TrappingCorrectionAm241::TrappingCorrectionAm241() : m_Interrupt(false)
 {
   gStyle->SetPalette(1, 0);
 }
@@ -261,7 +120,7 @@ TrappingCorrection::TrappingCorrection() : m_Interrupt(false)
 
 
 //! Default destructor
-TrappingCorrection::~TrappingCorrection()
+TrappingCorrectionAm241::~TrappingCorrectionAm241()
 {
   // Intentionally left blank
 }
@@ -271,20 +130,24 @@ TrappingCorrection::~TrappingCorrection()
 
 
 //! Parse the command line
-bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
+bool TrappingCorrectionAm241::ParseCommandLine(int argc, char** argv)
 {
   ostringstream Usage;
   Usage<<endl;
-  Usage<<"  Usage: TrappingCorrection <options>"<<endl;
+  Usage<<"  Usage: TrappingCorrectionAm241 <options>"<<endl;
   Usage<<"    General options:"<<endl;
-  Usage<<"         -h:   HV-illumination input file name (.roa)"<<endl;
-  Usage<<"         -l:   LV-illumination input file name (.roa)"<<endl;
+  Usage<<"         --HVfile:   HV illumination input file name (.hdf5 or .txt with list of hdf5s)"<<endl;
+  Usage<<"         --LVfile:   LV illumination input file name (.hdf5 or .txt with list of hdf5s)"<<endl;
+  Usage<<"         --emin:   minimum Event energy (default 40 keV)"<<endl;
+  Usage<<"         --emax:   maximum Event energy (default 70 kev)"<<endl;
+  Usage<<"         -e:   energy calibration file (.ecal)"<<endl;
   Usage<<"         --tcal:   TAC calibration file"<<endl;
   Usage<<"         --tcut:   TAC cut file"<<endl;
   Usage<<"         -p:   do pixel-by-pixel correction"<<endl;
+  Usage<<"         -m:   strip map file name (.map)"<<endl;
   Usage<<"         -g:   greedy strip pairing (default is chi-square)"<<endl;
-  // Usage<<"         -c:   Card cage data (i.e. no TAC calibration required)"<<endl;
-  Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS"<<endl;
+  Usage<<"         -n:   exclude nearest neighbors"<<endl;
+  Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS)"<<endl;
   Usage<<"         -h:   print this help"<<endl;
   Usage<<endl;
 
@@ -301,8 +164,8 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
   m_PixelCorrect = false;
   m_GreedyPairing = false;
-  m_MinEnergy = 0;
-  m_MaxEnergy = 5000;
+  m_MinEnergy = 40;
+  m_MaxEnergy = 70;
   
   time_t rawtime;
   tm* timeinfo;
@@ -320,31 +183,23 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
     // First check if each option has sufficient arguments:
     // Single argument
-    if (Option == "-i" || Option == "-e" || Option == "-t" || Option == "-o" || Option == "--emin" || Option == "--emax") {
-      if (!((argc > i+1) && 
-            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0))){
+    if ((Option == "--HVfile") || (Option == "--LVfile") || (Option == "-o") || (Option == "--emin") || (Option == "--emax") || (Option == "--tcal") || (Option == "--tcut") || (Option == "-m")) {
+      if (!((argc > i+1) && (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0))){
         cout<<"Error: Option "<<argv[i][1]<<" needs a second argument!"<<endl;
         cout<<Usage.str()<<endl;
         return false;
       }
     } 
-    // Multiple arguments template
-    /*
-    else if (Option == "-??") {
-      if (!((argc > i+2) && 
-            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0) && 
-            (argv[i+2][0] != '-' || isalpha(argv[i+2][1]) == 0))){
-        cout<<"Error: Option "<<argv[i][1]<<" needs two arguments!"<<endl;
-        cout<<Usage.str()<<endl;
-        return false;
-      }
-    }
-    */
 
     // Then fulfill the options:
-    if (Option == "-i") {
-      m_FileName = argv[++i];
-      cout<<"Accepting file name: "<<m_FileName<<endl;
+    if (Option == "--HVfile") {
+      m_HVFileName = argv[++i];
+      cout<<"Accepting file name: "<<m_HVFileName<<endl;
+    } 
+
+    if (Option == "--LVfile") {
+      m_LVFileName = argv[++i];
+      cout<<"Accepting file name: "<<m_LVFileName<<endl;
     } 
 
     if (Option == "-e") {
@@ -360,18 +215,24 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
       m_MaxEnergy = stod(argv[++i]);
     } 
 
-    if (Option == "-t") {
-      m_TACFile = argv[++i];
-      cout<<"Accepting file name: "<<m_TACFile<<endl;
+    if (Option == "--tcal") {
+      m_TACCalFile = argv[++i];
+      cout<<"Accepting file name: "<<m_TACCalFile<<endl;
+    } 
+
+    if (Option == "--tcut") {
+      m_TACCutFile = argv[++i];
+      cout<<"Accepting file name: "<<m_TACCutFile<<endl;
+    }
+
+    if (Option == "-m"){
+      m_StripMapFile = argv[++i];
+      cout<<"Accepting file name: "<<m_StripMapFile<<endl;
     } 
 
     if (Option == "-o"){
       m_OutFile = argv[++i];
       cout<<"Accepting file name: "<<m_OutFile<<endl;
-    }
-
-    if (Option == "-c"){
-      m_CardCageOverride = true;
     }
 
     if (Option == "-p"){
@@ -380,6 +241,10 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
     if (Option == "-g"){
       m_GreedyPairing = true;
+    }
+
+    if (Option == "-n"){
+      m_ExcludeNN = true;
     }
 
   }
@@ -392,283 +257,268 @@ bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
 
 
 //! Do whatever analysis is necessary
-bool TrappingCorrection::Analyze()
+bool TrappingCorrectionAm241::Analyze()
 {
-
-/*  TH2D* h2 = new TH2D("fracmap","fracmap",356*2,-356,356,35,356-30,356+5);
-//  for (int i=-662; i<662; i++){
-//    for (int j=662-30; j<662+5; j++){
-  for (int i=0; i<356*2; i++){
-    for (int j=0; j<35; j++){
-      float c = ((float)i-356)/((float)j+356-30);
-      cout<<c<<endl;
-      h2->SetBinContent(i,j,c);
-    }
-  }
-  TCanvas *ctemp = new TCanvas();
-  h2->Draw("colz");
-  ctemp->Print("frac_map.pdf");
-*/  
   //time code just to see
   TStopwatch watch;
   watch.Start();
 
   if (m_Interrupt == true) return false;
 
-  MSupervisor* S = MSupervisor::GetSupervisor();
-  
-	MModuleLoaderMeasurementsROA* Loader;
-	MModuleTACcut* TACCalibrator;
-	MModuleEnergyCalibrationUniversal* EnergyCalibrator;
-	MModuleEventFilter* EventFilter;
+  // [HV Illum. CTD, HV Illum. Energy, LV Illum. CTD, LV Illum. Energy]
+  vector<double> HVEndpoints;
+  vector<double> LVEndpoints;
 
-  unsigned int MNumber = 0;
-  cout<<"Creating ROA loader"<<endl;
-  Loader = new MModuleLoaderMeasurementsROA();
-  Loader->SetFileName(m_FileName);
-  S->SetModule(Loader, MNumber);
-  ++MNumber;
+  vector<MString> FileNames;
+  FileNames.push_back(m_HVFileName);
+  FileNames.push_back(m_LVFileName);
 
-  if (m_CardCageOverride==false) {
-	  cout<<"Creating TAC calibrator"<<endl;
-	  TACCalibrator = new MModuleTACcut();
-	  TACCalibrator->SetTACCalFileName(m_TACFile);
-	  S->SetModule(TACCalibrator, MNumber);
-	  ++MNumber;
-  }
- 
-  cout<<"Creating energy calibrator"<<endl;
-  EnergyCalibrator = new MModuleEnergyCalibrationUniversal();
-  EnergyCalibrator->SetFileName(m_EcalFile);
-  EnergyCalibrator->EnablePreampTempCorrection(false);
-  S->SetModule(EnergyCalibrator, MNumber);
-  ++MNumber;
+  vector<MString> IllumSide;
+  IllumSide.push_back(MString("HV"));
+  IllumSide.push_back(MString("LV"));
 
-  cout<<"Creating Event filter"<<endl;
-  //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
-  EventFilter = new MModuleEventFilter();
-  EventFilter->SetMinimumLVStrips(1);
-  EventFilter->SetMaximumLVStrips(1);
-  EventFilter->SetMinimumHVStrips(1);
-  EventFilter->SetMaximumHVStrips(1);
-  EventFilter->SetMinimumTotalEnergy(m_MinEnergy);
-  EventFilter->SetMaximumTotalEnergy(m_MaxEnergy);
-  S->SetModule(EventFilter, MNumber);
-  ++MNumber;
-  
-  cout<<"Creating strip pairing"<<endl;
-  MModule* Pairing;
-  if (m_GreedyPairing == true){
-    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
-    Pairing = new MModuleStripPairingGreedy();
-  }
-  else {
-    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
-    Pairing = new MModuleStripPairingChiSquare();
-  }
-  S->SetModule(Pairing, MNumber);
+  for (unsigned int s=0; s<2; ++s) {
 
-  cout<<"Initializing Loader"<<endl;
-  if (Loader->Initialize() == false) return false;
-  if (m_CardCageOverride==false) {
-  	cout<<"Initializing TAC calibrator"<<endl;
-  	if (TACCalibrator->Initialize() == false) return false;
-  }
-  cout<<"Initializing Energy calibrator"<<endl;
-  if (EnergyCalibrator->Initialize() == false) return false;
-  cout<<"Initializing Event filter"<<endl;
-  if (EventFilter->Initialize() == false) return false;
-  cout<<"Initializing Pairing"<<endl;
-  if (Pairing->Initialize() == false) return false;
+    MString InputFile = FileNames[s];
+    vector<MString> HDFNames;
 
-  map<int, TH2D*> Histograms;
-  map<int, SymmetryFCN*> FCNs;
-
-  bool IsFinished = false;
-  MReadOutAssembly* Event = new MReadOutAssembly();
-
-  cout<<"Analyzing..."<<endl;
-  while (IsFinished == false && m_Interrupt == false) {
-    Event->Clear();
-
-    if (Loader->IsReady() ){
-      Loader->AnalyzeEvent(Event);
-
-      if (m_CardCageOverride==false) {
-      	TACCalibrator->AnalyzeEvent(Event);
-      }
-
-      EnergyCalibrator->AnalyzeEvent(Event);
-      bool Unfiltered = EventFilter->AnalyzeEvent(Event);
-      Pairing->AnalyzeEvent(Event);
-
-      if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true)) {
-        for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
-          double HVEnergy = 0.0;
-          double LVEnergy = 0.0;
-          double HVEnergyResolution = 0.0;
-          double LVEnergyResolution = 0.0;
-          vector<MStripHit*> HVStrips;
-          vector<MStripHit*> LVStrips;
-
-          MHit* H = Event->GetHit(h);
-          
-          int DetID = H->GetStripHit(0)->GetDetectorID();
-          TH2D* Hist = Histograms[DetID];
-          SymmetryFCN* FCN = FCNs[DetID]; 
-          
-          if (Hist == nullptr) {
-            char name[64]; sprintf(name,"Detector %d (Uncorrected)",DetID);
-            Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
-            Hist->SetXTitle("CTD (ns)");
-            Hist->SetYTitle("HV/LV Energy Ratio");
-            Histograms[DetID] = Hist;
-          }
-
-          if (FCN == nullptr) {
-            FCN = new SymmetryFCN();
-            FCNs[DetID] = FCN;
-          }
-
-          for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
-            MStripHit* SH = H->GetStripHit(sh);
-
-            if (SH->IsLowVoltageStrip()==true) {
-              LVEnergy += SH->GetEnergy();
-              LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
-              LVStrips.push_back(SH);
-            } else {
-              HVEnergy += SH->GetEnergy();
-              HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
-              HVStrips.push_back(SH);
-            }
-          }
-
-          double HVEnergyFraction = 0;
-          double LVEnergyFraction = 0;
-          MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
-          MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
-          double EnergyFraction = HVEnergy/LVEnergy;
-          double CTD = LVSH->GetTiming() - HVSH->GetTiming();
-          if (m_CardCageOverride == true) {
-            CTD *= -1;
-          }
-          Hist->Fill(CTD, EnergyFraction);
-          FCN->AddCTD(CTD);
-          FCN->AddHVEnergy(HVEnergy, HVEnergyResolution);
-          FCN->AddLVEnergy(LVEnergy, LVEnergyResolution);
+    if ((InputFile.GetSubString(InputFile.Length() - 4)) == "hdf5") {
+      HDFNames.push_back(InputFile);
+    } else if ((InputFile.GetSubString(InputFile.Length() - 3)) == "txt") {
+      MFile F;
+      if (F.Open(InputFile)==false) {
+        cout<<"Error: Failed to open input file."<<endl;
+      } else {
+        MString Line;
+        while (F.ReadLine(Line)) {
+          HDFNames.push_back(Line.Trim());
         }
       }
     }
-    IsFinished = Loader->IsFinished();
+
+    map<int, TH1D*> CTDHistograms;
+    map<int, TH1D*> HVEnergyHistograms;
+    map<int, TH1D*> LVEnergyHistograms;
+
+    for (unsigned int f = 0; f<HDFNames.size(); ++f) {
+
+      MString File = HDFNames[f];
+      cout<<"Beginning analysis of file "<<File<<endl;
+
+      MSupervisor* S = MSupervisor::GetSupervisor();
+      
+    	MModuleLoaderMeasurementsHDF* Loader;
+    	MModuleTACcut* TACCalibrator;
+    	MModuleEnergyCalibrationUniversal* EnergyCalibrator;
+    	MModuleEventFilter* EventFilter;
+
+      unsigned int MNumber = 0;
+      cout<<"Creating HDF5 loader"<<endl;
+      Loader = new MModuleLoaderMeasurementsHDF();
+      Loader->SetFileNameStripMap(m_StripMapFile);
+      Loader->SetFileName(File);
+      Loader->SetLoadContinuationFiles(true);
+      S->SetModule(Loader, MNumber);
+      ++MNumber;
+
+      cout<<"Creating TAC calibrator"<<endl;
+      TACCalibrator = new MModuleTACcut();
+      TACCalibrator->SetTACCalFileName(m_TACCalFile);
+      TACCalibrator->SetTACCutFileName(m_TACCutFile);
+      S->SetModule(TACCalibrator, MNumber);
+      ++MNumber;
+     
+      cout<<"Creating energy calibrator"<<endl;
+      EnergyCalibrator = new MModuleEnergyCalibrationUniversal();
+      EnergyCalibrator->SetFileName(m_EcalFile);
+      EnergyCalibrator->EnablePreampTempCorrection(false);
+      S->SetModule(EnergyCalibrator, MNumber);
+      ++MNumber;
+
+      cout<<"Creating Event filter"<<endl;
+      //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
+      EventFilter = new MModuleEventFilter();
+      EventFilter->SetMinimumLVStrips(1);
+      EventFilter->SetMaximumLVStrips(3);
+      EventFilter->SetMinimumHVStrips(1);
+      EventFilter->SetMaximumHVStrips(3);
+      EventFilter->SetMinimumHits(0);
+      EventFilter->SetMaximumHits(100);
+      EventFilter->SetMinimumTotalEnergy(m_MinEnergy);
+      EventFilter->SetMaximumTotalEnergy(m_MaxEnergy*2);
+      S->SetModule(EventFilter, MNumber);
+      ++MNumber;
+      
+      cout<<"Creating strip pairing"<<endl;
+      MModule* Pairing;
+      if (m_GreedyPairing == true){
+        Pairing = new MModuleStripPairingGreedy();
+      }
+      else {
+        Pairing = new MModuleStripPairingChiSquare();
+      }
+      S->SetModule(Pairing, MNumber);
+
+      cout<<"Initializing Loader"<<endl;
+      if (Loader->Initialize() == false) return false;
+      cout<<"Initializing TAC calibrator"<<endl;
+      if (TACCalibrator->Initialize() == false) return false;
+      cout<<"Initializing Energy calibrator"<<endl;
+      if (EnergyCalibrator->Initialize() == false) return false;
+      cout<<"Initializing Event filter"<<endl;
+      if (EventFilter->Initialize() == false) return false;
+      cout<<"Initializing Pairing"<<endl;
+      if (Pairing->Initialize() == false) return false;
+
+      bool IsFinished = false;
+      MReadOutAssembly* Event = new MReadOutAssembly();
+
+      cout<<"Analyzing..."<<endl;
+      while ((IsFinished == false) && (m_Interrupt == false)) {
+        Event->Clear();
+
+        if (Loader->IsReady()) {
+
+          Loader->AnalyzeEvent(Event);
+          TACCalibrator->AnalyzeEvent(Event);
+          EnergyCalibrator->AnalyzeEvent(Event);
+          bool Unfiltered = EventFilter->AnalyzeEvent(Event);
+
+          if (Unfiltered == true) {
+            
+            Pairing->AnalyzeEvent(Event);
+
+            if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true) && (Event->GetNHits()==1)) {
+              for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
+                double HVEnergy = 0.0;
+                double LVEnergy = 0.0;
+                double HVEnergyResolution = 0.0;
+                double LVEnergyResolution = 0.0;
+                vector<MStripHit*> HVStrips;
+                vector<MStripHit*> LVStrips;
+
+                MHit* H = Event->GetHit(h);
+                
+                int DetID = H->GetStripHit(0)->GetDetectorID();
+                TH1D* CTDHist = CTDHistograms[DetID];
+                TH1D* HVHist = HVEnergyHistograms[DetID];
+                TH1D* LVHist = LVEnergyHistograms[DetID];
+                
+                if (CTDHist == nullptr) {
+                  char name[64]; sprintf(name,"CTD: Detector %d %s Illumination",DetID,IllumSide[s].Data());
+                  CTDHist = new TH1D(name, name, (g_MaxCTD - g_MinCTD)/2, g_MinCTD, g_MaxCTD);
+                  CTDHist->SetXTitle("CTD (ns)");
+                  CTDHist->SetYTitle("Hits");
+                  CTDHistograms[DetID] = CTDHist;
+                }
+
+                if (HVHist == nullptr) {
+                  char name[64]; sprintf(name,"HV energy: Detector %d %s Illumination",DetID,IllumSide[s].Data());
+                  HVHist = new TH1D(name, name, (m_MaxEnergy - m_MinEnergy)*2, m_MinEnergy, m_MaxEnergy);
+                  HVHist->SetXTitle("HV Energy (keV)");
+                  HVHist->SetYTitle("Hits");
+                  HVEnergyHistograms[DetID] = HVHist;
+                }
+
+                if (LVHist == nullptr) {
+                  char name[64]; sprintf(name,"LV energy: Detector %d %s Illumination",DetID,IllumSide[s].Data());
+                  LVHist = new TH1D(name, name, (m_MaxEnergy - m_MinEnergy)*2, m_MinEnergy, m_MaxEnergy);
+                  LVHist->SetXTitle("LV Energy (keV)");
+                  LVHist->SetYTitle("Hits");
+                  LVEnergyHistograms[DetID] = LVHist;
+                }
+
+                for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
+                  MStripHit* SH = H->GetStripHit(sh);
+
+                  if ((m_ExcludeNN==false) || ((m_ExcludeNN==true) && (SH->IsNearestNeighbor()==false))) {
+                    if (SH->IsLowVoltageStrip()==true) {
+                      LVEnergy += SH->GetEnergy();
+                      LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+                      LVStrips.push_back(SH);
+                    } else {
+                      HVEnergy += SH->GetEnergy();
+                      HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+                      HVStrips.push_back(SH);
+                    }
+                  }
+                }
+
+                if ((HVStrips.size()>0) && (LVStrips.size()>0)) {
+                  double HVEnergyFraction = 0;
+                  double LVEnergyFraction = 0;
+                  MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
+                  MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
+                  if ((LVSH->HasCalibratedTiming()==true) && (HVSH->HasCalibratedTiming()==true)) {
+                    double CTD = LVSH->GetTiming() - HVSH->GetTiming();
+                    CTDHist->Fill(CTD);
+                    HVHist->Fill(HVEnergy);
+                    LVHist->Fill(LVEnergy);
+                  }
+                }
+              }
+            }
+          }
+        }
+        IsFinished = Loader->IsFinished();
+      }
+    }
+
+    for (auto H: CTDHistograms) {
+      
+      int DetID = H.first;
+      cout<<"Fitting detector with ID "<<DetID<<endl;
+      
+      TFitResultPtr CTDFit = H.second->Fit("gaus", "S");
+      TFitResultPtr HVFit = HVEnergyHistograms[DetID]->Fit("gaus", "S");
+      TFitResultPtr LVFit = LVEnergyHistograms[DetID]->Fit("gaus", "S");
+
+      cout<<"Results of CTD fit:"<<endl;
+      CTDFit->Print();
+      cout<<"Results of HV energy fit:"<<endl;
+      HVFit->Print();
+      cout<<"Results of LV energy fit:"<<endl;
+      LVFit->Print();
+        
+      TFile CTDFile(m_OutFile+MString("_Det")+DetID+MString("_CTDHist_") + IllumSide[s]+ MString("Illum.root"),"recreate");
+
+      TCanvas* CTDCanvas = new TCanvas();
+      CTDCanvas->SetLogz();
+      CTDCanvas->cd();
+      H.second->Draw("colz");
+
+      H.second->Write();
+      CTDFile.Close();
+
+
+      TFile HVHistFile(m_OutFile+MString("_Det")+DetID+MString("_HVEnergyHist_") + IllumSide[s]+ MString("Illum.root"),"recreate");
+
+      TCanvas* HVHistCanvas = new TCanvas();
+      HVHistCanvas->SetLogz();
+      HVHistCanvas->cd();
+      HVEnergyHistograms[DetID]->Draw("colz");
+
+      HVEnergyHistograms[DetID]->Write();
+      HVHistFile.Close();
+
+      TFile LVHistFile(m_OutFile+MString("_Det")+DetID+MString("_LVEnergyHist_") + IllumSide[s]+ MString("Illum.root"),"recreate");
+
+      TCanvas* LVHistCanvas = new TCanvas();
+      LVHistCanvas->SetLogz();
+      LVHistCanvas->cd();
+      LVEnergyHistograms[DetID]->Draw("colz");
+
+      LVEnergyHistograms[DetID]->Write();
+      LVHistFile.Close();
+      
+    }
   }
 
   //setup output file
-  ofstream OutputCalFile;
-  OutputCalFile.open(m_OutFile+MString("_parameters.txt"));
-  OutputCalFile<<"Det"<<'\t'<<"HV Slope"<<'\t'<<"HV Intercept"<<'\t'<<"LV Slope"<<'\t'<<"LV Intercept"<<endl<<endl;
-
-  for (auto H: Histograms) {
-    
-    int DetID = H.first;
-    TFile f(m_OutFile+MString("_Det")+DetID+MString("_Hist_Uncorr.root"),"recreate");
-
-    TCanvas* C = new TCanvas();
-    C->SetLogz();
-    C->cd();
-    H.second->Draw("colz");
-
-    H.second->Write();
-    f.Close();
-
-  }
-
-  for (auto F: FCNs) {
-
-    int DetID = F.first;
-    MnUserParameters* InitialStateSym = new MnUserParameters();
-    InitialStateSym->Add("HVSlope", 1e-3, 1e-4, 0, 3e-1);
-    InitialStateSym->Add("HVIntercept", 0, 0.01, -2, 2);
-    InitialStateSym->Add("LVSlope", 0, 1e-4, -3e-2, 0);
-    InitialStateSym->Add("LVIntercept", 0, 0.01, -2, 2);
-
-    InitialStateSym->Fix("LVSlope");
-    InitialStateSym->Fix("LVIntercept");
-    InitialStateSym->Fix("HVIntercept");
-
-
-    MnMigrad migradSym(*F.second, *InitialStateSym);
-     // Minimize
-    FunctionMinimum MinimumSym = migradSym();
-
-    MnUserParameters ParametersSym = MinimumSym.UserParameters();
-    // double HVSlope = ParametersSym.Value("HVSlope");
-    // double HVIntercept = ParametersSym.Value("HVIntercept");
-    // double LVSlope = ParametersSym.Value("LVSlope");
-    // double LVIntercept = ParametersSym.Value("LVIntercept");
-
-    // output
-    cout<<MinimumSym<<endl;
-
-    MnUserParameters* InitialStateChi = new MnUserParameters();
-    InitialStateChi->Add("HVSlope", ParametersSym.Value("HVSlope"), ParametersSym.Error("HVSlope"));
-    InitialStateChi->Add("HVIntercept", 0, 0.01, -2, 2);
-    InitialStateChi->Add("LVSlope", 0, 1e-4, -3e-2, 0);
-    InitialStateChi->Add("LVIntercept", 0, 0.01, -2, 2);
-
-    InitialStateChi->Fix("LVSlope");
-    InitialStateChi->Fix("LVIntercept");
-    InitialStateChi->Fix("HVSlope");
-
-
-    ChiSquaredFCN* ChiSquaredF = new ChiSquaredFCN();
-    ChiSquaredF->SetCTD(F.second->GetCTD());
-    ChiSquaredF->SetHVEnergy(F.second->GetHVEnergy(), F.second->GetHVEnergyResolution());
-    ChiSquaredF->SetLVEnergy(F.second->GetLVEnergy(), F.second->GetLVEnergyResolution());
-    MnMigrad migradChi(*ChiSquaredF, *InitialStateChi);
-     // Minimize
-    FunctionMinimum MinimumChi = migradChi();
-
-    MnUserParameters ParametersChi = MinimumChi.UserParameters();
-    double HVSlope = ParametersChi.Value("HVSlope");
-    double HVIntercept = ParametersChi.Value("HVIntercept");
-    double LVSlope = ParametersChi.Value("LVSlope");
-    double LVIntercept = ParametersChi.Value("LVIntercept");
-    // output
-    cout<<MinimumChi<<endl;
-
-    char name[64]; sprintf(name,"Detector %d (Corrected)",DetID);
-    TH2D* Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
-    Hist->SetXTitle("CTD (ns)");
-    Hist->SetYTitle("HV/LV Energy Ratio");
-
-    vector<double> CTDList = F.second->GetCTD();
-    vector<double> HVEnergyList = F.second->GetHVEnergy();
-    vector<double> LVEnergyList = F.second->GetLVEnergy();
-    for (unsigned int i=0; i<CTDList.size(); ++i) {
-      
-      double CTDHVShift = CTDList[i] + g_MaxCTD;
-      double CTDLVShift = CTDList[i] + g_MinCTD;
-      // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
-      double CorrectedHVEnergy = HVEnergyList[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
-      double CorrectedLVEnergy = LVEnergyList[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
-      
-      Hist->Fill(CTDList[i], CorrectedHVEnergy/CorrectedLVEnergy);
-    }
-
-    TCanvas* C = new TCanvas();
-    C->SetLogz();
-    C->cd();
-    Hist->Draw("colz");
-
-    TFile f(m_OutFile+MString("_Det")+DetID+MString("_Hist_Corr.root"),"recreate");
-    Hist->Write();
-    f.Close();
-
-    OutputCalFile<<to_string(DetID)<<'\t'<<to_string(HVSlope)<<'\t'<<to_string(HVIntercept)<<'\t'<<to_string(LVSlope)<<'\t'<<to_string(LVIntercept)<<endl<<endl;
-
-  }
-  OutputCalFile.close();
+  // ofstream OutputCalFile;
+  // OutputCalFile.open(m_OutFile+MString("_parameters.txt"));
+  // OutputCalFile<<"Det"<<'\t'<<"HV Slope"<<'\t'<<"HV Intercept"<<'\t'<<"LV Slope"<<'\t'<<"LV Intercept"<<endl<<endl;
+  // OutputCalFile.close();
 
   watch.Stop();
   cout<<"total time (s): "<<watch.CpuTime()<<endl;
@@ -680,10 +530,10 @@ bool TrappingCorrection::Analyze()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-TrappingCorrection* g_Prg = 0;
+TrappingCorrectionAm241* g_Prg = 0;
 int g_NInterruptCatches = 1;
 
-MStripHit* TrappingCorrection::GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction)
+MStripHit* TrappingCorrectionAm241::GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction)
 {
   double MaxEnergy = -numeric_limits<double>::max(); // AZ: When both energies are zero (which shouldn't happen) we still pick one
   double TotalEnergy = 0.0;
@@ -737,7 +587,7 @@ int main(int argc, char** argv)
 
   TApplication TrappingCorrectionApp("TrappingCorrectionApp", 0, 0);
 
-  g_Prg = new TrappingCorrection();
+  g_Prg = new TrappingCorrectionAm241();
 
   if (g_Prg->ParseCommandLine(argc, argv) == false) {
     cerr<<"Error during parsing of command line!"<<endl;

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -66,10 +66,12 @@ using namespace std;
 
 double g_MinCTD = -400;
 double g_MaxCTD = 400;
-int g_MinCounts = 1000;
+int g_MinCounts = 250;
 
 int g_HVStrips = 64;
 int g_LVStrips = 64;
+
+double g_AmPhotopeak = 59.54;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -332,6 +334,7 @@ bool TrappingCorrectionAm241::Analyze()
       }
     }
 
+    // Analyze all the data and fill in the histograms
     for (unsigned int f = 0; f<HDFNames.size(); ++f) {
 
       MString File = HDFNames[f];
@@ -516,6 +519,8 @@ bool TrappingCorrectionAm241::Analyze()
     map<int, TH1D*> FullDetHVEnergyHistograms;
     map<int, TH1D*> FullDetLVEnergyHistograms;
     
+    // Add up the pixel-level histograms to get full detector histograms
+    // Fit to the pixel-level histograms and record the results
     for (auto H: CTDHistograms) {
       
       int PixelID = H.first;

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -604,7 +604,7 @@ bool TrappingCorrectionAm241::Analyze()
           cout.rdbuf(coutbuf);
           LVFitFile.close();
 
-          if ((!(CTDFit->IsEmpty())) && (!(HVFit->IsEmpty())) && (!(LVFit->IsEmpty()))) {
+          if ((!(CTDFit->IsEmpty())) && (!(HVFit->IsEmpty())) && (!(LVFit->IsEmpty())) && ((CTDFit->Chi2()/CTDFit->Ndf()) < 5) && ((HVFit->Chi2()/HVFit->Ndf()) < 5) && ((LVFit->Chi2()/LVFit->Ndf()) < 5)) {
             Endpoints[PixelID][s].push_back(CTDFit->Parameter(2));
             Endpoints[PixelID][s].push_back(HVFit->Parameter(1));
             Endpoints[PixelID][s].push_back(LVFit->Parameter(1));

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -755,7 +755,9 @@ TF1* TrappingCorrectionAm241::GeneratePhotopeakFunction()
   PhotopeakFunction->SetParameter("Sigma", 2);
   PhotopeakFunction->SetParameter("Shelf norm", 0.05);
 
+  PhotopeakFunction->SetParLimits(0, 10, 1e8);
   PhotopeakFunction->SetParLimits(1, 55, 65);
+  PhotopeakFunction->SetParLimits(2, 0.1, 10);
   PhotopeakFunction->SetParLimits(3, 0, 0.1);
 
   return PhotopeakFunction;
@@ -781,7 +783,11 @@ TF1* TrappingCorrectionAm241::GenerateCTDFunction(double CTDFitMin, double CTDFi
   CTDFunction->SetParameter("Sigma", 16);
   CTDFunction->SetParameter("Mu", CTDGuess);
   CTDFunction->FixParameter(4, FlipSwitch);
+
+  CTDFunction->SetParLimits(0, 0, 1e8);
+  CTDFunction->SetParLimits(1, 0, 1);
   CTDFunction->SetParLimits(2, CTDFitMin, CTDFitMax);
+  CTDFunction->SetParLimits(3, 0, 100);
 
   return CTDFunction;
 }

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -1,0 +1,759 @@
+/* 
+ * TrappingCorrection.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+// Standard
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <csignal>
+#include <cstdlib>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <ctime>
+#include <cstdio>
+using namespace std;
+
+// ROOT
+#include <TROOT.h>
+#include <TEnv.h>
+#include <TSystem.h>
+#include <TApplication.h>
+#include <TStyle.h>
+#include <TCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+#include <TStopwatch.h>
+#include <TProfile.h>
+#include <Minuit2/FCNBase.h>
+#include <Minuit2/MnMigrad.h>
+#include <Minuit2/MnMinos.h>
+#include <Minuit2/FunctionMinimum.h>
+#include <Minuit2/MnUserParameters.h>
+#include <Minuit2/MnApplication.h>
+#include <Minuit2/MnStrategy.h>
+using namespace ROOT::Minuit2;
+
+// MEGAlib
+#include "MGlobal.h"
+#include "MFile.h"
+#include "MReadOutElementDoubleStrip.h"
+#include "MFileReadOuts.h"
+#include "MReadOutAssembly.h"
+#include "MStripHit.h"
+#include "MReadOutSequence.h"
+#include "MSupervisor.h"
+#include "MModuleLoaderMeasurementsROA.h"
+#include "MModuleEnergyCalibrationUniversal.h"
+#include "MModuleEventFilter.h"
+#include "MModuleStripPairingGreedy.h"
+#include "MModuleStripPairingChiSquare.h"
+#include "MModuleTACcut.h"
+#include "MAssembly.h"
+
+
+int g_HistBins = 75;
+double g_MinCTD = -250;
+double g_MaxCTD = 250;
+// double g_MinRatio = 0.94;
+// double g_MaxRatio = 1.06;
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class SymmetryFCN : public FCNBase
+{
+public:
+  //! Operator which returns the symmetry of m_CTDHistogram given the parameters passed
+  double operator()(vector<double> const &v) const override;
+  double Up() const override { return 1; }
+
+  void AddCTD(double CTD){ m_CTD.push_back(CTD); }
+  void AddHVEnergy(double HVEnergy, double HVEnergyResolution){ m_HVEnergy.push_back(HVEnergy); m_HVEnergyResolution.push_back(HVEnergyResolution); }
+  void AddLVEnergy(double LVEnergy, double LVEnergyResolution){ m_LVEnergy.push_back(LVEnergy); m_LVEnergyResolution.push_back(LVEnergyResolution); }
+
+  vector<double> GetCTD(){ return m_CTD; }
+  vector<double> GetHVEnergy(){ return m_HVEnergy; }
+  vector<double> GetLVEnergy(){ return m_LVEnergy; }
+  vector<double> GetHVEnergyResolution(){ return m_HVEnergyResolution; }
+  vector<double> GetLVEnergyResolution(){ return m_LVEnergyResolution; }
+
+  void SetCTD(vector<double> CTD){ m_CTD = CTD; }
+  void SetHVEnergy(vector<double> HVEnergy, vector<double> HVEnergyResolution){ m_HVEnergy = HVEnergy; m_HVEnergyResolution = HVEnergyResolution; }
+  void SetLVEnergy(vector<double> LVEnergy, vector<double> LVEnergyResolution){ m_LVEnergy = LVEnergy; m_LVEnergyResolution = LVEnergyResolution; }
+
+  //! The measured CTD and HV/LV energies
+  vector<double> m_CTD;
+  vector<double> m_HVEnergy;
+  vector<double> m_LVEnergy;
+  vector<double> m_HVEnergyResolution;
+  vector<double> m_LVEnergyResolution;
+
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class ChiSquaredFCN : public SymmetryFCN
+{
+public:
+  //! Operator which returns the symmetry of m_CTDHistogram given the parameters passed
+  double operator()(vector<double> const &v) const override;
+  double Up() const override { return 1; }
+
+};
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+//! A standalone program based on MEGAlib and ROOT
+class TrappingCorrection
+{
+public:
+  //! Default constructor
+  TrappingCorrection();
+  //! Default destructor
+  ~TrappingCorrection();
+  
+  //! Parse the command line
+  bool ParseCommandLine(int argc, char** argv);
+  //! Analyze what eveer needs to be analyzed...
+  bool Analyze();
+  //!load cross talk correction
+  vector<vector<vector<float> > > LoadCrossTalk();
+  //! Interrupt the analysis
+  void Interrupt() { m_Interrupt = true; }
+
+  void dummy_func() { return; }
+
+  MStripHit* GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction);
+
+private:
+  //! True, if the analysis needs to be interrupted
+  bool m_Interrupt;
+  //! The input file name
+  MString m_FileName;
+  MString m_EcalFile;
+  MString m_TACFile;
+  //! output file names
+  MString m_OutFile;
+  //! energy E0
+  // float m_E0;
+  //! option to correct charge loss or not
+  // bool m_CorrectCL;
+  //! option to do a pixel-by-pixel calibration (instead of detector-by-detector)
+  bool m_PixelCorrect;
+  bool m_GreedyPairing;
+  bool m_CardCageOverride;
+
+  double m_MinEnergy;
+  double m_MaxEnergy;
+
+};
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+double SymmetryFCN::operator()(vector<double> const &v) const
+{
+  double HVSlope = v[0];
+  double HVIntercept = v[1];
+  double LVSlope = v[2];
+  double LVIntercept = v[3];
+
+  char name[64]; sprintf(name,"name");
+  int HistBins = g_HistBins;
+  if (HistBins%2 == 0) {
+    HistBins += 1;
+  }
+  TH2D CorrectedHistogram(name, name, HistBins, g_MinCTD, g_MaxCTD, HistBins, g_MinRatio, g_MaxRatio);
+
+  for (unsigned int i = 0; i < m_CTD.size(); ++i) {
+    double CTDHVShift = m_CTD[i] + g_MaxCTD;
+    double CTDLVShift = m_CTD[i] + g_MinCTD;
+    // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
+    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
+    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+    CorrectedHistogram.Fill(m_CTD[i], CorrectedHVEnergy/CorrectedLVEnergy);
+  }
+
+  vector<vector<double>> BinValues;
+  vector<vector<double>> ReflectedBinValues;
+  double Asymmetry = 0;
+
+  for (unsigned int y = 0; y < CorrectedHistogram.GetNbinsY(); ++y) {
+    
+    vector<double> XValues;
+
+    for (unsigned int x = 0; x < CorrectedHistogram.GetNbinsX(); ++x) {
+      XValues.push_back(CorrectedHistogram.GetBinContent(x,y));
+    }
+
+    // BinValues.push_back(XValues);
+    vector<double> ReflectedXValues = XValues;
+    reverse(ReflectedXValues.begin(), ReflectedXValues.end());
+
+    for (unsigned int x = 0; x < XValues.size(); ++x) {
+      Asymmetry += pow(XValues[x] - ReflectedXValues[x], 2)/(XValues[x] + ReflectedXValues[x]);
+    }
+  }
+
+  return Asymmetry;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+double ChiSquaredFCN::operator()(vector<double> const &v) const
+{
+  double HVSlope = v[0];
+  double HVIntercept = v[1];
+  double LVSlope = v[2];
+  double LVIntercept = v[3];
+
+  double ChiSquare = 0;
+
+  for (unsigned int i = 0; i < m_CTD.size(); ++i) {
+    double CTDHVShift = m_CTD[i] + g_MaxCTD;
+    double CTDLVShift = m_CTD[i] + g_MinCTD;
+    // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
+    double CorrectedHVEnergy = m_HVEnergy[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
+    double CorrectedLVEnergy = m_LVEnergy[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+
+    ChiSquare += pow(CorrectedHVEnergy - CorrectedLVEnergy, 2)/(m_HVEnergyResolution[i] + m_LVEnergyResolution[i]);
+  }
+
+  // ChiSquare /= m_CTD.size();
+
+  return ChiSquare;
+
+}
+
+
+//! Default constructor
+TrappingCorrection::TrappingCorrection() : m_Interrupt(false)
+{
+  gStyle->SetPalette(1, 0);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Default destructor
+TrappingCorrection::~TrappingCorrection()
+{
+  // Intentionally left blank
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Parse the command line
+bool TrappingCorrection::ParseCommandLine(int argc, char** argv)
+{
+  ostringstream Usage;
+  Usage<<endl;
+  Usage<<"  Usage: TrappingCorrection <options>"<<endl;
+  Usage<<"    General options:"<<endl;
+  Usage<<"         -h:   HV-illumination input file name (.roa)"<<endl;
+  Usage<<"         -l:   LV-illumination input file name (.roa)"<<endl;
+  Usage<<"         --tcal:   TAC calibration file"<<endl;
+  Usage<<"         --tcut:   TAC cut file"<<endl;
+  Usage<<"         -p:   do pixel-by-pixel correction"<<endl;
+  Usage<<"         -g:   greedy strip pairing (default is chi-square)"<<endl;
+  // Usage<<"         -c:   Card cage data (i.e. no TAC calibration required)"<<endl;
+  Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS"<<endl;
+  Usage<<"         -h:   print this help"<<endl;
+  Usage<<endl;
+
+  string Option;
+
+  // Check for help
+  for (int i = 1; i < argc; i++) {
+    Option = argv[i];
+    if (Option == "-h" || Option == "--help" || Option == "?" || Option == "-?") {
+      cout<<Usage.str()<<endl;
+      return false;
+    }
+  }
+
+  m_PixelCorrect = false;
+  m_GreedyPairing = false;
+  m_MinEnergy = 0;
+  m_MaxEnergy = 5000;
+  
+  time_t rawtime;
+  tm* timeinfo;
+  time(&rawtime);
+  timeinfo = gmtime(&rawtime);
+
+  char buffer [80];
+  strftime(buffer,80,"%Y%m%d%H%M%S",timeinfo);
+
+  m_OutFile = MString(buffer);
+
+  // Now parse the command line options:
+  for (int i = 1; i < argc; i++) {
+    Option = argv[i];
+
+    // First check if each option has sufficient arguments:
+    // Single argument
+    if (Option == "-i" || Option == "-e" || Option == "-t" || Option == "-o" || Option == "--emin" || Option == "--emax") {
+      if (!((argc > i+1) && 
+            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0))){
+        cout<<"Error: Option "<<argv[i][1]<<" needs a second argument!"<<endl;
+        cout<<Usage.str()<<endl;
+        return false;
+      }
+    } 
+    // Multiple arguments template
+    /*
+    else if (Option == "-??") {
+      if (!((argc > i+2) && 
+            (argv[i+1][0] != '-' || isalpha(argv[i+1][1]) == 0) && 
+            (argv[i+2][0] != '-' || isalpha(argv[i+2][1]) == 0))){
+        cout<<"Error: Option "<<argv[i][1]<<" needs two arguments!"<<endl;
+        cout<<Usage.str()<<endl;
+        return false;
+      }
+    }
+    */
+
+    // Then fulfill the options:
+    if (Option == "-i") {
+      m_FileName = argv[++i];
+      cout<<"Accepting file name: "<<m_FileName<<endl;
+    } 
+
+    if (Option == "-e") {
+      m_EcalFile = argv[++i];
+      cout<<"Accepting file name: "<<m_EcalFile<<endl;
+    } 
+
+    if (Option == "--emin") {
+      m_MinEnergy = stod(argv[++i]);
+    } 
+
+    if (Option == "--emax") {
+      m_MaxEnergy = stod(argv[++i]);
+    } 
+
+    if (Option == "-t") {
+      m_TACFile = argv[++i];
+      cout<<"Accepting file name: "<<m_TACFile<<endl;
+    } 
+
+    if (Option == "-o"){
+      m_OutFile = argv[++i];
+      cout<<"Accepting file name: "<<m_OutFile<<endl;
+    }
+
+    if (Option == "-c"){
+      m_CardCageOverride = true;
+    }
+
+    if (Option == "-p"){
+      m_PixelCorrect = true;
+    }
+
+    if (Option == "-g"){
+      m_GreedyPairing = true;
+    }
+
+  }
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Do whatever analysis is necessary
+bool TrappingCorrection::Analyze()
+{
+
+/*  TH2D* h2 = new TH2D("fracmap","fracmap",356*2,-356,356,35,356-30,356+5);
+//  for (int i=-662; i<662; i++){
+//    for (int j=662-30; j<662+5; j++){
+  for (int i=0; i<356*2; i++){
+    for (int j=0; j<35; j++){
+      float c = ((float)i-356)/((float)j+356-30);
+      cout<<c<<endl;
+      h2->SetBinContent(i,j,c);
+    }
+  }
+  TCanvas *ctemp = new TCanvas();
+  h2->Draw("colz");
+  ctemp->Print("frac_map.pdf");
+*/  
+  //time code just to see
+  TStopwatch watch;
+  watch.Start();
+
+  if (m_Interrupt == true) return false;
+
+  MSupervisor* S = MSupervisor::GetSupervisor();
+  
+	MModuleLoaderMeasurementsROA* Loader;
+	MModuleTACcut* TACCalibrator;
+	MModuleEnergyCalibrationUniversal* EnergyCalibrator;
+	MModuleEventFilter* EventFilter;
+
+  unsigned int MNumber = 0;
+  cout<<"Creating ROA loader"<<endl;
+  Loader = new MModuleLoaderMeasurementsROA();
+  Loader->SetFileName(m_FileName);
+  S->SetModule(Loader, MNumber);
+  ++MNumber;
+
+  if (m_CardCageOverride==false) {
+	  cout<<"Creating TAC calibrator"<<endl;
+	  TACCalibrator = new MModuleTACcut();
+	  TACCalibrator->SetTACCalFileName(m_TACFile);
+	  S->SetModule(TACCalibrator, MNumber);
+	  ++MNumber;
+  }
+ 
+  cout<<"Creating energy calibrator"<<endl;
+  EnergyCalibrator = new MModuleEnergyCalibrationUniversal();
+  EnergyCalibrator->SetFileName(m_EcalFile);
+  EnergyCalibrator->EnablePreampTempCorrection(false);
+  S->SetModule(EnergyCalibrator, MNumber);
+  ++MNumber;
+
+  cout<<"Creating Event filter"<<endl;
+  //! Only use events with 1 Strip Hit on each side to avoid strip pairing complications
+  EventFilter = new MModuleEventFilter();
+  EventFilter->SetMinimumLVStrips(1);
+  EventFilter->SetMaximumLVStrips(1);
+  EventFilter->SetMinimumHVStrips(1);
+  EventFilter->SetMaximumHVStrips(1);
+  EventFilter->SetMinimumTotalEnergy(m_MinEnergy);
+  EventFilter->SetMaximumTotalEnergy(m_MaxEnergy);
+  S->SetModule(EventFilter, MNumber);
+  ++MNumber;
+  
+  cout<<"Creating strip pairing"<<endl;
+  MModule* Pairing;
+  if (m_GreedyPairing == true){
+    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
+    Pairing = new MModuleStripPairingGreedy();
+  }
+  else {
+    // Pairing = dynamic_cast<MModuleStripPairingChiSquare*>(Pairing);
+    Pairing = new MModuleStripPairingChiSquare();
+  }
+  S->SetModule(Pairing, MNumber);
+
+  cout<<"Initializing Loader"<<endl;
+  if (Loader->Initialize() == false) return false;
+  if (m_CardCageOverride==false) {
+  	cout<<"Initializing TAC calibrator"<<endl;
+  	if (TACCalibrator->Initialize() == false) return false;
+  }
+  cout<<"Initializing Energy calibrator"<<endl;
+  if (EnergyCalibrator->Initialize() == false) return false;
+  cout<<"Initializing Event filter"<<endl;
+  if (EventFilter->Initialize() == false) return false;
+  cout<<"Initializing Pairing"<<endl;
+  if (Pairing->Initialize() == false) return false;
+
+  map<int, TH2D*> Histograms;
+  map<int, SymmetryFCN*> FCNs;
+
+  bool IsFinished = false;
+  MReadOutAssembly* Event = new MReadOutAssembly();
+
+  cout<<"Analyzing..."<<endl;
+  while (IsFinished == false && m_Interrupt == false) {
+    Event->Clear();
+
+    if (Loader->IsReady() ){
+      Loader->AnalyzeEvent(Event);
+
+      if (m_CardCageOverride==false) {
+      	TACCalibrator->AnalyzeEvent(Event);
+      }
+
+      EnergyCalibrator->AnalyzeEvent(Event);
+      bool Unfiltered = EventFilter->AnalyzeEvent(Event);
+      Pairing->AnalyzeEvent(Event);
+
+      if ((Event->HasAnalysisProgress(MAssembly::c_StripPairing) == true) && (Unfiltered==true)) {
+        for (unsigned int h = 0; h < Event->GetNHits(); ++h) {
+          double HVEnergy = 0.0;
+          double LVEnergy = 0.0;
+          double HVEnergyResolution = 0.0;
+          double LVEnergyResolution = 0.0;
+          vector<MStripHit*> HVStrips;
+          vector<MStripHit*> LVStrips;
+
+          MHit* H = Event->GetHit(h);
+          
+          int DetID = H->GetStripHit(0)->GetDetectorID();
+          TH2D* Hist = Histograms[DetID];
+          SymmetryFCN* FCN = FCNs[DetID]; 
+          
+          if (Hist == nullptr) {
+            char name[64]; sprintf(name,"Detector %d (Uncorrected)",DetID);
+            Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
+            Hist->SetXTitle("CTD (ns)");
+            Hist->SetYTitle("HV/LV Energy Ratio");
+            Histograms[DetID] = Hist;
+          }
+
+          if (FCN == nullptr) {
+            FCN = new SymmetryFCN();
+            FCNs[DetID] = FCN;
+          }
+
+          for (unsigned int sh = 0; sh < H->GetNStripHits(); ++sh) {
+            MStripHit* SH = H->GetStripHit(sh);
+
+            if (SH->IsLowVoltageStrip()==true) {
+              LVEnergy += SH->GetEnergy();
+              LVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+              LVStrips.push_back(SH);
+            } else {
+              HVEnergy += SH->GetEnergy();
+              HVEnergyResolution += (SH->GetEnergyResolution())*(SH->GetEnergyResolution());
+              HVStrips.push_back(SH);
+            }
+          }
+
+          double HVEnergyFraction = 0;
+          double LVEnergyFraction = 0;
+          MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
+          MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
+          double EnergyFraction = HVEnergy/LVEnergy;
+          double CTD = LVSH->GetTiming() - HVSH->GetTiming();
+          if (m_CardCageOverride == true) {
+            CTD *= -1;
+          }
+          Hist->Fill(CTD, EnergyFraction);
+          FCN->AddCTD(CTD);
+          FCN->AddHVEnergy(HVEnergy, HVEnergyResolution);
+          FCN->AddLVEnergy(LVEnergy, LVEnergyResolution);
+        }
+      }
+    }
+    IsFinished = Loader->IsFinished();
+  }
+
+  //setup output file
+  ofstream OutputCalFile;
+  OutputCalFile.open(m_OutFile+MString("_parameters.txt"));
+  OutputCalFile<<"Det"<<'\t'<<"HV Slope"<<'\t'<<"HV Intercept"<<'\t'<<"LV Slope"<<'\t'<<"LV Intercept"<<endl<<endl;
+
+  for (auto H: Histograms) {
+    
+    int DetID = H.first;
+    TFile f(m_OutFile+MString("_Det")+DetID+MString("_Hist_Uncorr.root"),"recreate");
+
+    TCanvas* C = new TCanvas();
+    C->SetLogz();
+    C->cd();
+    H.second->Draw("colz");
+
+    H.second->Write();
+    f.Close();
+
+  }
+
+  for (auto F: FCNs) {
+
+    int DetID = F.first;
+    MnUserParameters* InitialStateSym = new MnUserParameters();
+    InitialStateSym->Add("HVSlope", 1e-3, 1e-4, 0, 3e-1);
+    InitialStateSym->Add("HVIntercept", 0, 0.01, -2, 2);
+    InitialStateSym->Add("LVSlope", 0, 1e-4, -3e-2, 0);
+    InitialStateSym->Add("LVIntercept", 0, 0.01, -2, 2);
+
+    InitialStateSym->Fix("LVSlope");
+    InitialStateSym->Fix("LVIntercept");
+    InitialStateSym->Fix("HVIntercept");
+
+
+    MnMigrad migradSym(*F.second, *InitialStateSym);
+     // Minimize
+    FunctionMinimum MinimumSym = migradSym();
+
+    MnUserParameters ParametersSym = MinimumSym.UserParameters();
+    // double HVSlope = ParametersSym.Value("HVSlope");
+    // double HVIntercept = ParametersSym.Value("HVIntercept");
+    // double LVSlope = ParametersSym.Value("LVSlope");
+    // double LVIntercept = ParametersSym.Value("LVIntercept");
+
+    // output
+    cout<<MinimumSym<<endl;
+
+    MnUserParameters* InitialStateChi = new MnUserParameters();
+    InitialStateChi->Add("HVSlope", ParametersSym.Value("HVSlope"), ParametersSym.Error("HVSlope"));
+    InitialStateChi->Add("HVIntercept", 0, 0.01, -2, 2);
+    InitialStateChi->Add("LVSlope", 0, 1e-4, -3e-2, 0);
+    InitialStateChi->Add("LVIntercept", 0, 0.01, -2, 2);
+
+    InitialStateChi->Fix("LVSlope");
+    InitialStateChi->Fix("LVIntercept");
+    InitialStateChi->Fix("HVSlope");
+
+
+    ChiSquaredFCN* ChiSquaredF = new ChiSquaredFCN();
+    ChiSquaredF->SetCTD(F.second->GetCTD());
+    ChiSquaredF->SetHVEnergy(F.second->GetHVEnergy(), F.second->GetHVEnergyResolution());
+    ChiSquaredF->SetLVEnergy(F.second->GetLVEnergy(), F.second->GetLVEnergyResolution());
+    MnMigrad migradChi(*ChiSquaredF, *InitialStateChi);
+     // Minimize
+    FunctionMinimum MinimumChi = migradChi();
+
+    MnUserParameters ParametersChi = MinimumChi.UserParameters();
+    double HVSlope = ParametersChi.Value("HVSlope");
+    double HVIntercept = ParametersChi.Value("HVIntercept");
+    double LVSlope = ParametersChi.Value("LVSlope");
+    double LVIntercept = ParametersChi.Value("LVIntercept");
+    // output
+    cout<<MinimumChi<<endl;
+
+    char name[64]; sprintf(name,"Detector %d (Corrected)",DetID);
+    TH2D* Hist = new TH2D(name, name, g_HistBins, g_MinCTD, g_MaxCTD, g_HistBins, g_MinRatio, g_MaxRatio);
+    Hist->SetXTitle("CTD (ns)");
+    Hist->SetYTitle("HV/LV Energy Ratio");
+
+    vector<double> CTDList = F.second->GetCTD();
+    vector<double> HVEnergyList = F.second->GetHVEnergy();
+    vector<double> LVEnergyList = F.second->GetLVEnergy();
+    for (unsigned int i=0; i<CTDList.size(); ++i) {
+      
+      double CTDHVShift = CTDList[i] + g_MaxCTD;
+      double CTDLVShift = CTDList[i] + g_MinCTD;
+      // Correct the HV and LV energies by dividing by the CCE. DeltaCCE is defined as a linear function with units percentage energy lost.
+      double CorrectedHVEnergy = HVEnergyList[i]/(1 - (HVSlope*CTDHVShift + HVIntercept)/100);
+      double CorrectedLVEnergy = LVEnergyList[i]/(1 - (LVSlope*CTDLVShift + LVIntercept)/100);
+      
+      Hist->Fill(CTDList[i], CorrectedHVEnergy/CorrectedLVEnergy);
+    }
+
+    TCanvas* C = new TCanvas();
+    C->SetLogz();
+    C->cd();
+    Hist->Draw("colz");
+
+    TFile f(m_OutFile+MString("_Det")+DetID+MString("_Hist_Corr.root"),"recreate");
+    Hist->Write();
+    f.Close();
+
+    OutputCalFile<<to_string(DetID)<<'\t'<<to_string(HVSlope)<<'\t'<<to_string(HVIntercept)<<'\t'<<to_string(LVSlope)<<'\t'<<to_string(LVIntercept)<<endl<<endl;
+
+  }
+  OutputCalFile.close();
+
+  watch.Stop();
+  cout<<"total time (s): "<<watch.CpuTime()<<endl;
+ 
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+TrappingCorrection* g_Prg = 0;
+int g_NInterruptCatches = 1;
+
+MStripHit* TrappingCorrection::GetDominantStrip(vector<MStripHit*>& Strips, double& EnergyFraction)
+{
+  double MaxEnergy = -numeric_limits<double>::max(); // AZ: When both energies are zero (which shouldn't happen) we still pick one
+  double TotalEnergy = 0.0;
+  MStripHit* MaxStrip = nullptr;
+
+  // Iterate through strip hits and get the strip with highest energy
+  for (const auto SH : Strips) {
+    double Energy = SH->GetEnergy();
+    TotalEnergy += Energy;
+    if (Energy > MaxEnergy) {
+      MaxStrip = SH;
+      MaxEnergy = Energy;
+    }
+  }
+  if (TotalEnergy == 0) {
+    EnergyFraction = 0;
+  } else {
+    EnergyFraction = MaxEnergy/TotalEnergy;
+  }
+  return MaxStrip;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Called when an interrupt signal is flagged
+//! All catched signals lead to a well defined exit of the program
+void CatchSignal(int a)
+{
+  if (g_Prg != 0 && g_NInterruptCatches-- > 0) {
+    cout<<"Catched signal Ctrl-C (ID="<<a<<"):"<<endl;
+    g_Prg->Interrupt();
+  } else {
+    abort();
+  }
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Main program
+int main(int argc, char** argv)
+{
+  // Catch a user interupt for graceful shutdown
+  signal(SIGINT, CatchSignal);
+
+  // Initialize global MEGALIB variables, especially mgui, etc.
+  MGlobal::Initialize("Standalone", "a standalone example program");
+
+  TApplication TrappingCorrectionApp("TrappingCorrectionApp", 0, 0);
+
+  g_Prg = new TrappingCorrection();
+
+  if (g_Prg->ParseCommandLine(argc, argv) == false) {
+    cerr<<"Error during parsing of command line!"<<endl;
+    return -1;
+  } 
+  if (g_Prg->Analyze() == false) {
+    cerr<<"Error during analysis!"<<endl;
+    return -2;
+  } 
+
+  TrappingCorrectionApp.Run();
+
+  cout<<"Program exited normally!"<<endl;
+
+  return 0;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -505,7 +505,7 @@ bool TrappingCorrectionAm241::Analyze()
     for (auto H: CTDHistograms[s]) {
       
       int ID = H.first;
-      if (H.second->Integral() > g_MinCounts) {
+      if ((H.second->Integral() > g_MinCounts) && (HVEnergyHistograms[s][ID]->Integral() > g_MinCounts) && (LVEnergyHistograms[s][ID]->Integral() > g_MinCounts)) {
 
         TFitResultPtr CTDFit = H.second->Fit("gaus", "SQ");
         TFitResultPtr HVFit = HVEnergyHistograms[s][ID]->Fit("gaus", "SQ");

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -114,6 +114,7 @@ private:
   bool m_PixelCorrect;
   bool m_GreedyPairing;
   bool m_ExcludeNN;
+  bool m_ContinueHDF5;
 
   double m_MinEnergy;
   double m_MaxEnergy;
@@ -162,6 +163,7 @@ bool TrappingCorrectionAm241::ParseCommandLine(int argc, char** argv)
   Usage<<"         -g:   greedy strip pairing (default is chi-square)"<<endl;
   Usage<<"         -n:   exclude nearest neighbors"<<endl;
   Usage<<"         -o:   outfile (default YYYYMMDDHHMMSS)"<<endl;
+  Usage<<"         --nocontinue:  Suppress continuous HDF5 loading"<<endl;
   Usage<<"         -h:   print this help"<<endl;
   Usage<<endl;
 
@@ -178,6 +180,7 @@ bool TrappingCorrectionAm241::ParseCommandLine(int argc, char** argv)
 
   m_PixelCorrect = false;
   m_GreedyPairing = false;
+  m_ContinueHDF5 = true;
   m_MinEnergy = 40;
   m_MaxEnergy = 70;
   
@@ -209,58 +212,41 @@ bool TrappingCorrectionAm241::ParseCommandLine(int argc, char** argv)
     if (Option == "--HVfile") {
       m_HVFileName = argv[++i];
       cout<<"Accepting file name: "<<m_HVFileName<<endl;
-    } 
-
-    if (Option == "--LVfile") {
+    } else if (Option == "--LVfile") {
       m_LVFileName = argv[++i];
       cout<<"Accepting file name: "<<m_LVFileName<<endl;
-    } 
-
-    if (Option == "-e") {
+    } else if (Option == "-e") {
       m_EcalFile = argv[++i];
       cout<<"Accepting file name: "<<m_EcalFile<<endl;
-    } 
-
-    if (Option == "--emin") {
+    } else if (Option == "--emin") {
       m_MinEnergy = stod(argv[++i]);
-    } 
-
-    if (Option == "--emax") {
+    } else if (Option == "--emax") {
       m_MaxEnergy = stod(argv[++i]);
-    } 
-
-    if (Option == "--tcal") {
+    } else if (Option == "--tcal") {
       m_TACCalFile = argv[++i];
       cout<<"Accepting file name: "<<m_TACCalFile<<endl;
-    } 
-
-    if (Option == "--tcut") {
+    } else if (Option == "--tcut") {
       m_TACCutFile = argv[++i];
       cout<<"Accepting file name: "<<m_TACCutFile<<endl;
-    }
-
-    if (Option == "-m"){
+    } else if (Option == "-m") {
       m_StripMapFile = argv[++i];
       cout<<"Accepting file name: "<<m_StripMapFile<<endl;
-    } 
-
-    if (Option == "-o"){
+    } else if (Option == "-o") {
       m_OutFile = argv[++i];
       cout<<"Accepting file name: "<<m_OutFile<<endl;
-    }
-
-    if (Option == "-p"){
+    } else if (Option == "-p") {
       m_PixelCorrect = true;
-    }
-
-    if (Option == "-g"){
+    } else if (Option == "-g") {
       m_GreedyPairing = true;
-    }
-
-    if (Option == "-n"){
+    } else if (Option == "-n") {
       m_ExcludeNN = true;
+    } else if (Option == "--nocontinue") {
+      m_ContinueHDF5 = false;
+    } else {
+      cout<<"Argument not recognized:"<<Option<<endl;
+      cout<<Usage.str()<<endl;
+      return false;
     }
-
   }
 
   return true;
@@ -323,6 +309,8 @@ bool TrappingCorrectionAm241::Analyze()
     if ((InputFile.GetSubString(InputFile.Length() - 4)) == "hdf5") {
       HDFNames.push_back(InputFile);
     } else if ((InputFile.GetSubString(InputFile.Length() - 3)) == "txt") {
+      cout<<"Reading input file "<<InputFile<<endl;
+      cout<<"WARNING: When passing a list of files, ensure that you have chosen the correct HDF5 continuous reading mode. Use the --nocontinue option to suppress continuous file reading."<<endl;
       MFile F;
       if (F.Open(InputFile)==false) {
         cout<<"Error: Failed to open input file."<<endl;
@@ -352,7 +340,7 @@ bool TrappingCorrectionAm241::Analyze()
       Loader = new MModuleLoaderMeasurementsHDF();
       Loader->SetFileNameStripMap(m_StripMapFile);
       Loader->SetFileName(File);
-      Loader->SetLoadContinuationFiles(true);
+      Loader->SetLoadContinuationFiles(m_ContinueHDF5);
       S->SetModule(Loader, MNumber);
       ++MNumber;
 

--- a/apps/TrappingCorrectionAm241.cxx
+++ b/apps/TrappingCorrectionAm241.cxx
@@ -317,9 +317,18 @@ bool TrappingCorrectionAm241::Analyze()
       } else {
         MString Line;
         while (F.ReadLine(Line)) {
-          HDFNames.push_back(Line.Trim());
+          MString Trimmed = Line.Trim();
+          if ((Trimmed != "")) {
+            if (F.Exists(Trimmed)==true) {
+              HDFNames.push_back(Trimmed);
+            } else {
+              cout<<"Error: Could not find file "<<Trimmed<<endl;
+            }
+          }
         }
       }
+    } else {
+      cout<<"Error: Unrecognized file format: "<<InputFile<<endl;
     }
 
     // Analyze all the data and fill in the histograms


### PR DESCRIPTION
Nuclearizer apps which determine charge trapping correction parameters. One app will take in Am241 illumination data for both sides of the detector, and will separately determine the charge loss parameters on the HV side and the LV side. The other app will take in any dataset and maximize symmetry in HV/LV energy ratio vs. CTD space in order to determine charge loss parameters for one side of the detector while the parameters for the other side remain frozen. The Am241 app will be useful for laboratory calibrations to determine the state of charge trapping before launch, and the symmetry-maximizing app will be useful for ongoing calibration of hole-trapping throughout the mission.