### PR TITLE
Update MModuleTACcut.cxx

### DIFF
--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -223,8 +223,18 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
         double FlagToEnDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][3];
         double FlagDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][5];
         // double TotalOffset = ShapingOffset + DisableTime + FlagToEnDelay + FlagDelay; // Changing the total Offset based on data instead
-        double TotalOffset = 3000;
-        double HardCoincidenceWindow = 600; // #TODO: Subject to change pending more analysis
+        // TotalOffset: Earliest time (in ns) after which valid timing hits can appear, start of the allowed timing window
+        constexpr double TotalOffset = 3000;
+        // TODO
+        // FIXME: Match TotalOffset with timing contributions from electronics
+        // HACK: Temporary number, rough estimate
+        // TODO(@NicoleRodriguezCavero)
+        // HardCoincidenceWindow: Width of the valid coincidence region (after TotalOffset) during which multiple strip hits are considered part of the same event
+        constexpr double HardCoincidenceWindow = 600;
+        // TODO
+        // FIXME: Coincidence window subject to change pending more analysis
+        // HACK: Temporary number, rough estimate
+        // TODO(@NicoleRodriguezCavero)
         // if ((SHTiming > TotalOffset + CoincidenceWindow) || (SHTiming < TotalOffset) || (SHTiming < MaxTAC - CoincidenceWindow)) {
         //   Passed = false;
         // } else if (HasExpos()==true) {

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -225,16 +225,10 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
         // double TotalOffset = ShapingOffset + DisableTime + FlagToEnDelay + FlagDelay; // Changing the total Offset based on data instead
         // TotalOffset: Earliest time (in ns) after which valid timing hits can appear, start of the allowed timing window
         constexpr double TotalOffset = 3000.0;
-        // TODO
-        // FIXME: Match TotalOffset with timing contributions from electronics
-        // HACK: Temporary number, rough estimate
-        // TODO(@NicoleRodriguezCavero)
+        // TODO(@NicoleRodriguezCavero): Match TotalOffset with timing contributions from electronics, temporary number is a rough estimate
         // HardCoincidenceWindow: Width of the valid coincidence region (after TotalOffset) during which multiple strip hits are considered part of the same event
         constexpr double HardCoincidenceWindow = 600.0;
-        // TODO
-        // FIXME: Coincidence window subject to change pending more analysis
-        // HACK: Temporary number, rough estimate
-        // TODO(@NicoleRodriguezCavero)
+        // TODO(@NicoleRodriguezCavero): Coincidence window subject to change pending more analysis
         // if ((SHTiming > TotalOffset + CoincidenceWindow) || (SHTiming < TotalOffset) || (SHTiming < MaxTAC - CoincidenceWindow)) {
         //   Passed = false;
         // } else if (HasExpos()==true) {

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -222,8 +222,15 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
         double DisableTime = m_TACCut[DetID][m_SideToIndex[Side]][StripID][2];
         double FlagToEnDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][3];
         double FlagDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][5];
-        double TotalOffset = ShapingOffset + DisableTime + FlagToEnDelay + FlagDelay;
-        if ((SHTiming > TotalOffset + CoincidenceWindow) || (SHTiming < TotalOffset) || (SHTiming < MaxTAC - CoincidenceWindow)) {
+        // double TotalOffset = ShapingOffset + DisableTime + FlagToEnDelay + FlagDelay; // Changing the total Offset based on data instead
+        double TotalOffset = 3000;
+        double HardCoincidenceWindow = 600; // #TODO: Subject to change pending more analysis
+        // if ((SHTiming > TotalOffset + CoincidenceWindow) || (SHTiming < TotalOffset) || (SHTiming < MaxTAC - CoincidenceWindow)) {
+        //   Passed = false;
+        // } else if (HasExpos()==true) {
+        //   m_ExpoTACcut->AddTAC(DetID, SHTiming);
+        // }
+        if ((SHTiming < TotalOffset) || (SHTiming < MaxTAC - HardCoincidenceWindow)) { //Eliminating the upper boundary condition and just using one cut based on the coincidence window
           Passed = false;
         } else if (HasExpos()==true) {
           m_ExpoTACcut->AddTAC(DetID, SHTiming);

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -224,13 +224,13 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
         double FlagDelay = m_TACCut[DetID][m_SideToIndex[Side]][StripID][5];
         // double TotalOffset = ShapingOffset + DisableTime + FlagToEnDelay + FlagDelay; // Changing the total Offset based on data instead
         // TotalOffset: Earliest time (in ns) after which valid timing hits can appear, start of the allowed timing window
-        constexpr double TotalOffset = 3000;
+        constexpr double TotalOffset = 3000.0;
         // TODO
         // FIXME: Match TotalOffset with timing contributions from electronics
         // HACK: Temporary number, rough estimate
         // TODO(@NicoleRodriguezCavero)
         // HardCoincidenceWindow: Width of the valid coincidence region (after TotalOffset) during which multiple strip hits are considered part of the same event
-        constexpr double HardCoincidenceWindow = 600;
+        constexpr double HardCoincidenceWindow = 600.0;
         // TODO
         // FIXME: Coincidence window subject to change pending more analysis
         // HACK: Temporary number, rough estimate


### PR DESCRIPTION
TACcut module now includes events with wrong fast timing due to spectator strips stopping the TAC clock early. We changed the cutoff of minimum calibrated TAC to include events between 3000 and ~3800 ns. This will allow us to cut less data from particularly higher energy sources. Currently we have hard-coded a coincidence window and the optimum one is still under revision.

Previous TACcut version TAC distribution:
<img width="532" height="331" alt="Previous TAC spectrum" src="https://github.com/user-attachments/assets/59c21964-7989-4ff6-a399-f7f93abe49b4" />
Previous TACcut version Cs-137 spectral distribution:
<img width="532" height="328" alt="Previous Cs-137 Energy spectrum" src="https://github.com/user-attachments/assets/ff14200a-6796-40e6-9cae-5433de77c6d3" />
New TACcut version TAC distribution:
<img width="545" height="344" alt="Current TAC spectrum" src="https://github.com/user-attachments/assets/689f9448-c649-4d1b-9fa7-08ace8c077e8" />
New TACcut version Cs-137 spectral distribution:
<img width="523" height="329" alt="Current Cs-137 Energy spectrum" src="https://github.com/user-attachments/assets/1bea762c-043e-4ca3-93de-e2f72e1658ec" />
