### PR TITLE
Refined TAC cuts

### DIFF
--- a/include/MGUIOptionsTACcut.h
+++ b/include/MGUIOptionsTACcut.h
@@ -69,14 +69,6 @@ class MGUIOptionsTACcut : public MGUIOptions
  protected:
   //! The detector IDs as a string
   TGTextEntry* m_Detectors;
-  //! The total TAC selection
-  MGUIEMinMaxEntry* m_TAC;
-
-  //! FPGA setting of time between FLAG rising and ENABLE falling
-  MGUIEEntry* m_DisableTime;
-
-  //! internal FPGA delay between FLAG rising and FPGA reacting
-  MGUIEEntry* m_FlagToEnDelay;
 
   //! Select TAC Calibration file to load, converts readout timing to nanoseconds
   MGUIEFileSelector* m_TACCalFileSelector;

--- a/include/MModuleTACcut.h
+++ b/include/MModuleTACcut.h
@@ -119,10 +119,10 @@ class MModuleTACcut : public MModule
 double m_DisableTime, m_FlagToEnDelay;
 MString m_TACCalFile;
 MString m_TACCutFile;
-unordered_map<int, unordered_map<int, vector<double>>> m_HVTACCal;
-unordered_map<int, unordered_map<int, vector<double>>> m_LVTACCal;
-unordered_map<int, unordered_map<int, vector<double>>> m_HVTACCut;
-unordered_map<int, unordered_map<int, vector<double>>> m_LVTACCut;
+
+//! Map DetID -> Side (LV=0, HV=1) -> Strip ID -> TAC calibration/cut parameters
+unordered_map<int, vector<unordered_map<int, vector<double>>>> m_TACCal;
+unordered_map<int, vector<unordered_map<int, vector<double>>>> m_TACCut;
 
 vector<unsigned int> m_DetectorIDs;
 

--- a/include/MModuleTACcut.h
+++ b/include/MModuleTACcut.h
@@ -80,16 +80,6 @@ class MModuleTACcut : public MModule
   //! Get filename for TAC Cut
   MString GetTACCutFileName() const {return m_TACCutFile;}
 
-  //! Set the disable time
-  void SetDisableTime(double DisableTime) { m_DisableTime = DisableTime; }
-  //! Get the disable time
-  unsigned int GetDisableTime() const { return m_DisableTime; }
-
-  //! Set the shaping flag_to_en_delay
-  void SetFlagToEnDelay(double FlagToEnDelay) { m_FlagToEnDelay = FlagToEnDelay; }
-  //! Get the shaping flag_to_en_delay
-  unsigned int GetFlagToEnDelay() const { return m_FlagToEnDelay; }
-
   //! Load the TAC calibration file
   bool LoadTACCalFile(MString FName);
 
@@ -115,8 +105,7 @@ class MModuleTACcut : public MModule
   // private members:
  private:
 
-// declare TAC Cut and calibration variables here
-double m_DisableTime, m_FlagToEnDelay;
+//! TAC cut and TAC calibration parameter files
 MString m_TACCalFile;
 MString m_TACCutFile;
 

--- a/include/MModuleTACcut.h
+++ b/include/MModuleTACcut.h
@@ -124,6 +124,9 @@ MString m_TACCutFile;
 unordered_map<int, vector<unordered_map<int, vector<double>>>> m_TACCal;
 unordered_map<int, vector<unordered_map<int, vector<double>>>> m_TACCut;
 
+//! Map characters representing sides of the detectors indices to avoid mistakes
+unordered_map<char, int> m_SideToIndex;
+
 vector<unsigned int> m_DetectorIDs;
 
 MGUIExpoTACcut* m_ExpoTACcut;

--- a/src/MGUIOptionsTACcut.cxx
+++ b/src/MGUIOptionsTACcut.cxx
@@ -84,14 +84,6 @@ void MGUIOptionsTACcut::Create()
   m_TACCutFileSelector->SetFileType("TAC", "*.csv");
   TGLayoutHints* TACCutLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
   m_OptionsFrame->AddFrame(m_TACCutFileSelector, TACCutLayout);
-
-  TGLayoutHints* DisableTimeLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 30, 10, 0, 10);  
-  m_DisableTime = new MGUIEEntry(m_OptionsFrame, "Disable Time [ns]:", false, dynamic_cast<MModuleTACcut*>(m_Module)->GetDisableTime(), false, -numeric_limits<double>::max()/2, numeric_limits<double>::max()/2);
-  m_OptionsFrame->AddFrame(m_DisableTime, DisableTimeLayout);
-
-  TGLayoutHints* FlagToEnDelayLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 30, 10, 0, 10);  
-  m_FlagToEnDelay = new MGUIEEntry(m_OptionsFrame, "FLAG to ENABLE delay [ns]:", false, dynamic_cast<MModuleTACcut*>(m_Module)->GetFlagToEnDelay(), false, -numeric_limits<double>::max()/2, numeric_limits<double>::max()/2);
-  m_OptionsFrame->AddFrame(m_FlagToEnDelay, FlagToEnDelayLayout);  
   
   PostCreate();
 }
@@ -136,8 +128,6 @@ bool MGUIOptionsTACcut::OnApply()
   // Store the data in the module
   dynamic_cast<MModuleTACcut*>(m_Module)->SetTACCalFileName(m_TACCalFileSelector->GetFileName());
   dynamic_cast<MModuleTACcut*>(m_Module)->SetTACCutFileName(m_TACCutFileSelector->GetFileName());
-  dynamic_cast<MModuleTACcut*>(m_Module)->SetDisableTime(m_DisableTime->GetAsDouble());
-  dynamic_cast<MModuleTACcut*>(m_Module)->SetFlagToEnDelay(m_FlagToEnDelay->GetAsDouble());
 
   return true;
 }

--- a/src/MGUIOptionsTACcut.cxx
+++ b/src/MGUIOptionsTACcut.cxx
@@ -86,7 +86,7 @@ void MGUIOptionsTACcut::Create()
   m_OptionsFrame->AddFrame(m_TACCutFileSelector, TACCutLayout);
 
   TGLayoutHints* DisableTimeLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 30, 10, 0, 10);  
-  m_DisableTime = new MGUIEEntry(m_OptionsFrame, "Diable Time [ns]:", false, dynamic_cast<MModuleTACcut*>(m_Module)->GetDisableTime(), false, -numeric_limits<double>::max()/2, numeric_limits<double>::max()/2);
+  m_DisableTime = new MGUIEEntry(m_OptionsFrame, "Disable Time [ns]:", false, dynamic_cast<MModuleTACcut*>(m_Module)->GetDisableTime(), false, -numeric_limits<double>::max()/2, numeric_limits<double>::max()/2);
   m_OptionsFrame->AddFrame(m_DisableTime, DisableTimeLayout);
 
   TGLayoutHints* FlagToEnDelayLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 30, 10, 0, 10);  

--- a/src/MModuleEnergyCalibrationUniversal.cxx
+++ b/src/MModuleEnergyCalibrationUniversal.cxx
@@ -395,17 +395,6 @@ bool MModuleEnergyCalibrationUniversal::AnalyzeEvent(MReadOutAssembly* Event)
     } 
   }
 
-  for (unsigned int i = 0; i < Event->GetNStripHits(); ) {
-    MStripHit* SH = Event->GetStripHit(i);
-    if (SH->GetEnergy() < 8) {
-      Event->RemoveStripHit(i);
-      delete SH;
-    } else {
-      ++i;
-    }
-  }
-
-
   Event->SetAnalysisProgress(MAssembly::c_EnergyCalibration);
   
   return true;

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -216,10 +216,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
         double TotalOffset = ShapingOffset + m_DisableTime + m_FlagToEnDelay;
         if ((SHTiming > TotalOffset + CoincidenceWindow) || (SHTiming < TotalOffset) || (SHTiming < MaxTAC - CoincidenceWindow)) {
           Passed = false;
-        }
-      }
-      if (Passed==true) {
-        if (HasExpos()==true) {
+        } else if (HasExpos()==true) {
           m_ExpoTACcut->AddTAC(DetID, SHTiming);
         }
       }

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -83,8 +83,6 @@ MModuleTACcut::MModuleTACcut() : MModule()
   // Can we use multiple instances of this class
   m_AllowMultipleInstances = false;
 
-  m_DisableTime = 1396;
-  m_FlagToEnDelay = 104;
   m_SideToIndex = {{'l', 0}, {'h', 1}, {'0', 0}, {'1', 1}, {'p', 0}, {'n', 1}};
 }
 
@@ -111,7 +109,7 @@ bool MModuleTACcut::Initialize()
   }
 
   if (LoadTACCutFile(m_TACCutFile) == false) {
-    cout<<m_XmlTag<<": Error: TAC Calibration file could not be loaded."<<endl;
+    cout<<m_XmlTag<<": Error: TAC Cut file could not be loaded."<<endl;
     return false;
   }
 
@@ -143,7 +141,7 @@ void MModuleTACcut::CreateExpos()
   m_ExpoTACcut->SetTACHistogramArrangement(m_DetectorIDs);
   for (unsigned int i = 0; i < m_DetectorIDs.size(); ++i) {
     unsigned int DetID = m_DetectorIDs[i];
-    m_ExpoTACcut->SetTACHistogramParameters(DetID, 120, 0, 7000);
+    m_ExpoTACcut->SetTACHistogramParameters(DetID, 200, 0, 6000);
   }
   m_Expos.push_back(m_ExpoTACcut);
 }
@@ -166,7 +164,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       return false;
     }
     if (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size()) {
-      cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCal (max strip ID: "<<m_TACCal[DetID].size()-1<<") - skipping event"<<endl;
+      cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCal (max strip ID: "<<m_TACCal[DetID][m_SideToIndex[Side]].size()-1<<") - skipping event"<<endl;
       return false;
     }
     if (DetID >= m_TACCut.size()) {
@@ -174,7 +172,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       return false;
     }
     if (StripID >= m_TACCut[DetID][m_SideToIndex[Side]].size()) {
-      cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCut (max strip ID: "<<m_TACCut[DetID].size()-1<<") - skipping event"<<endl;
+      cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCut (max strip ID: "<<m_TACCut[DetID][m_SideToIndex[Side]].size()-1<<") - skipping event"<<endl;
       return false;
     }
   }
@@ -207,13 +205,16 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       int DetID = SH->GetDetectorID();
       int StripID = SH->GetStripID();
       char Side = SH->IsLowVoltageStrip() ? 'l' : 'h';
-      double FLNoiseCut = m_TACCut[DetID][m_SideToIndex[Side]][StripID][2];
+      double FLNoiseCut = m_TACCut[DetID][m_SideToIndex[Side]][StripID][4];
       if ((SHTiming < FLNoiseCut)) {
         Passed = false;
       } else if (SH->HasFastTiming()==true) {
         double ShapingOffset = m_TACCut[DetID][m_SideToIndex[Side]][StripID][0];
         double CoincidenceWindow = m_TACCut[DetID][m_SideToIndex[Side]][StripID][1];
-        double TotalOffset = ShapingOffset + m_DisableTime + m_FlagToEnDelay;
+        double DisableTime = m_TACCut[DetID][m_SideToIndex[Side]][StripID][2];
+        double FlagToEnDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][3];
+        double FlagDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][5];
+        double TotalOffset = ShapingOffset + DisableTime + FlagToEnDelay + FlagDelay;
         if ((SHTiming > TotalOffset + CoincidenceWindow) || (SHTiming < TotalOffset) || (SHTiming < MaxTAC - CoincidenceWindow)) {
           Passed = false;
         } else if (HasExpos()==true) {
@@ -274,16 +275,6 @@ bool MModuleTACcut::ReadXmlConfiguration(MXmlNode* Node)
     SetTACCutFileName(TACCutFileNameNode->GetValue());
   }
 
-  MXmlNode* DisableTimeNode = Node->GetNode("DisableTime");
-  if (DisableTimeNode != nullptr) {
-    m_DisableTime = DisableTimeNode->GetValueAsDouble();
-  }
-
-  MXmlNode* FlagToEnDelayNode = Node->GetNode("FlagToEnDelay");
-  if (FlagToEnDelayNode != nullptr) {
-    m_FlagToEnDelay = FlagToEnDelayNode->GetValueAsDouble();
-  }
-
   return true;
 }
 
@@ -299,8 +290,6 @@ MXmlNode* MModuleTACcut::CreateXmlConfiguration()
   
   new MXmlNode(Node, "TACCalFileName", m_TACCalFile);
   new MXmlNode(Node, "TACCutFileName", m_TACCutFile);
-  new MXmlNode(Node, "DisableTime", m_DisableTime);
-  new MXmlNode(Node, "FlagToEnDelay", m_FlagToEnDelay);
 
   return Node;
 }
@@ -317,7 +306,7 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
   // ReadOutID, Detector, Side, Strip, TAC cal, TAC cal error, TAC offset, TAC offset error
   MFile F;
   if (F.Open(FName) == false) {
-    cout<<"MModuleTACcut: failed to open TAC Calibration file."<<endl;
+    cout<<m_XmlTag<<": Error: failed to open TAC Calibration file."<<endl;
     return false;
   } else {
     MString Line;
@@ -330,8 +319,8 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
           MString SideString = Tokens[1+IndexOffset].Trim();
           char Side;
           if (SideString.Length()!=1) {
-            cout<<"MModuleTACcut: Expected 1 character Side, got string: "<<SideString<<" In TAC calibration file."<<endl;
-            continue;
+            cout<<m_XmlTag<<": Error: Expected 1 character Side, got string \""<<SideString<<"\" in TAC calibration file."<<endl;
+            return false;
           }
           else {
             Side = SideString[0];
@@ -360,7 +349,8 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
           if (m_SideToIndex.find(Side) != m_SideToIndex.end()) {
             m_TACCal[DetID][m_SideToIndex[Side]][StripID] = CalValues;
           } else {
-            cout<<"MModuleTACcut: Unable to identify Side "<<Side<<" In TAC calibration file."<<endl;
+            cout<<m_XmlTag<<": Error: Unable to identify Side \""<<Side<<"\" in TAC calibration file."<<endl;
+            return false;
           }
         }
       }
@@ -379,38 +369,51 @@ bool MModuleTACcut::LoadTACCalFile(MString FName)
 bool MModuleTACcut::LoadTACCutFile(MString FName)
 {
   // Read in the TAC Cut file, which should contain for each strip:
-  //  DetID, h or l for high or low voltage, shaping offset, coincidence window
+  //  DetID, h or l for high or low voltage, StripID, shaping offset, coincidence window
+  // or new format:
+  //  DetID, h or l for high or low voltage, StripID, shaping offset, coincidence window, disable time, flag-to-enable delay, FL noise cut, flag delay
   MFile F;
+  bool OldFormatMessage = false;
   if (F.Open(FName) == false) {
-    cout << "MModuleTACcut: failed to open TAC Cut file." << endl;
+    cout<<m_XmlTag<<": Error: failed to open TAC Cut file."<<endl;
     return false;
   } else {
-    bool FLNoiseCutIncluded = false;
     MString Line;
     while (F.ReadLine(Line)) {
       if (!Line.BeginsWith("#")) {
         std::vector<MString> Tokens = Line.Tokenize(",");
-        if ((Tokens.size() == 5) || (Tokens.size() == 6)) {
+        if (Tokens.size() >= 5) {
           int DetID = Tokens[0].ToInt();
-          MString SideString = Tokens[1].Trim();
+          MString SideString = Tokens[1];
           char Side;
           if (SideString.Length()!=1) {
-            cout<<"MModuleTACcut: Expected 1 character Side, got string: "<<SideString<<" In TAC cut file."<<endl;
-            continue;
-          }
-          else {
+            cout<<m_XmlTag<<": Error: Expected 1 character Side, got string:\""<<SideString<<"\" in TAC cut file."<<endl;
+            return false;
+          } else {
             Side = SideString[0];
           }
           int StripID = Tokens[2].ToInt();
           double ShapingOffset = Tokens[3].ToDouble();
           double CoincidenceWindow = Tokens[4].ToDouble();
-          double FLNoiseCut = 100; // Old file format did not include a FLNoise Cut. Default to 100ns if not present in the file.
-          if (Tokens.size()==6) {
-            FLNoiseCut = Tokens[5].ToDouble();
-            FLNoiseCutIncluded = true;
+          if ((Tokens.size() == 5) && (OldFormatMessage==false)) {
+            cout<<m_XmlTag<<": Error: TAC cut file is using the old format. Using default values for FL noise cut, flag delay, disable time, and flag-to-enable delay."<<endl;
+            OldFormatMessage = true;
+          }
+          double DisableTime = 1400;
+          double FlagToEnDelay = 104;
+          double FLNoiseCut = 0;
+          double FlagDelay = 0;
+          if (Tokens.size()==9) {
+            DisableTime = Tokens[5].ToDouble();
+            FlagToEnDelay = Tokens[6].ToDouble();
+            FLNoiseCut = Tokens[7].ToDouble();
+            FlagDelay = Tokens[8].ToDouble();
+          } else if (Tokens.size()!=5) {
+            cout<<m_XmlTag<<": Error: Unrecognized TAC cut file format. Number of parameters is "<<Tokens.size()<<"."<<endl;
+            return false;
           }
           vector<double> CutParams;
-          CutParams.push_back(ShapingOffset); CutParams.push_back(CoincidenceWindow); CutParams.push_back(FLNoiseCut);
+          CutParams.push_back(ShapingOffset); CutParams.push_back(CoincidenceWindow); CutParams.push_back(DisableTime); CutParams.push_back(FlagToEnDelay); CutParams.push_back(FLNoiseCut); CutParams.push_back(FlagDelay);
           
           if (m_TACCut.find(DetID) == m_TACCut.end()) {
             vector<unordered_map<int, vector<double>>> TempVector;
@@ -428,7 +431,8 @@ bool MModuleTACcut::LoadTACCutFile(MString FName)
           if (m_SideToIndex.find(Side) != m_SideToIndex.end()) {
             m_TACCut[DetID][m_SideToIndex[Side]][StripID] = CutParams;
           } else {
-            cout<<"MModuleTACcut: Unable to identify Side "<<Side<<" In TAC calibration file."<<endl;
+            cout<<m_XmlTag<<": Error: Unable to identify Side "<<Side<<" In TAC cut file."<<endl;
+            return false;
           }
         }
       }

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -165,7 +165,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       cout<<m_XmlTag<<": Error: DetID "<<DetID<<" is not in TACCal (max det ID: "<<m_TACCal.size()-1<<") - skipping event"<<endl;
       return false;
     }
-    if ((SH->IsGuardRing()==false) && (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size())) {
+    if (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size()) {
       cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCal (max strip ID: "<<m_TACCal[DetID].size()-1<<") - skipping event"<<endl;
       return false;
     }
@@ -173,7 +173,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       cout<<m_XmlTag<<": Error: DetID "<<DetID<<" is not in TACCut (max det ID: "<<m_TACCut.size()-1<<") - skipping event"<<endl;
       return false;
     }
-    if ((SH->IsGuardRing()==false) && (StripID >= m_TACCut[DetID][m_SideToIndex[Side]].size())) {
+    if (StripID >= m_TACCut[DetID][m_SideToIndex[Side]].size()) {
       cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCut (max strip ID: "<<m_TACCut[DetID].size()-1<<") - skipping event"<<endl;
       return false;
     }

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -165,7 +165,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       cout<<m_XmlTag<<": Error: DetID "<<DetID<<" is not in TACCal (max det ID: "<<m_TACCal.size()-1<<") - skipping event"<<endl;
       return false;
     }
-    if (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size()) {
+    if ((SH->IsGuardRing()==false) && (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size())) {
       cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCal (max strip ID: "<<m_TACCal[DetID].size()-1<<") - skipping event"<<endl;
       return false;
     }
@@ -173,7 +173,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       cout<<m_XmlTag<<": Error: DetID "<<DetID<<" is not in TACCut (max det ID: "<<m_TACCut.size()-1<<") - skipping event"<<endl;
       return false;
     }
-    if (StripID >= m_TACCut[DetID][m_SideToIndex[Side]].size()) {
+    if ((SH->IsGuardRing()==false) && (StripID >= m_TACCut[DetID][m_SideToIndex[Side]].size())) {
       cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCut (max strip ID: "<<m_TACCut[DetID].size()-1<<") - skipping event"<<endl;
       return false;
     }


### PR DESCRIPTION
The calculation of MaxTAC, which represents the first strip hit, has been corrected to only compare against strip hits with fast timing and which are not nearest neighbors (rather than all strip hits). A new cut, referred to as the "FL noise cut" has also been added. The expected format for the TAC cut file allows for this parameter to be included for each strip, but it doesn't have to be included. Finally, the way that the TAC calibration and TAC cut parameters are stored has been changed so that they are not split into different variables according to LV and HV.