### PR TITLE
BUG: l=0 and h=1 when parsing new TAC calibration format

### DIFF
--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -319,9 +319,9 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
             m_DetectorIDs.push_back(DetID);
           }
           
-          if (Tokens[1+IndexOffset] == "l") {
+          if ((Tokens[1+IndexOffset] == "l") || (Tokens[1+IndexOffset] == "0")) {
             m_LVTACCal[DetID][StripID] = CalValues;
-          } else if (Tokens[1+IndexOffset] == "h") {
+          } else if ((Tokens[1+IndexOffset] == "h") || (Tokens[1+IndexOffset] == "1")) {
             m_HVTACCal[DetID][StripID] = CalValues;
           }
         }


### PR DESCRIPTION
The new format does not use h and l for HV and LV sides. Instead it uses 0 and 1. I updated the TAC calibration module to align with this change. 