### PR TITLE
New strip pairing Expos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,8 @@ $(LB)/MGUIOptionsDepthCalibration.o \
 $(LB)/MModuleDepthCalibration2024.o \
 $(LB)/MGUIOptionsDepthCalibration2024.o \
 $(LB)/MGUIExpoStripPairing.o \
+$(LB)/MGUIExpoStripPairingHits.o \
+$(LB)/MGUIExpoStripPairingStripHits.o \
 $(LB)/MModuleStripPairingGreedy.o \
 $(LB)/MGUIOptionsStripPairing.o \
 $(LB)/MModuleStripPairingChiSquare.o \

--- a/include/MGUIExpoStripPairingHits.h
+++ b/include/MGUIExpoStripPairingHits.h
@@ -1,0 +1,97 @@
+/*
+ * MGUIExpoStripPairingHits.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIExpoStripPairingHits__
+#define __MGUIExpoStripPairingHits__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TString.h>
+#include <TGClient.h>
+#include <TRootEmbeddedCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+
+// NuSTAR libs
+#include "MGUIExpo.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIExpoStripPairingHits : public MGUIExpo
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIExpoStripPairingHits(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIExpoStripPairingHits();
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  //! Update the frame
+  virtual void Update();
+
+  //! Reset the data in the UI
+  virtual void Reset();
+
+  //! Export the data in the UI
+  virtual void Export(const MString& FileName);
+
+  //! Set the hits histogram parameters 
+  void SetHitsHistogramParameters(int NBins, double Min, double Max);
+
+  //! Add data to the hits histogram
+  void AddHits(int NHits);
+
+  // protected methods:
+ protected:
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+  //! Hits canvas
+  TRootEmbeddedCanvas* m_HitsCanvas;
+  //! Hits histogram
+  TH1D* m_Hits;
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIExpoStripPairingHits, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MGUIExpoStripPairingStripHits.h
+++ b/include/MGUIExpoStripPairingStripHits.h
@@ -1,0 +1,98 @@
+/*
+ * MGUIExpoStripPairingStripHits.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIExpoStripPairingStripHits__
+#define __MGUIExpoStripPairingStripHits__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TString.h>
+#include <TGClient.h>
+#include <TRootEmbeddedCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+
+// NuSTAR libs
+#include "MGUIExpo.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIExpoStripPairingStripHits : public MGUIExpo
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIExpoStripPairingStripHits(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIExpoStripPairingStripHits();
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  //! Update the frame
+  virtual void Update();
+
+  //! Reset the data in the UI
+  virtual void Reset();
+
+  //! Export the data in the UI
+  virtual void Export(const MString& FileName);
+
+  //! Set the energy histogram parameters 
+  void SetStripHitsHistogramParameters(int NBins, double Min, double Max);
+
+  //! Add data to the energy histogram
+  void AddStripHits(double LVStripHits, double HVStripHits);
+
+  // protected methods:
+ protected:
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+  //! Energy canvas
+  TRootEmbeddedCanvas* m_StripHitsCanvas;
+  //! Energy histogram
+  TH2D* m_StripHits;
+
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIExpoStripPairingStripHits, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MModuleStripPairingChiSquare.h
+++ b/include/MModuleStripPairingChiSquare.h
@@ -31,6 +31,8 @@
 #include "MModule.h"
 #include "MStripHit.h"
 #include "MGUIExpoStripPairing.h"
+#include "MGUIExpoStripPairingHits.h"
+#include "MGUIExpoStripPairingStripHits.h"
 
 // Forward declarations:
 
@@ -84,6 +86,8 @@ class MModuleStripPairingChiSquare : public MModule
  protected:
   //! The display of debugging data
   MGUIExpoStripPairing* m_ExpoStripPairing;
+  MGUIExpoStripPairingHits* m_ExpoStripPairingHits;
+  MGUIExpoStripPairingStripHits* m_ExpoStripPairingStripHits;
 
 
   // private members:

--- a/src/MGUIExpoStripPairing.cxx
+++ b/src/MGUIExpoStripPairing.cxx
@@ -49,12 +49,12 @@ MGUIExpoStripPairing::MGUIExpoStripPairing(MModule* Module) : MGUIExpo(Module)
   // standard constructor
 
   // Set the new title of the tab here:
-  m_TabTitle = "Strip Pairing";
+  m_TabTitle = "Strip Pairing Energies";
 
   // Add all histograms and canvases below
-  m_Energies = new TH2D("", "Strip pairing: energy distribution p vs. n side", 1000, 0, 1000, 1000, 0, 1000);
-  m_Energies->SetXTitle("Energy p-Side [keV]");
-  m_Energies->SetYTitle("Energy n-Side [keV]");
+  m_Energies = new TH2D("", "Strip pairing: energy distribution LV vs. HV side", 1000, 0, 1000, 1000, 0, 1000);
+  m_Energies->SetXTitle("Energy LV Side [keV]");
+  m_Energies->SetYTitle("Energy HV Side [keV]");
   m_Energies->SetZTitle("counts");
   m_Energies->SetFillColor(kAzure+7);
 

--- a/src/MGUIExpoStripPairingHits.cxx
+++ b/src/MGUIExpoStripPairingHits.cxx
@@ -1,0 +1,191 @@
+/*
+ * MGUIExpoStripPairingHits.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+// Include the header:
+#include "MGUIExpoStripPairingHits.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include <TSystem.h>
+#include <TString.h>
+#include <TGLabel.h>
+#include <TGResourcePool.h>
+#include <TCanvas.h>
+
+// MEGAlib libs:
+#include "MStreams.h"
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MGUIExpoStripPairingHits)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoStripPairingHits::MGUIExpoStripPairingHits(MModule* Module) : MGUIExpo(Module)
+{
+  // standard constructor
+
+  // Set the new title of the tab here:
+  m_TabTitle = "Strip Pairing Hits";
+
+  // Add all histograms and canvases below
+
+  m_Hits = new TH1D("", "Strip pairing: Number of Hits per Event", 5, 1, 5);
+  m_Hits->SetXTitle("Number of Hits");
+  m_Hits->SetYTitle("Number of Events");
+  m_Hits->SetFillColor(kAzure+7);
+
+  m_HitsCanvas = 0;
+
+  // use hierarchical cleaning
+  SetCleanup(kDeepCleanup);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoStripPairingHits::~MGUIExpoStripPairingHits()
+{
+  // kDeepCleanup is activated 
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingHits::Reset()
+{
+  //! Reset the data in the UI
+
+  m_Mutex.Lock();
+  
+  m_Hits->Reset();
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingHits::AddHits(int NHits)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+  
+  m_Hits->Fill(NHits);
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingHits::SetHitsHistogramParameters(int NBins, double Min, double Max)
+{
+  // Set the energy histogram parameters 
+
+  m_Mutex.Lock();
+  
+  m_Hits->SetBins(NBins, Min, Max);
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingHits::Create()
+{
+  // Add the GUI options here
+  
+  // Do not create it twice!
+  if (m_IsCreated == true) return;
+  
+  m_Mutex.Lock();
+
+  TGLayoutHints* CanvasLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX | kLHintsExpandY,
+                                                  2, 2, 2, 2);
+
+  TGHorizontalFrame* HFrame = new TGHorizontalFrame(this);
+  AddFrame(HFrame, CanvasLayout);
+
+  m_HitsCanvas = new TRootEmbeddedCanvas("Hits", HFrame, 100, 100);
+  HFrame->AddFrame(m_HitsCanvas, CanvasLayout);
+
+  m_HitsCanvas->GetCanvas()->cd();
+  m_HitsCanvas->GetCanvas()->SetGridy();
+  m_HitsCanvas->GetCanvas()->SetGridx();
+  m_Hits->Draw("colz");
+  m_HitsCanvas->GetCanvas()->Update();
+  
+  m_IsCreated = true;
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingHits::Update()
+{
+  //! Update the frame
+
+  m_Mutex.Lock();
+
+  if (m_HitsCanvas != 0) {
+    m_HitsCanvas->GetCanvas()->Modified();
+    m_HitsCanvas->GetCanvas()->Update();
+  }
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+
+void MGUIExpoStripPairingHits::Export(const MString& FileName)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+  
+  m_HitsCanvas->GetCanvas()->SaveAs(FileName);
+  
+  m_Mutex.UnLock();
+}
+
+
+
+// MGUIExpoStripPairingHits: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MGUIExpoStripPairingStripHits.cxx
+++ b/src/MGUIExpoStripPairingStripHits.cxx
@@ -1,0 +1,190 @@
+/*
+ * MGUIExpoStripPairingStripHits.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+// Include the header:
+#include "MGUIExpoStripPairingStripHits.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include <TSystem.h>
+#include <TString.h>
+#include <TGLabel.h>
+#include <TGResourcePool.h>
+#include <TCanvas.h>
+
+// MEGAlib libs:
+#include "MStreams.h"
+
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MGUIExpoStripPairingStripHits)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoStripPairingStripHits::MGUIExpoStripPairingStripHits(MModule* Module) : MGUIExpo(Module)
+{
+  // standard constructor
+
+  // Set the new title of the tab here:
+  m_TabTitle = "Strip Pairing StripHits";
+
+  // Add all histograms and canvases below
+  m_StripHits = new TH2D("", "Strip pairing: Strip Hit distribution LV vs. HV side", 10, 0.5, 10.5, 10, 0.5, 10.5);
+  m_StripHits->SetXTitle("Strip Hits LV Side");
+  m_StripHits->SetYTitle("Strip Hits HV Side");
+  m_StripHits->SetZTitle("Hits");
+  m_StripHits->SetFillColor(kAzure+7);
+
+  m_StripHitsCanvas = 0;
+
+  // use hierarchical cleaning
+  SetCleanup(kDeepCleanup);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIExpoStripPairingStripHits::~MGUIExpoStripPairingStripHits()
+{
+  // kDeepCleanup is activated 
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingStripHits::Reset()
+{
+  //! Reset the data in the UI
+
+  m_Mutex.Lock();
+  
+  m_StripHits->Reset();
+  
+  m_Mutex.UnLock();
+}
+  
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingStripHits::SetStripHitsHistogramParameters(int NBins, double Min, double Max)
+{
+  // Set the energy histogram parameters 
+
+  m_Mutex.Lock();
+  
+  m_StripHits->SetBins(NBins, Min, Max, NBins, Min, Max);
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingStripHits::AddStripHits(double LVStripHits, double HVStripHits)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+  
+  m_StripHits->Fill(LVStripHits, HVStripHits);
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingStripHits::Create()
+{
+  // Add the GUI options here
+  
+  // Do not create it twice!
+  if (m_IsCreated == true) return;
+  
+  m_Mutex.Lock();
+
+  TGLayoutHints* CanvasLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft | kLHintsExpandX | kLHintsExpandY,
+                                                  2, 2, 2, 2);
+
+  TGHorizontalFrame* HFrame = new TGHorizontalFrame(this);
+  AddFrame(HFrame, CanvasLayout);
+
+  
+  m_StripHitsCanvas = new TRootEmbeddedCanvas("StripHits", HFrame, 100, 100);
+  HFrame->AddFrame(m_StripHitsCanvas, CanvasLayout);
+
+  m_StripHitsCanvas->GetCanvas()->cd();
+  m_StripHitsCanvas->GetCanvas()->SetGridy();
+  m_StripHitsCanvas->GetCanvas()->SetGridx();
+  m_StripHits->Draw("colz");
+  m_StripHitsCanvas->GetCanvas()->Update();
+  
+  m_IsCreated = true;
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingStripHits::Update()
+{
+  //! Update the frame
+
+  m_Mutex.Lock();
+  
+  if (m_StripHitsCanvas != 0) {
+    m_StripHitsCanvas->GetCanvas()->Modified();
+    m_StripHitsCanvas->GetCanvas()->Update();
+  }
+  
+  m_Mutex.UnLock();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIExpoStripPairingStripHits::Export(const MString& FileName)
+{
+  // Add data to the energy histogram
+
+  m_Mutex.Lock();
+  
+  m_StripHitsCanvas->GetCanvas()->SaveAs(FileName);
+  
+  m_Mutex.UnLock();
+}
+
+
+// MGUIExpoStripPairingStripHits: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MModuleStripPairingChiSquare.cxx
+++ b/src/MModuleStripPairingChiSquare.cxx
@@ -106,6 +106,14 @@ void MModuleStripPairingChiSquare::CreateExpos()
   m_ExpoStripPairing = new MGUIExpoStripPairing(this);
   m_ExpoStripPairing->SetEnergiesHistogramParameters(1500, 0, 1500);
   m_Expos.push_back(m_ExpoStripPairing);
+
+  m_ExpoStripPairingHits = new MGUIExpoStripPairingHits(this);
+  m_ExpoStripPairingHits->SetHitsHistogramParameters(5, 0.5, 5.5);
+  m_Expos.push_back(m_ExpoStripPairingHits);
+
+  m_ExpoStripPairingStripHits = new MGUIExpoStripPairingStripHits(this);
+  m_ExpoStripPairingStripHits->SetStripHitsHistogramParameters(10, 0.5, 10.5);
+  m_Expos.push_back(m_ExpoStripPairingStripHits);
 }
 
 
@@ -480,6 +488,9 @@ bool MModuleStripPairingChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
     double XEnergyTotal = 0;
     double YEnergyTotal = 0;
     double EnergyTotal = 0;
+    // Create a list for plotting X and Y energies
+    vector<double> XEnergies;
+    vector<double> YEnergies;
 
     for (unsigned int h = 0; h < min(BestXSideCombo.size(), BestYSideCombo.size()); ++h) {
       XPos = 0;
@@ -515,9 +526,12 @@ bool MModuleStripPairingChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
       }
       EnergyTotal += Energy;
 
-      if (HasExpos() == true) {
-        m_ExpoStripPairing->AddEnergies(XEnergy, YEnergy);
-      }
+      XEnergies.push_back(XEnergy);
+      YEnergies.push_back(YEnergy);
+
+      // if (HasExpos() == true) {
+      //   m_ExpoStripPairing->AddEnergies(XEnergy, YEnergy);
+      // }
 
       MHit* Hit = new MHit();
       Hit->SetEnergy(Energy);
@@ -535,6 +549,25 @@ bool MModuleStripPairingChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
       Event->SetStripPairingIncomplete(true, "Strips not pairable wihin 2.5 sigma of measure denergy");
       Event->SetAnalysisProgress(MAssembly::c_StripPairing);
       return false;
+    }
+    else if (HasExpos() == true){
+      m_ExpoStripPairingHits->AddHits(Event->GetNHits());
+      for (unsigned int i = 0; i < XEnergies.size(); ++i){
+        m_ExpoStripPairing->AddEnergies(XEnergies[i], YEnergies[i]);
+      }
+      for (unsigned int h = 0; h<Event->GetNHits(); h++){
+        double HVStrips = 0;
+        double LVStrips = 0;
+        for (unsigned int sh=0; sh<Event->GetHit(h)->GetNStripHits(); sh++){
+          if (Event->GetHit(h)->GetStripHit(sh)->IsLowVoltageStrip()==true){
+            LVStrips++;
+          }
+          else{
+            HVStrips++;
+          }
+        }
+        m_ExpoStripPairingStripHits->AddStripHits(LVStrips, HVStrips);
+      }
     }
 
     //


### PR DESCRIPTION
Adding 2 new Expos for strip pairing modules. One plots a 1-D histogram of the number of Hits per Event, and the other plots a 2-D histogram of the number of HV and LV Strip Hits per Hit. Strip pairing modules will also be updated to use these modules.