### PR TITLE
Updated GR and shield veto flag, added save option for veto events

### DIFF
--- a/include/MGUIOptionsEventSaver.h
+++ b/include/MGUIOptionsEventSaver.h
@@ -79,6 +79,9 @@ class MGUIOptionsEventSaver : public MGUIOptions
   //! Checkbutton to save or reject bad events
   TGCheckButton* m_SaveBadEvents;
 
+  //! Checkbutton to save veto events
+  TGCheckButton* m_SaveVetoEvents;
+
   //! Checkbutton to add a time tag
   TGCheckButton* m_AddTimeTag;
 

--- a/include/MModuleEventSaver.h
+++ b/include/MModuleEventSaver.h
@@ -58,10 +58,15 @@ class MModuleEventSaver : public MModule
   //! Set the file name
   void SetFileName(const MString& Name) { m_FileName = Name; }
   
-  //! Get the file name
+  //! Return true if the Bad events should be saved
   bool GetSaveBadEvents() const { return m_SaveBadEvents; }
-  //! Set the file name
+  //! Set whether the Bad events should be saved
   void SetSaveBadEvents(bool SaveBadEvents) { m_SaveBadEvents = SaveBadEvents; }
+
+  //! Return true if the Veto events should be saved
+  bool GetSaveVetoEvents() const { return m_SaveVetoEvents; }
+  //! Set whether the Veto events should be saved
+  void SetSaveVetoEvents(bool SaveVetoEvents) {m_SaveVetoEvents = SaveVetoEvents; }
   
   //! Get the add time tag flag
   bool GetAddTimeTag() const { return m_AddTimeTag; }
@@ -187,6 +192,9 @@ class MModuleEventSaver : public MModule
   
   //! Save bad events
   bool m_SaveBadEvents;
+
+  //! Save Veto events
+  bool m_SaveVetoEvents;
 
   //! Add a time tag to the file
   bool m_AddTimeTag;

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -109,25 +109,15 @@ class MReadOutAssembly : public MReadOutSequence
   //! Find out if the event contains strip hits in a given detector
   bool InDetector(int DetectorID);
 
-  //! Set the vetoed flag
-  void SetVeto(bool Veto = true) { m_Veto = Veto; }
-  //! Return the veto flag
-  bool GetVeto() const { return m_Veto; }
-
-  //! Set the guard ring 0 veto flag
-  void SetGR0Veto(bool Veto = true) { m_VetoGR0 = Veto; }
-  //! Get the guard ring 0 veto flag
-  bool GetGR0Veto() const { return m_VetoGR0; }
-
-  //! Set the guard ring 1 veto flag
-  void SetGR1Veto(bool Veto = true) { m_VetoGR1 = Veto; }
-  //! Get the guard ring 1 veto flag
-  bool GetGR1Veto() const { return m_VetoGR1; }
+  //! Set the guard ring veto flag
+  void SetGuardRingVeto(bool Veto = true) { m_GuardRingVeto = Veto; }
+  //! Get the guard ring veto flag
+  bool GetGuardRingVeto() const { return m_GuardRingVeto; }
 
   //! Set the shield veto flag
-  void SetShieldVeto(bool Veto = true) { m_VetoShield = Veto; }
+  void SetShieldVeto(bool Veto = true) { m_ShieldVeto = Veto; }
   //! Get the shield veto flag
-  bool GetShieldVeto() const { return m_VetoShield; }
+  bool GetShieldVeto() const { return m_ShieldVeto; }
 
   //! Set the triggered flag
   void SetTrigger(bool Trigger = true) { m_Trigger = Trigger; }
@@ -254,6 +244,9 @@ class MReadOutAssembly : public MReadOutSequence
   //! Get the filgtered-out flag
   bool IsFilteredOut() const { return m_FilteredOut; }
 
+  //! Returns true if any of the "veto" flags have been set
+  bool IsVeto() const;
+
   //! Returns true if none of the "bad" or "incomplete" flags has been set and the event has not been filtered out or rejected
   bool IsGood() const;
   //! Returns true if any of the "bad" or "incomplete" flags has been set
@@ -338,14 +331,11 @@ class MReadOutAssembly : public MReadOutSequence
   //! Veto flag of this event
   bool m_Veto;
 
-  //! Guard ring 0 veto flag
-  bool m_VetoGR0;
-
-  //! Guard ring 1 veto flag
-  bool m_VetoGR1;
+  //! Guard ring veto flag
+  bool m_GuardRingVeto;
 
   //! Shield veto flag
-  bool m_VetoShield;
+  bool m_ShieldVeto;
 
   //! Trigger flag of this event
   bool m_Trigger;

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -328,9 +328,6 @@ class MReadOutAssembly : public MReadOutSequence
   //! Quality of this event
   double m_EventQuality;
 
-  //! Veto flag of this event
-  bool m_Veto;
-
   //! Guard ring veto flag
   bool m_GuardRingVeto;
 

--- a/src/MBinaryFlightDataParser.cxx
+++ b/src/MBinaryFlightDataParser.cxx
@@ -1242,16 +1242,16 @@ bool MBinaryFlightDataParser::ConvertToMReadOutAssemblys( dataframe * DataIn, ve
 		NewEvent->SetTime( NewTime );
 
 		if( E.TrigAndVetoInfo & 0x70 ){
-			NewEvent->SetVeto();
+			NewEvent->SetShieldVeto(); // Was ->SetVeto()
 		}
 
 		if( E.TrigAndVetoInfo & 0x10 ){
-			//had a guard ring 0 veto
-			NewEvent->SetGR0Veto(true);
+			//had a guard ring veto
+			NewEvent->SetGuardRingVeto(true);
 		}
 
 		if( E.TrigAndVetoInfo & 0x20 ){
-			NewEvent->SetGR1Veto(true);
+			NewEvent->SetGuardRingVeto(true);
 		}
 
 		if( E.TrigAndVetoInfo & 0x40 ){

--- a/src/MGUIOptionsEventSaver.cxx
+++ b/src/MGUIOptionsEventSaver.cxx
@@ -89,6 +89,10 @@ void MGUIOptionsEventSaver::Create()
   m_SaveBadEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSaveBadEvents());
   m_OptionsFrame->AddFrame(m_SaveBadEvents, LabelLayout);
 
+  m_SaveVetoEvents = new TGCheckButton(m_OptionsFrame, "Save guard ring and shield veto events (Veto)", 1);
+  m_SaveVetoEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSaveVetoEvents());
+  m_OptionsFrame->AddFrame(m_SaveVetoEvents, LabelLayout);
+
   m_AddTimeTag = new TGCheckButton(m_OptionsFrame, "Add a unique time tag", 3);
   m_AddTimeTag->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetAddTimeTag());
   m_OptionsFrame->AddFrame(m_AddTimeTag, LabelLayout);
@@ -200,6 +204,7 @@ bool MGUIOptionsEventSaver::OnApply()
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetFileName(m_FileSelector->GetFileName());
 
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetSaveBadEvents(m_SaveBadEvents->IsOn());
+  dynamic_cast<MModuleEventSaver*>(m_Module)->SetSaveVetoEvents(m_SaveVetoEvents->IsOn());
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetAddTimeTag(m_AddTimeTag->IsOn());
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetSplitFile(m_SplitFile->IsOn());
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetSplitFileTime(MTime(m_SplitFileTime->GetAsInt()));

--- a/src/MModuleEventSaver.cxx
+++ b/src/MModuleEventSaver.cxx
@@ -75,6 +75,7 @@ MModuleEventSaver::MModuleEventSaver() : MModule()
   m_InternalFileName = "";
   m_Zip = false;
   m_SaveBadEvents = true;
+  m_SaveVetoEvents = true;
   m_AddTimeTag = false;
     
   m_RoaWithADCs = true;
@@ -332,6 +333,11 @@ bool MModuleEventSaver::AnalyzeEvent(MReadOutAssembly* Event)
     if (Event->IsBad() == true) return true;
   }
 
+  if (m_SaveVetoEvents == false) {
+    if (Event->IsVeto() == true) return true;
+  }
+
+
   MFile* Choosen = 0; // Wish C++ would allow unassigned references...
   if (m_SplitFile == true) {
     MTime Current = Event->GetTime();
@@ -395,6 +401,10 @@ bool MModuleEventSaver::ReadXmlConfiguration(MXmlNode* Node)
   if (SaveBadEventsNode != 0) {
     m_SaveBadEvents = SaveBadEventsNode->GetValueAsBoolean();
   }
+  MXmlNode* SaveVetoEventsNode = Node->GetNode("SaveVetoEvents");
+  if (SaveVetoEventsNode != 0) {
+    m_SaveVetoEvents = SaveVetoEventsNode->GetValueAsBoolean();
+  }
   MXmlNode* AddTimeTagNode = Node->GetNode("AddTimeTag");
   if (AddTimeTagNode != 0) {
     m_AddTimeTag = AddTimeTagNode->GetValueAsBoolean();
@@ -456,6 +466,7 @@ MXmlNode* MModuleEventSaver::CreateXmlConfiguration()
   new MXmlNode(Node, "FileName", m_FileName);
   new MXmlNode(Node, "Mode", m_Mode);
   new MXmlNode(Node, "SaveBadEvents", m_SaveBadEvents);
+  new MXmlNode(Node, "SaveVetoEvents", m_SaveVetoEvents);
   new MXmlNode(Node, "AddTimeTag", m_AddTimeTag);
   new MXmlNode(Node, "SplitFile", m_SplitFile);
   new MXmlNode(Node, "SplitFileTime", m_SplitFileTime.GetAsSystemSeconds());

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -444,14 +444,17 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       H->IsLowVoltageStrip(m_StripMap.IsLowVoltage(StripID));
       H->SetADCUnits(ADCs);
       H->SetTAC(TACs);
-      
+
+
       // Set boolean flags based on HitType and TimingType
       H->IsGuardRing(HitType == 2);
+      if (H->IsGuardRing()) {
+        Event->SetGuardRingVeto(true); }
       H->IsNearestNeighbor(HitType == 1);
       H->HasFastTiming(TimingType == 1);
         
       Event->AddStripHit(H);
-        
+       
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<StripID<<" not found in strip map"<<endl;
       return false;

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -163,7 +163,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
       cout<<m_XmlTag<<": Error: DetID "<<DetID<<" is not in TACCal (max det ID: "<<m_TACCal.size()-1<<") - skipping event"<<endl;
       return false;
     }
-    if (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size()) {
+    if (StripID >= m_TACCal[DetID][m_SideToIndex[Side]].size() && SH->IsGuardRing()==false) {
       cout<<m_XmlTag<<": Error: StripID "<<StripID<<" on side "<<Side<<" is not in TACCal (max strip ID: "<<m_TACCal[DetID][m_SideToIndex[Side]].size()-1<<") - skipping event"<<endl;
       return false;
     }

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -119,7 +119,8 @@ void MReadOutAssembly::Clear()
   m_EventTimeUTC = 0;
   m_MJD = 0.0;
 
-  m_Veto = false;
+  m_ShieldVeto = false;
+  m_GuardRingVeto = false;
   m_Trigger = true;
 
   for (int DetectorID = 0; DetectorID <= 11; DetectorID++) {
@@ -535,6 +536,12 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
     S<<endl;
   }
 
+  if (m_GuardRingVeto == true) {
+    S<<"BD GR Veto"<<endl;
+  }
+  if (m_ShieldVeto == true) {
+    S<<"BD Shield Veto"<<endl;
+  }
 
   
   return true;
@@ -617,6 +624,16 @@ void MReadOutAssembly::StreamEvta(ostream& S)
     if (m_DepthCalibration_OutofRangeString != "") S<<" ("<<m_DepthCalibration_OutofRangeString<<")";
     S<<endl;
   }
+
+  if (m_GuardRingVeto == true) {
+    S<<"BD GR Veto"<<endl;
+  }
+  if (m_ShieldVeto == true) {
+    S<<"BD Shield Veto"<<endl;
+  }
+
+
+
 }
 
 
@@ -711,7 +728,23 @@ bool MReadOutAssembly::IsBad() const
 
   return false;
 }
-  
+ 
+
+//////////////////////////////////////////////////////////////////////////////
+
+bool MReadOutAssembly::IsVeto() const
+{
+  //! Returns true if none of the "bad" or "incomplete" falgs has been set
+
+  if (m_ShieldVeto == true) return true;
+  if (m_GuardRingVeto == true) return true;
+
+  return false;
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+
 bool MReadOutAssembly::ComputeAbsoluteTime()
 {
 


### PR DESCRIPTION
We had multiple Veto flags for shield and GR vetos:

  //! Veto flag of this event
  bool m_Veto;
  //! Guard ring 0 veto flag
  bool m_VetoGR0;
  //! Guard ring 1 veto flag
  bool m_VetoGR1;
  //! Shield veto flag
  bool m_VetoShield;
  
  I reduced this down to:
  //! Guard ring veto flag
  bool m_GuardRingVeto;
  //! Shield veto flag
  bool m_ShieldVeto;
  
 Any event with a GR hit is identified/flagged in MModuleLoaderMeasurementsHDF, and there is now an option in MModuleEventSaver to save the GR events. The ShieldVeto flag isn't currently used since we don't yet have that in the data.