### PR TITLE
Clarifying Strip Hit variable names and matching HV/LV to X and Y for unit level testing

### DIFF
--- a/include/MModuleDepthCalibration2024.h
+++ b/include/MModuleDepthCalibration2024.h
@@ -104,11 +104,11 @@ class MModuleDepthCalibration2024 : public MModule
   //! Load in the specified coefficients file
   bool LoadCoeffsFile(MString FName);
   //! Return the coefficients for a pixel
-  vector<double>* GetPixelCoeffs(int pixel_code);
+  vector<double>* GetPixelCoeffs(int PixelCode);
   //! Load the splines file
   bool LoadSplinesFile(MString FName);
   //! Get the timing FWHM noise for the specified pixel and Energy
-  double GetTimingNoiseFWHM(int pixel_code, double Energy);
+  double GetTimingNoiseFWHM(int PixelCode, double Energy);
 
 
   // private methods


### PR DESCRIPTION
The variable names for Strip Hits and derived quantities have been changed throughout for clarity. Previously, some variables still used X and Y or P and N to denote the two sides of the detector. Now HV And LV are used throughout. Additionally, the mapping from X and Y position to HV and LV strip IDs, respectively, has been swapped to match the convention used for unit level testing.