### PR TITLE
Strip Pairing Chi Square Algorithm Updated

### DIFF
--- a/include/MGUIExpoStripPairingHits.h
+++ b/include/MGUIExpoStripPairingHits.h
@@ -1,0 +1,97 @@
+/*
+ * MGUIExpoStripPairingHits.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIExpoStripPairingHits__
+#define __MGUIExpoStripPairingHits__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TString.h>
+#include <TGClient.h>
+#include <TRootEmbeddedCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+
+// NuSTAR libs
+#include "MGUIExpo.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIExpoStripPairingHits : public MGUIExpo
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIExpoStripPairingHits(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIExpoStripPairingHits();
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  //! Update the frame
+  virtual void Update();
+
+  //! Reset the data in the UI
+  virtual void Reset();
+
+  //! Export the data in the UI
+  virtual void Export(const MString& FileName);
+
+  //! Set the hits histogram parameters 
+  void SetHitsHistogramParameters(int NBins, double Min, double Max);
+
+  //! Add data to the hits histogram
+  void AddHits(int NHits);
+
+  // protected methods:
+ protected:
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+  //! Hits canvas
+  TRootEmbeddedCanvas* m_HitsCanvas;
+  //! Hits histogram
+  TH1D* m_Hits;
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIExpoStripPairingHits, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MGUIExpoStripPairingStripHits.h
+++ b/include/MGUIExpoStripPairingStripHits.h
@@ -1,0 +1,98 @@
+/*
+ * MGUIExpoStripPairingStripHits.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIExpoStripPairingStripHits__
+#define __MGUIExpoStripPairingStripHits__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TString.h>
+#include <TGClient.h>
+#include <TRootEmbeddedCanvas.h>
+#include <TH1.h>
+#include <TH2.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+
+// NuSTAR libs
+#include "MGUIExpo.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIExpoStripPairingStripHits : public MGUIExpo
+{
+  // public Session:
+ public:
+  //! Default constructor
+  MGUIExpoStripPairingStripHits(MModule* Module);
+  //! Default destructor
+  virtual ~MGUIExpoStripPairingStripHits();
+
+  //! The creation part which gets overwritten
+  virtual void Create();
+
+  //! Update the frame
+  virtual void Update();
+
+  //! Reset the data in the UI
+  virtual void Reset();
+
+  //! Export the data in the UI
+  virtual void Export(const MString& FileName);
+
+  //! Set the energy histogram parameters 
+  void SetStripHitsHistogramParameters(int NBins, double Min, double Max);
+
+  //! Add data to the energy histogram
+  void AddStripHits(double LVStripHits, double HVStripHits);
+
+  // protected methods:
+ protected:
+
+
+  // protected members:
+ protected:
+
+  // private members:
+ private:
+  //! Energy canvas
+  TRootEmbeddedCanvas* m_StripHitsCanvas;
+  //! Energy histogram
+  TH2D* m_StripHits;
+
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIExpoStripPairingStripHits, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MGUIOptionsEventFilter.h
+++ b/include/MGUIOptionsEventFilter.h
@@ -80,7 +80,7 @@ class MGUIOptionsEventFilter : public MGUIOptions
   MGUIEMinMaxEntry* m_Hits;
     
   //! Reduced Chi Square Selection
-  MGUIEMinMaxEntry* m_RedChiSquareWindow;
+  MGUIEMinMaxEntry* m_ReducedChiSquareWindow;
 
   // private members:
  private:

--- a/include/MGUIOptionsEventFilter.h
+++ b/include/MGUIOptionsEventFilter.h
@@ -78,6 +78,9 @@ class MGUIOptionsEventFilter : public MGUIOptions
 
   //! The number of hits
   MGUIEMinMaxEntry* m_Hits;
+    
+  //! Reduced Chi Square Selection
+  MGUIEMinMaxEntry* m_RedChiSquareWindow;
 
   // private members:
  private:

--- a/include/MHit.h
+++ b/include/MHit.h
@@ -179,8 +179,9 @@ class MHit
 	//! Flag: possible charge loss
 	bool m_PossibleChargeLoss;
 
-	//! true if hit contains strip that was hit multiple times
+	//! true if hit contains strip that was hit multiple times on X
 	bool m_StripHitMultipleTimesX;
+    //! true if hit contains strip that was hit multiple times on Y
 	bool m_StripHitMultipleTimesY;
 
 	//! true if hit contains charge sharing

--- a/include/MHit.h
+++ b/include/MHit.h
@@ -179,9 +179,9 @@ class MHit
 	bool m_PossibleChargeLoss;
 
 	//! true if hit contains strip that was hit multiple times on X
-	bool m_StripHitMultipleTimesX;
+	bool m_StripHitMultipleTimesX = false;
     //! true if hit contains strip that was hit multiple times on Y
-	bool m_StripHitMultipleTimesY;
+	bool m_StripHitMultipleTimesY = false;
 
 	//! true if hit contains charge sharing
 	bool m_ChargeSharing;

--- a/include/MHit.h
+++ b/include/MHit.h
@@ -57,6 +57,16 @@ class MHit
   void SetEnergy(double Energy) { m_Energy = Energy; }
   //! Return the energy
   double GetEnergy() const { return m_Energy; }
+    
+    //! Set the LVenergy
+    void SetLVEnergy(double LVEnergy) { m_LVEnergy = LVEnergy; }
+    //! Return the LVenergy
+    double GetLVEnergy() const { return m_LVEnergy; }
+
+    //! Set the HVenergy
+    void SetHVEnergy(double HVEnergy) { m_HVEnergy = HVEnergy; }
+    //! Return the HVenergy
+    double GetHVEnergy() const { return m_HVEnergy; }
 
   //! Set the energy resolution
   void SetEnergyResolution(double EnergyResolution) { m_EnergyResolution = EnergyResolution; }
@@ -97,7 +107,7 @@ class MHit
 	void SetStripHitMultipleTimesY(bool stripHitMultipleTimesY) {m_StripHitMultipleTimesY = stripHitMultipleTimesY;}
 	//! get m_StripHitMultipleTimesY
 	bool GetStripHitMultipleTimesY() const { return m_StripHitMultipleTimesY; }
-
+// the above is defined in multiple places. I should change this.
 
 	//! set charge sharing flag
 	void SetChargeSharing(bool chargeSharing) {m_ChargeSharing = chargeSharing; }
@@ -148,6 +158,13 @@ class MHit
 
   //! Energy of the hit
   double m_Energy;
+    
+  //! LV Energy of the hit
+  double m_LVEnergy;
+    
+  //! HV Energy of the hit
+  double m_HVEnergy;
+    
   //! Energy resolution of the hit
   double m_EnergyResolution;
 

--- a/include/MHit.h
+++ b/include/MHit.h
@@ -107,7 +107,6 @@ class MHit
 	void SetStripHitMultipleTimesY(bool stripHitMultipleTimesY) {m_StripHitMultipleTimesY = stripHitMultipleTimesY;}
 	//! get m_StripHitMultipleTimesY
 	bool GetStripHitMultipleTimesY() const { return m_StripHitMultipleTimesY; }
-// the above is defined in multiple places. I should change this.
 
 	//! set charge sharing flag
 	void SetChargeSharing(bool chargeSharing) {m_ChargeSharing = chargeSharing; }

--- a/include/MModuleEventFilter.h
+++ b/include/MModuleEventFilter.h
@@ -108,6 +108,17 @@ class MModuleEventFilter : public MModule
   void SetMaximumHits(double MaximumHits) { m_MaximumHits = MaximumHits; }
   //! Get the maximum number of hits
   double GetMaximumHits() const { return m_MaximumHits; }
+    
+    //! Set the maximum Red Chi Square
+    void SetMaximumRedChiSquare(double MaximumRedChiSquare) { m_MaximumRedChiSquare = MaximumRedChiSquare; }
+    //! Get the maximum Red Chi Square
+    double GetMaximumRedChiSquare() const { return m_MaximumRedChiSquare; }
+    
+    //! Set the minimum Red Chi Square
+    void SetMinimumRedChiSquare(double MinimumRedChiSquare) { m_MinimumRedChiSquare = MinimumRedChiSquare; }
+    //! Get the minimum Red Chi Square
+    double GetMinimumRedChiSquare() const { return m_MinimumRedChiSquare; }
+
 
   // protected methods:
  protected:
@@ -143,6 +154,10 @@ class MModuleEventFilter : public MModule
   unsigned int m_MinimumHits;
   //! The maximum number of hits
   unsigned int m_MaximumHits;
+    
+  //! Minimum and maximum reduced chi square (as calculated in strip pairing code)
+  double m_MinimumRedChiSquare;
+  double m_MaximumRedChiSquare;
 
   
 #ifdef ___CLING___

--- a/include/MModuleEventFilter.h
+++ b/include/MModuleEventFilter.h
@@ -155,8 +155,10 @@ class MModuleEventFilter : public MModule
   //! The maximum number of hits
   unsigned int m_MaximumHits;
     
-  //! Minimum and maximum reduced chi square (as calculated in strip pairing code)
+  //! Minimum reduced chi square (as calculated in strip pairing code)
   double m_MinimumRedChiSquare;
+    
+  //! Maximum reduced chi square (as calculated in strip pairing code)
   double m_MaximumRedChiSquare;
 
   

--- a/include/MModuleEventFilter.h
+++ b/include/MModuleEventFilter.h
@@ -109,15 +109,15 @@ class MModuleEventFilter : public MModule
   //! Get the maximum number of hits
   double GetMaximumHits() const { return m_MaximumHits; }
     
-    //! Set the maximum Red Chi Square
-    void SetMaximumRedChiSquare(double MaximumRedChiSquare) { m_MaximumRedChiSquare = MaximumRedChiSquare; }
-    //! Get the maximum Red Chi Square
-    double GetMaximumRedChiSquare() const { return m_MaximumRedChiSquare; }
+    //! Set the maximum Reduced Chi Square
+    void SetMaximumReducedChiSquare(double MaximumReducedChiSquare) { m_MaximumReducedChiSquare = MaximumReducedChiSquare; }
+    //! Get the maximum Reduced Chi Square
+    double GetMaximumReducedChiSquare() const { return m_MaximumReducedChiSquare; }
     
-    //! Set the minimum Red Chi Square
-    void SetMinimumRedChiSquare(double MinimumRedChiSquare) { m_MinimumRedChiSquare = MinimumRedChiSquare; }
-    //! Get the minimum Red Chi Square
-    double GetMinimumRedChiSquare() const { return m_MinimumRedChiSquare; }
+    //! Set the minimum Reduced Chi Square
+    void SetMinimumReducedChiSquare(double MinimumReducedChiSquare) { m_MinimumReducedChiSquare = MinimumReducedChiSquare; }
+    //! Get the minimum Reduced Chi Square
+    double GetMinimumReducedChiSquare() const { return m_MinimumReducedChiSquare; }
 
 
   // protected methods:
@@ -156,10 +156,10 @@ class MModuleEventFilter : public MModule
   unsigned int m_MaximumHits;
     
   //! Minimum reduced chi square (as calculated in strip pairing code)
-  double m_MinimumRedChiSquare;
+  double m_MinimumReducedChiSquare;
     
   //! Maximum reduced chi square (as calculated in strip pairing code)
-  double m_MaximumRedChiSquare;
+  double m_MaximumReducedChiSquare;
 
   
 #ifdef ___CLING___

--- a/include/MModuleStripPairingChiSquare.h
+++ b/include/MModuleStripPairingChiSquare.h
@@ -31,6 +31,8 @@
 #include "MModule.h"
 #include "MStripHit.h"
 #include "MGUIExpoStripPairing.h"
+#include "MGUIExpoStripPairingHits.h"
+#include "MGUIExpoStripPairingStripHits.h"
 
 // Forward declarations:
 
@@ -84,7 +86,8 @@ class MModuleStripPairingChiSquare : public MModule
  protected:
   //! The display of debugging data
   MGUIExpoStripPairing* m_ExpoStripPairing;
-
+  MGUIExpoStripPairingHits* m_ExpoStripPairingHits;
+  MGUIExpoStripPairingStripHits* m_ExpoStripPairingStripHits;
 
   // private members:
  private:

--- a/include/MModuleStripPairingChiSquareUpdated.h
+++ b/include/MModuleStripPairingChiSquareUpdated.h
@@ -1,0 +1,130 @@
+/*
+ * MModuleStripPairingChiSquareUpdated.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MModuleStripPairingChiSquareUpdated__
+#define __MModuleStripPairingChiSquareUpdated__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Standard libs:
+#include<iostream>
+#include<vector>
+#include<cmath>
+#include<algorithm>
+#include<map>
+#include<limits>
+#include <numeric>
+
+// ROOT libs:
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MModule.h"
+#include "MStripHit.h"
+#include "MGUIExpoStripPairing.h"
+#include "MGUIExpoStripPairingHits.h"
+#include "MGUIExpoStripPairingStripHits.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MModuleStripPairingChiSquareUpdated : public MModule
+{
+  // public interface:
+ public:
+  //! Default constructor
+  MModuleStripPairingChiSquareUpdated();
+  //! Default destructor
+  virtual ~MModuleStripPairingChiSquareUpdated();
+  
+  //! Create a new object of this class 
+  virtual MModuleStripPairingChiSquareUpdated* Clone() { return new MModuleStripPairingChiSquareUpdated(); }
+
+  //! Create the expos
+  virtual void CreateExpos();
+
+  //! Initialize the module
+  virtual bool Initialize();
+
+  //! Finalize the module
+  virtual void Finalize();
+
+  //! Main data analysis routine, which updates the event to a new level 
+  virtual bool AnalyzeEvent(MReadOutAssembly* Event);
+
+  //! Show the options GUI
+  virtual void ShowOptionsGUI();
+
+  //! Read the configuration data from an XML node
+  virtual bool ReadXmlConfiguration(MXmlNode* Node);
+  //! Create an XML node tree from the configuration
+  virtual MXmlNode* CreateXmlConfiguration();
+
+  // protected methods:
+ protected:
+  // Find a new set of combinations giving the existing gone
+    vector<vector<vector<unsigned int>>> FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo);
+    
+  // Function to apply charge trapping correction
+    float ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits);
+    
+  // Divide an event's strip hits by detector and LV/HV side
+    vector<vector<vector<MStripHit*>>> CollectStripHits(MReadOutAssembly* Event);
+
+  // Read in strip hits on each side for each detector and perform quality selections
+    bool EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits);
+    
+  // Find all strip combinations for each detector on LV and HV sides given seed combinations
+    vector<vector<vector<vector<vector<unsigned int>>>>> FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo);
+
+  // Evaluate the reduced chi square for all possible strip pairings
+    tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits);
+  // Create hits
+    bool CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo);
+    
+    //! Return the order of indices resulting from sorting a vector
+    vector<size_t> Argsort(vector<double> &list);
+
+  // private methods:
+ private:
+
+
+
+  // protected members:
+ protected:
+  //! The display of debugging data
+  MGUIExpoStripPairing* m_ExpoStripPairing;
+  MGUIExpoStripPairingHits* m_ExpoStripPairingHits;
+  MGUIExpoStripPairingStripHits* m_ExpoStripPairingStripHits;
+
+
+  // private members:
+ private:
+
+
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MModuleStripPairingChiSquareUpdated, 0) // no description
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MModuleStripPairingMultiRoundChiSquare.h
+++ b/include/MModuleStripPairingMultiRoundChiSquare.h
@@ -75,24 +75,24 @@ class MModuleStripPairingMultiRoundChiSquare : public MModule
 
   // protected methods:
  protected:
-  // Find a new set of combinations giving the existing gone
+  //! Find a new set of combinations giving the existing gone
     vector<vector<vector<unsigned int>>> FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo);
     
-  // Function to apply charge trapping correction
+  //! Function to apply charge trapping correction
     float ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits);
     
-  // Divide an event's strip hits by detector and LV/HV side
+  //! Divide an event's strip hits by detector and LV/HV side
     vector<vector<vector<MStripHit*>>> CollectStripHits(MReadOutAssembly* Event);
 
-  // Read in strip hits on each side for each detector and perform quality selections
+  //! Read in strip hits on each side for each detector and perform quality selections
     bool EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits);
     
-  // Find all strip combinations for each detector on LV and HV sides given seed combinations
+  //! Find all strip combinations for each detector on LV and HV sides given seed combinations
     vector<vector<vector<vector<vector<unsigned int>>>>> FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo);
 
-  // Evaluate the reduced chi square for all possible strip pairings
+  //! Evaluate the reduced chi square for all possible strip pairings
     tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits);
-  // Create hits
+  //! Create hits
     bool CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo);
     
     //! Return the order of indices resulting from sorting a vector

--- a/include/MModuleStripPairingMultiRoundChiSquare.h
+++ b/include/MModuleStripPairingMultiRoundChiSquare.h
@@ -1,7 +1,7 @@
 /*
- * MModuleStripPairingChiSquareUpdated.h
+ * MModuleStripPairingMultiRoundChiSquare.h
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Julian Gerber & Andreas Zoglauer.
  * All rights reserved.
  *
  * Please see the source-file for the copyright-notice.
@@ -9,8 +9,8 @@
  */
 
 
-#ifndef __MModuleStripPairingChiSquareUpdated__
-#define __MModuleStripPairingChiSquareUpdated__
+#ifndef __MModuleStripPairingMultiRoundChiSquare__
+#define __MModuleStripPairingMultiRoundChiSquare__
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -41,17 +41,17 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 
-class MModuleStripPairingChiSquareUpdated : public MModule
+class MModuleStripPairingMultiRoundChiSquare : public MModule
 {
   // public interface:
  public:
   //! Default constructor
-  MModuleStripPairingChiSquareUpdated();
+    MModuleStripPairingMultiRoundChiSquare();
   //! Default destructor
-  virtual ~MModuleStripPairingChiSquareUpdated();
+  virtual ~MModuleStripPairingMultiRoundChiSquare();
   
   //! Create a new object of this class 
-  virtual MModuleStripPairingChiSquareUpdated* Clone() { return new MModuleStripPairingChiSquareUpdated(); }
+  virtual MModuleStripPairingMultiRoundChiSquare* Clone() { return new MModuleStripPairingMultiRoundChiSquare(); }
 
   //! Create the expos
   virtual void CreateExpos();
@@ -119,7 +119,7 @@ class MModuleStripPairingChiSquareUpdated : public MModule
 
 #ifdef ___CLING___
  public:
-  ClassDef(MModuleStripPairingChiSquareUpdated, 0) // no description
+  ClassDef(MModuleStripPairingMultiRoundChiSquare, 0) // no description
 #endif
 
 };

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -322,10 +322,10 @@ class MReadOutAssembly : public MReadOutSequence
   //! Get the MTime corresponding to absolute UTC time
   MTime GetAbsoluteTime() const {return m_EventTimeUTC; }
 
-  //! Set the Red. Chi^2
-  void SetRedChiSquare(double RedChiSquare) { m_RedChiSquare = RedChiSquare; }
-  //! Return the Red. Chi^2
-  double GetRedChiSquare() const { return m_RedChiSquare; }
+  //! Set the Reduced Chi^2
+  void SetReducedChiSquare(double ReducedChiSquare) { m_ReducedChiSquare = ReducedChiSquare; }
+  //! Return the Reduced Chi^2
+  double GetReducedChiSquare() const { return m_ReducedChiSquare; }
     
   //! Set flag for multiple hits on a single strip on LV side
   void SetMultipleHitsOnLVStrip(bool MultipleHitsOnLV) { m_MultipleHitsOnLVStrip = MultipleHitsOnLV; }
@@ -429,7 +429,7 @@ class MReadOutAssembly : public MReadOutSequence
   MPhysicalEvent* m_PhysicalEvent;
     
   //! Reduced Chi^2 of the Strip Paired Event
-  double m_RedChiSquare;
+  double m_ReducedChiSquare;
 
   // Flags indicating the quality of the event
   bool m_AspectIncomplete;

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -326,12 +326,6 @@ class MReadOutAssembly : public MReadOutSequence
   void SetReducedChiSquare(double ReducedChiSquare) { m_ReducedChiSquare = ReducedChiSquare; }
   //! Return the Reduced Chi^2
   double GetReducedChiSquare() const { return m_ReducedChiSquare; }
-    
-  //! Set flag for multiple hits on a single strip on LV side
-  void SetMultipleHitsOnLVStrip(bool MultipleHitsOnLV) { m_MultipleHitsOnLVStrip = MultipleHitsOnLV; }
-  //! Set flag for multiple hits on a single strip on HV side
-  void SetMultipleHitsOnHVStrip(bool MultipleHitsOnHV) { m_MultipleHitsOnHVStrip = MultipleHitsOnHV; }
-
 
   // protected methods:
  protected:
@@ -451,10 +445,6 @@ class MReadOutAssembly : public MReadOutSequence
   bool m_DepthCalibration_OutofRange;
   MString m_DepthCalibration_OutofRangeString;
   
-  // Flags for multiple hits on a single strip
-  bool m_MultipleHitsOnLVStrip;
-  bool m_MultipleHitsOnHVStrip;
-
 
 
   //! True if event has been filtered out

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -327,8 +327,9 @@ class MReadOutAssembly : public MReadOutSequence
   //! Return the Red. Chi^2
   double GetRedChiSquare() const { return m_RedChiSquare; }
     
-  //Set flags for multiple hits on a single strip
+  //! Set flag for multiple hits on a single strip on LV side
   void SetMultipleHitsOnLVStrip(bool MultipleHitsOnLV) { m_MultipleHitsOnLVStrip = MultipleHitsOnLV; }
+  //! Set flag for multiple hits on a single strip on HV side
   void SetMultipleHitsOnHVStrip(bool MultipleHitsOnHV) { m_MultipleHitsOnHVStrip = MultipleHitsOnHV; }
 
 

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -322,6 +322,15 @@ class MReadOutAssembly : public MReadOutSequence
   //! Get the MTime corresponding to absolute UTC time
   MTime GetAbsoluteTime() const {return m_EventTimeUTC; }
 
+  //! Set the Red. Chi^2
+  void SetRedChiSquare(double RedChiSquare) { m_RedChiSquare = RedChiSquare; }
+  //! Return the Red. Chi^2
+  double GetRedChiSquare() const { return m_RedChiSquare; }
+    
+  //Set flags for multiple hits on a single strip
+  void SetMultipleHitsOnLVStrip(bool MultipleHitsOnLV) { m_MultipleHitsOnLVStrip = MultipleHitsOnLV; }
+  void SetMultipleHitsOnHVStrip(bool MultipleHitsOnHV) { m_MultipleHitsOnHVStrip = MultipleHitsOnHV; }
+
 
   // protected methods:
  protected:
@@ -416,7 +425,10 @@ class MReadOutAssembly : public MReadOutSequence
   list<MDEECrystalHit> m_DEECrystalHits;
 
   //! The physical event from event reconstruction
-  MPhysicalEvent* m_PhysicalEvent; 
+  MPhysicalEvent* m_PhysicalEvent;
+    
+  //! Reduced Chi^2 of the Strip Paired Event
+  double m_RedChiSquare;
 
   // Flags indicating the quality of the event
   bool m_AspectIncomplete;
@@ -436,7 +448,11 @@ class MReadOutAssembly : public MReadOutSequence
   bool m_DepthCalibrationIncomplete;
   MString m_DepthCalibrationIncompleteString;
   bool m_DepthCalibration_OutofRange;
-  MString m_DepthCalibration_OutofRangeString;  
+  MString m_DepthCalibration_OutofRangeString;
+  
+  // Flags for multiple hits on a single strip
+  bool m_MultipleHitsOnLVStrip;
+  bool m_MultipleHitsOnHVStrip;
 
 
 

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -68,7 +68,7 @@ using namespace std;
 #include "MModuleDepthCalibrationB.h"
 #include "MModuleDepthCalibration2024.h"
 #include "MModuleStripPairingGreedy.h"
-#include "MModuleStripPairingChiSquareUpdated.h"
+#include "MModuleStripPairingMultiRoundChiSquare.h"
 #include "MModuleStripPairingChiSquare.h"
 #include "MModuleEventFilter.h"
 #include "MModuleEventSaver.h"
@@ -125,7 +125,7 @@ MAssembly::MAssembly()
   m_Supervisor->AddAvailableModule(new MModuleEnergyCalibrationUniversal());
 
   m_Supervisor->AddAvailableModule(new MModuleStripPairingGreedy());
-  m_Supervisor->AddAvailableModule(new MModuleStripPairingChiSquareUpdated());
+  m_Supervisor->AddAvailableModule(new MModuleStripPairingMultiRoundChiSquare());
   m_Supervisor->AddAvailableModule(new MModuleStripPairingChiSquare());
   m_Supervisor->AddAvailableModule(new MModuleDepthCalibration());
   m_Supervisor->AddAvailableModule(new MModuleDepthCalibrationB());

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -68,6 +68,7 @@ using namespace std;
 #include "MModuleDepthCalibrationB.h"
 #include "MModuleDepthCalibration2024.h"
 #include "MModuleStripPairingGreedy.h"
+#include "MModuleStripPairingChiSquareUpdated.h"
 #include "MModuleStripPairingChiSquare.h"
 #include "MModuleEventFilter.h"
 #include "MModuleEventSaver.h"
@@ -77,6 +78,7 @@ using namespace std;
 #include "MModuleDiagnostics.h"
 #include "MModuleDiagnosticsEnergyPerStrip.h"
 #include "MModuleDEESMEX.h"
+
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -123,6 +125,7 @@ MAssembly::MAssembly()
   m_Supervisor->AddAvailableModule(new MModuleEnergyCalibrationUniversal());
 
   m_Supervisor->AddAvailableModule(new MModuleStripPairingGreedy());
+  m_Supervisor->AddAvailableModule(new MModuleStripPairingChiSquareUpdated());
   m_Supervisor->AddAvailableModule(new MModuleStripPairingChiSquare());
   m_Supervisor->AddAvailableModule(new MModuleDepthCalibration());
   m_Supervisor->AddAvailableModule(new MModuleDepthCalibrationB());

--- a/src/MGUIExpoStripPairingStripHits.cxx
+++ b/src/MGUIExpoStripPairingStripHits.cxx
@@ -1,5 +1,5 @@
 /*
- * MGUIExpoStripPairing.cxx
+ * MGUIExpoStripPairingStripHits.cxx
  *
  *
  * Copyright (C) by Andreas Zoglauer.
@@ -17,7 +17,7 @@
 
 
 // Include the header:
-#include "MGUIExpoStripPairing.h"
+#include "MGUIExpoStripPairingStripHits.h"
 
 // Standard libs:
 
@@ -37,28 +37,28 @@
 
 
 #ifdef ___CLING___
-ClassImp(MGUIExpoStripPairing)
+ClassImp(MGUIExpoStripPairingStripHits)
 #endif
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MGUIExpoStripPairing::MGUIExpoStripPairing(MModule* Module) : MGUIExpo(Module)
+MGUIExpoStripPairingStripHits::MGUIExpoStripPairingStripHits(MModule* Module) : MGUIExpo(Module)
 {
   // standard constructor
 
   // Set the new title of the tab here:
-  m_TabTitle = "Strip Pairing Energies";
+  m_TabTitle = "Strip Pairing StripHits";
 
   // Add all histograms and canvases below
-  m_Energies = new TH2D("", "Strip pairing: energy distribution LV vs. HV side", 1000, 0, 1000, 1000, 0, 1000);
-  m_Energies->SetXTitle("Energy LV Side [keV]");
-  m_Energies->SetYTitle("Energy HV Side [keV]");
-  m_Energies->SetZTitle("counts");
-  m_Energies->SetFillColor(kAzure+7);
+  m_StripHits = new TH2D("", "Strip pairing: Strip Hit distribution LV vs. HV side", 10, 0.5, 10.5, 10, 0.5, 10.5);
+  m_StripHits->SetXTitle("Strip Hits LV Side");
+  m_StripHits->SetYTitle("Strip Hits HV Side");
+  m_StripHits->SetZTitle("Hits");
+  m_StripHits->SetFillColor(kAzure+7);
 
-  m_EnergiesCanvas = 0;
+  m_StripHitsCanvas = 0;
 
   // use hierarchical cleaning
   SetCleanup(kDeepCleanup);
@@ -68,7 +68,7 @@ MGUIExpoStripPairing::MGUIExpoStripPairing(MModule* Module) : MGUIExpo(Module)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MGUIExpoStripPairing::~MGUIExpoStripPairing()
+MGUIExpoStripPairingStripHits::~MGUIExpoStripPairingStripHits()
 {
   // kDeepCleanup is activated 
 }
@@ -77,13 +77,13 @@ MGUIExpoStripPairing::~MGUIExpoStripPairing()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoStripPairing::Reset()
+void MGUIExpoStripPairingStripHits::Reset()
 {
   //! Reset the data in the UI
 
   m_Mutex.Lock();
   
-  m_Energies->Reset();
+  m_StripHits->Reset();
   
   m_Mutex.UnLock();
 }
@@ -92,13 +92,13 @@ void MGUIExpoStripPairing::Reset()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoStripPairing::SetEnergiesHistogramParameters(int NBins, double Min, double Max)
+void MGUIExpoStripPairingStripHits::SetStripHitsHistogramParameters(int NBins, double Min, double Max)
 {
   // Set the energy histogram parameters 
 
   m_Mutex.Lock();
   
-  m_Energies->SetBins(NBins, Min, Max, NBins, Min, Max);
+  m_StripHits->SetBins(NBins, Min, Max, NBins, Min, Max);
   
   m_Mutex.UnLock();
 }
@@ -107,13 +107,13 @@ void MGUIExpoStripPairing::SetEnergiesHistogramParameters(int NBins, double Min,
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoStripPairing::AddEnergies(double pEnergy, double nEnergy)
+void MGUIExpoStripPairingStripHits::AddStripHits(double LVStripHits, double HVStripHits)
 {
   // Add data to the energy histogram
 
   m_Mutex.Lock();
   
-  m_Energies->Fill(pEnergy, nEnergy);
+  m_StripHits->Fill(LVStripHits, HVStripHits);
   
   m_Mutex.UnLock();
 }
@@ -122,7 +122,7 @@ void MGUIExpoStripPairing::AddEnergies(double pEnergy, double nEnergy)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoStripPairing::Create()
+void MGUIExpoStripPairingStripHits::Create()
 {
   // Add the GUI options here
   
@@ -138,14 +138,14 @@ void MGUIExpoStripPairing::Create()
   AddFrame(HFrame, CanvasLayout);
 
   
-  m_EnergiesCanvas = new TRootEmbeddedCanvas("Energies", HFrame, 100, 100);
-  HFrame->AddFrame(m_EnergiesCanvas, CanvasLayout);
+  m_StripHitsCanvas = new TRootEmbeddedCanvas("StripHits", HFrame, 100, 100);
+  HFrame->AddFrame(m_StripHitsCanvas, CanvasLayout);
 
-  m_EnergiesCanvas->GetCanvas()->cd();
-  m_EnergiesCanvas->GetCanvas()->SetGridy();
-  m_EnergiesCanvas->GetCanvas()->SetGridx();
-  m_Energies->Draw("colz");
-  m_EnergiesCanvas->GetCanvas()->Update();
+  m_StripHitsCanvas->GetCanvas()->cd();
+  m_StripHitsCanvas->GetCanvas()->SetGridy();
+  m_StripHitsCanvas->GetCanvas()->SetGridx();
+  m_StripHits->Draw("colz");
+  m_StripHitsCanvas->GetCanvas()->Update();
   
   m_IsCreated = true;
   
@@ -156,15 +156,15 @@ void MGUIExpoStripPairing::Create()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoStripPairing::Update()
+void MGUIExpoStripPairingStripHits::Update()
 {
   //! Update the frame
 
   m_Mutex.Lock();
   
-  if (m_EnergiesCanvas != 0) {
-    m_EnergiesCanvas->GetCanvas()->Modified();
-    m_EnergiesCanvas->GetCanvas()->Update();
+  if (m_StripHitsCanvas != 0) {
+    m_StripHitsCanvas->GetCanvas()->Modified();
+    m_StripHitsCanvas->GetCanvas()->Update();
   }
   
   m_Mutex.UnLock();
@@ -174,17 +174,17 @@ void MGUIExpoStripPairing::Update()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MGUIExpoStripPairing::Export(const MString& FileName)
+void MGUIExpoStripPairingStripHits::Export(const MString& FileName)
 {
   // Add data to the energy histogram
 
   m_Mutex.Lock();
   
-  m_EnergiesCanvas->GetCanvas()->SaveAs(FileName);
+  m_StripHitsCanvas->GetCanvas()->SaveAs(FileName);
   
   m_Mutex.UnLock();
 }
 
 
-// MGUIExpoStripPairing: the end...
+// MGUIExpoStripPairingStripHits: the end...
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/MGUIOptionsEventFilter.cxx
+++ b/src/MGUIOptionsEventFilter.cxx
@@ -125,6 +125,20 @@ void MGUIOptionsEventFilter::Create()
                                 dynamic_cast<MModuleEventFilter*>(m_Module)->GetMaximumHits(),
                                 true, 0.0);
   m_OptionsFrame->AddFrame(m_Hits, SecondariesLayout);
+    
+  TGLabel* RedChiSquareLabel = new TGLabel(m_OptionsFrame,
+      "Reduced Chi Squared Window (as calculated in strip pairing)\n"
+      "This requires that Strip Pairing has been done.");
+    m_OptionsFrame->AddFrame(RedChiSquareLabel, FirstLayout);
+
+    m_RedChiSquareWindow = new MGUIEMinMaxEntry(m_OptionsFrame,
+                                  "Choose the minimum and maximum Reduced Chi Square (inclusive):",
+                                  false,
+                                  dynamic_cast<MModuleEventFilter*>(m_Module)->GetMinimumRedChiSquare(),
+                                  dynamic_cast<MModuleEventFilter*>(m_Module)->GetMaximumRedChiSquare(),
+                                  true, 0.0);
+    m_OptionsFrame->AddFrame(m_RedChiSquareWindow, SecondariesLayout);
+    
 
   PostCreate();
 }
@@ -179,6 +193,9 @@ bool MGUIOptionsEventFilter::OnApply()
 
   dynamic_cast<MModuleEventFilter*>(m_Module)->SetMinimumHits(m_Hits->GetMinValue());
   dynamic_cast<MModuleEventFilter*>(m_Module)->SetMaximumHits(m_Hits->GetMaxValue());
+    
+  dynamic_cast<MModuleEventFilter*>(m_Module)->SetMinimumRedChiSquare(m_RedChiSquareWindow->GetMinValue());
+  dynamic_cast<MModuleEventFilter*>(m_Module)->SetMaximumRedChiSquare(m_RedChiSquareWindow->GetMaxValue());
 
   return true;
 }

--- a/src/MGUIOptionsEventFilter.cxx
+++ b/src/MGUIOptionsEventFilter.cxx
@@ -126,18 +126,18 @@ void MGUIOptionsEventFilter::Create()
                                 true, 0.0);
   m_OptionsFrame->AddFrame(m_Hits, SecondariesLayout);
     
-  TGLabel* RedChiSquareLabel = new TGLabel(m_OptionsFrame,
+  TGLabel* ReducedChiSquareLabel = new TGLabel(m_OptionsFrame,
       "Reduced Chi Squared Window (as calculated in strip pairing)\n"
       "This requires that Strip Pairing has been done.");
-    m_OptionsFrame->AddFrame(RedChiSquareLabel, FirstLayout);
+    m_OptionsFrame->AddFrame(ReducedChiSquareLabel, FirstLayout);
 
-    m_RedChiSquareWindow = new MGUIEMinMaxEntry(m_OptionsFrame,
+    m_ReducedChiSquareWindow = new MGUIEMinMaxEntry(m_OptionsFrame,
                                   "Choose the minimum and maximum Reduced Chi Square (inclusive):",
                                   false,
-                                  dynamic_cast<MModuleEventFilter*>(m_Module)->GetMinimumRedChiSquare(),
-                                  dynamic_cast<MModuleEventFilter*>(m_Module)->GetMaximumRedChiSquare(),
+                                  dynamic_cast<MModuleEventFilter*>(m_Module)->GetMinimumReducedChiSquare(),
+                                  dynamic_cast<MModuleEventFilter*>(m_Module)->GetMaximumReducedChiSquare(),
                                   true, 0.0);
-    m_OptionsFrame->AddFrame(m_RedChiSquareWindow, SecondariesLayout);
+    m_OptionsFrame->AddFrame(m_ReducedChiSquareWindow, SecondariesLayout);
     
 
   PostCreate();
@@ -194,8 +194,8 @@ bool MGUIOptionsEventFilter::OnApply()
   dynamic_cast<MModuleEventFilter*>(m_Module)->SetMinimumHits(m_Hits->GetMinValue());
   dynamic_cast<MModuleEventFilter*>(m_Module)->SetMaximumHits(m_Hits->GetMaxValue());
     
-  dynamic_cast<MModuleEventFilter*>(m_Module)->SetMinimumRedChiSquare(m_RedChiSquareWindow->GetMinValue());
-  dynamic_cast<MModuleEventFilter*>(m_Module)->SetMaximumRedChiSquare(m_RedChiSquareWindow->GetMaxValue());
+  dynamic_cast<MModuleEventFilter*>(m_Module)->SetMinimumReducedChiSquare(m_ReducedChiSquareWindow->GetMinValue());
+  dynamic_cast<MModuleEventFilter*>(m_Module)->SetMaximumReducedChiSquare(m_ReducedChiSquareWindow->GetMaxValue());
 
   return true;
 }

--- a/src/MGUIOptionsStripPairing.cxx
+++ b/src/MGUIOptionsStripPairing.cxx
@@ -70,6 +70,7 @@ void MGUIOptionsStripPairing::Create()
   
   m_Mode = new MGUIERBList(m_OptionsFrame, "Please select a strip pairing mode:");
   m_Mode->Add("Andreas's algorithm");
+  m_Mode->Add("Strip pairing - Chi Square Version (Updated - 2025)");
   m_Mode->Add("Daniel's 'greedy' algorithm");
   m_Mode->SetSelected(dynamic_cast<MModuleStripPairingGreedy*>(m_Module)->GetMode());
   m_Mode->Create();

--- a/src/MGUIOptionsStripPairing.cxx
+++ b/src/MGUIOptionsStripPairing.cxx
@@ -70,7 +70,7 @@ void MGUIOptionsStripPairing::Create()
   
   m_Mode = new MGUIERBList(m_OptionsFrame, "Please select a strip pairing mode:");
   m_Mode->Add("Andreas's algorithm");
-  m_Mode->Add("Strip pairing - Chi Square Version (Updated - 2025)");
+  m_Mode->Add("Multi Round Chi Square - Julian");
   m_Mode->Add("Daniel's 'greedy' algorithm");
   m_Mode->SetSelected(dynamic_cast<MModuleStripPairingGreedy*>(m_Module)->GetMode());
   m_Mode->Create();

--- a/src/MHit.cxx
+++ b/src/MHit.cxx
@@ -135,14 +135,22 @@ bool MHit::StreamDat(ostream& S, int Version)
   //! Stream the content to an ASCII file 
   
   if( Version == 1 ){
-     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<" "<<m_LVEnergy<<" "<<m_HVEnergy<<endl;
+     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<endl;
   } else if( Version == 2 ){
 	  //stream the hit information, then stream the strip hit info for this hit so that 
 	  //we will know which strip hits were associated with which hits
-     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<" "<<m_LVEnergy<<" "<<m_HVEnergy<<endl;
+     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<endl;
 	  for( auto SH : m_StripHits ){
 		  SH->StreamDat(S,0);
 	  }
+  } else if( Version == 3 ){
+      //stream the hit information, then stream the strip hit info for this hit so that
+      //we will know which strip hits were associated with which hits
+      //this version also reads out the LV and HV energy of each hit
+     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<" "<<m_LVEnergy<<" "<<m_HVEnergy<<endl;
+      for( auto SH : m_StripHits ){
+          SH->StreamDat(S,0);
+      }
   }
 
  

--- a/src/MHit.cxx
+++ b/src/MHit.cxx
@@ -73,6 +73,10 @@ void MHit::Clear()
 
   m_Position = g_VectorNotDefined;
   m_Energy = g_DoubleNotDefined;
+    
+  m_LVEnergy = g_DoubleNotDefined;
+  m_HVEnergy = g_DoubleNotDefined;
+    
   m_PositionResolution = g_VectorNotDefined;
   m_EnergyResolution = g_DoubleNotDefined;
 
@@ -131,11 +135,11 @@ bool MHit::StreamDat(ostream& S, int Version)
   //! Stream the content to an ASCII file 
   
   if( Version == 1 ){
-     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<endl;
+     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<" "<<m_LVEnergy<<" "<<m_HVEnergy<<endl;
   } else if( Version == 2 ){
 	  //stream the hit information, then stream the strip hit info for this hit so that 
 	  //we will know which strip hits were associated with which hits
-     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<endl;
+     S<<"HT "<<m_Position.GetX()<<" "<<m_Position.GetY()<<" "<<m_Position.GetZ()<<" "<<m_Energy<<" "<<m_LVEnergy<<" "<<m_HVEnergy<<endl;
 	  for( auto SH : m_StripHits ){
 		  SH->StreamDat(S,0);
 	  }
@@ -196,7 +200,7 @@ void MHit::StreamEvta(ostream& S)
   }
   
   S<<"HT 3;"<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy
-       <<";"<<m_PositionResolution.GetX()<<";"<<m_PositionResolution.GetY()<<";"<<m_PositionResolution.GetZ()<<";"<<m_EnergyResolution;
+    <<";"<<m_PositionResolution.GetX()<<";"<<m_PositionResolution.GetY()<<";"<<m_PositionResolution.GetZ()<<";"<<m_EnergyResolution;
   for (unsigned int i = 0; i < Origins.size(); ++i) {
     S<<";"<<Origins[i]; 
   }

--- a/src/MModuleEventFilter.cxx
+++ b/src/MModuleEventFilter.cxx
@@ -91,8 +91,8 @@ MModuleEventFilter::MModuleEventFilter() : MModule()
   m_MinimumHits = 0;
   m_MaximumHits = 100;
     
-  m_MinimumRedChiSquare = -1;
-  m_MaximumRedChiSquare = numeric_limits<double>::max();
+  m_MinimumReducedChiSquare = -1;
+  m_MaximumReducedChiSquare = numeric_limits<double>::max();
 }
 
 
@@ -176,7 +176,7 @@ bool MModuleEventFilter::AnalyzeEvent(MReadOutAssembly* Event)
     
   // Apply Chi^2 filter (as calculated in strip pairing)
     
-    if (Event->GetRedChiSquare() < m_MinimumRedChiSquare || Event->GetRedChiSquare() > m_MaximumRedChiSquare) {
+    if (Event->GetReducedChiSquare() < m_MinimumReducedChiSquare || Event->GetReducedChiSquare() > m_MaximumReducedChiSquare) {
         FilteredOut = true;
     }
 
@@ -248,13 +248,13 @@ bool MModuleEventFilter::ReadXmlConfiguration(MXmlNode* Node)
     m_MaximumHits = MaximumHitsNode->GetValueAsUnsignedInt();
   }
     
-  MXmlNode* MinimumRedChiSquareNode = Node->GetNode("MinimumRedChiSquare");
-  if (MinimumRedChiSquareNode != 0) {
-    m_MinimumRedChiSquare = MinimumRedChiSquareNode->GetValueAsDouble();
+  MXmlNode* MinimumReducedChiSquareNode = Node->GetNode("MinimumReducedChiSquare");
+  if (MinimumReducedChiSquareNode != 0) {
+    m_MinimumReducedChiSquare = MinimumReducedChiSquareNode->GetValueAsDouble();
   }
-  MXmlNode* MaximumRedChiSquareNode = Node->GetNode("MaximumRedChiSquare");
-  if (MaximumRedChiSquareNode != 0) {
-    m_MaximumRedChiSquare = MaximumRedChiSquareNode->GetValueAsDouble();
+  MXmlNode* MaximumReducedChiSquareNode = Node->GetNode("MaximumReducedChiSquare");
+  if (MaximumReducedChiSquareNode != 0) {
+    m_MaximumReducedChiSquare = MaximumReducedChiSquareNode->GetValueAsDouble();
   }
 
   return true;
@@ -282,8 +282,8 @@ MXmlNode* MModuleEventFilter::CreateXmlConfiguration()
   new MXmlNode(Node, "MinimumHits", m_MinimumHits);
   new MXmlNode(Node, "MaximumHits", m_MaximumHits);
     
-  new MXmlNode(Node, "MinimumRedChiSquare", m_MinimumRedChiSquare);
-  new MXmlNode(Node, "MaximumRedChiSquare", m_MaximumRedChiSquare);
+  new MXmlNode(Node, "MinimumReducedChiSquare", m_MinimumReducedChiSquare);
+  new MXmlNode(Node, "MaximumReducedChiSquare", m_MaximumReducedChiSquare);
 
   return Node;
 }

--- a/src/MModuleEventFilter.cxx
+++ b/src/MModuleEventFilter.cxx
@@ -81,6 +81,18 @@ MModuleEventFilter::MModuleEventFilter() : MModule()
   
   m_MinimumTotalEnergy = 0;
   m_MaximumTotalEnergy = 10000;
+
+  m_MinimumHVStrips = 0;
+  m_MaximumHVStrips = 20;
+
+  m_MinimumLVStrips = 0;
+  m_MaximumLVStrips = 20;
+
+  m_MinimumHits = 0;
+  m_MaximumHits = 100;
+    
+  m_MinimumRedChiSquare = -1;
+  m_MaximumRedChiSquare = numeric_limits<double>::max();
 }
 
 
@@ -145,6 +157,30 @@ bool MModuleEventFilter::AnalyzeEvent(MReadOutAssembly* Event)
     }   
   }
   
+  unsigned int NHVStrips = 0;
+  unsigned int NLVStrips = 0;
+  for (unsigned int sh = 0; sh < Event->GetNStripHits(); ++sh) {
+    if (Event->GetStripHit(sh)->IsLowVoltageStrip() == true) {
+      ++NLVStrips;
+    } else {
+      ++NHVStrips;
+    }
+  }
+  if (NHVStrips < m_MinimumHVStrips || NHVStrips > m_MaximumHVStrips || NLVStrips < m_MinimumLVStrips || NLVStrips > m_MaximumLVStrips) {
+    FilteredOut = true;
+  }
+
+  if (Event->GetNHits() < m_MinimumHits || Event->GetNHits() > m_MaximumHits) {
+    FilteredOut = true;
+  }
+    
+  // Apply Chi^2 filter (as calculated in strip pairing)
+    
+    if (Event->GetRedChiSquare() < m_MinimumRedChiSquare || Event->GetRedChiSquare() > m_MaximumRedChiSquare) {
+        FilteredOut = true;
+    }
+
+
   if (FilteredOut == true) {
     Event->SetFilteredOut(true);
   }
@@ -185,6 +221,42 @@ bool MModuleEventFilter::ReadXmlConfiguration(MXmlNode* Node)
     m_MaximumTotalEnergy = MaximumTotalEnergyNode->GetValueAsDouble();
   }
 
+  MXmlNode* MinimumHVStripsNode = Node->GetNode("MinimumHVStrips");
+  if (MinimumHVStripsNode != 0) {
+    m_MinimumHVStrips = MinimumHVStripsNode->GetValueAsUnsignedInt();
+  }
+  MXmlNode* MaximumHVStripsNode = Node->GetNode("MaximumHVStrips");
+  if (MaximumHVStripsNode != 0) {
+    m_MaximumHVStrips = MaximumHVStripsNode->GetValueAsUnsignedInt();
+  }
+
+  MXmlNode* MinimumLVStripsNode = Node->GetNode("MinimumLVStrips");
+  if (MinimumLVStripsNode != 0) {
+    m_MinimumLVStrips = MinimumLVStripsNode->GetValueAsUnsignedInt();
+  }
+  MXmlNode* MaximumLVStripsNode = Node->GetNode("MaximumLVStrips");
+  if (MaximumLVStripsNode != 0) {
+    m_MaximumLVStrips = MaximumLVStripsNode->GetValueAsUnsignedInt();
+  }
+
+  MXmlNode* MinimumHitsNode = Node->GetNode("MinimumHits");
+  if (MinimumHitsNode != 0) {
+    m_MinimumHits = MinimumHitsNode->GetValueAsUnsignedInt();
+  }
+  MXmlNode* MaximumHitsNode = Node->GetNode("MaximumHits");
+  if (MaximumHitsNode != 0) {
+    m_MaximumHits = MaximumHitsNode->GetValueAsUnsignedInt();
+  }
+    
+  MXmlNode* MinimumRedChiSquareNode = Node->GetNode("MinimumRedChiSquare");
+  if (MinimumRedChiSquareNode != 0) {
+    m_MinimumRedChiSquare = MinimumRedChiSquareNode->GetValueAsDouble();
+  }
+  MXmlNode* MaximumRedChiSquareNode = Node->GetNode("MaximumRedChiSquare");
+  if (MaximumRedChiSquareNode != 0) {
+    m_MaximumRedChiSquare = MaximumRedChiSquareNode->GetValueAsDouble();
+  }
+
   return true;
 }
 
@@ -200,6 +272,18 @@ MXmlNode* MModuleEventFilter::CreateXmlConfiguration()
 
   new MXmlNode(Node, "MinimumTotalEnergy", m_MinimumTotalEnergy);
   new MXmlNode(Node, "MaximumTotalEnergy", m_MaximumTotalEnergy);
+
+  new MXmlNode(Node, "MinimumHVStrips", m_MinimumHVStrips);
+  new MXmlNode(Node, "MaximumHVStrips", m_MaximumHVStrips);
+
+  new MXmlNode(Node, "MinimumLVStrips", m_MinimumLVStrips);
+  new MXmlNode(Node, "MaximumLVStrips", m_MaximumLVStrips);
+
+  new MXmlNode(Node, "MinimumHits", m_MinimumHits);
+  new MXmlNode(Node, "MaximumHits", m_MaximumHits);
+    
+  new MXmlNode(Node, "MinimumRedChiSquare", m_MinimumRedChiSquare);
+  new MXmlNode(Node, "MaximumRedChiSquare", m_MaximumRedChiSquare);
 
   return Node;
 }

--- a/src/MModuleEventSaver.cxx
+++ b/src/MModuleEventSaver.cxx
@@ -168,7 +168,7 @@ bool MModuleEventSaver::Initialize()
   ostringstream Header;
   if (m_Mode == c_DatFile) {
     Header<<endl;
-    Header<<"Version 1"<<endl;
+    Header<<"Version 3"<<endl;
     Header<<"Type DAT"<<endl;
     Header<<endl;
   } else if (m_Mode == c_EvtaFile) {
@@ -357,7 +357,7 @@ bool MModuleEventSaver::AnalyzeEvent(MReadOutAssembly* Event)
   if (m_Mode == c_EvtaFile) {
     Event->StreamEvta(Out);
   } else if (m_Mode == c_DatFile) {
-    Event->StreamDat(Out, 1);    
+    Event->StreamDat(Out, 3);
   } else if (m_Mode == c_RoaFile) {
     Event->StreamRoa(Out, m_RoaWithADCs, m_RoaWithTACs, m_RoaWithEnergies, m_RoaWithTimings, m_RoaWithTemperatures, m_RoaWithFlags, m_RoaWithOrigins, m_RoaWithNearestNeighbors);
   }

--- a/src/MModuleStripPairingChiSquare.cxx
+++ b/src/MModuleStripPairingChiSquare.cxx
@@ -106,6 +106,14 @@ void MModuleStripPairingChiSquare::CreateExpos()
   m_ExpoStripPairing = new MGUIExpoStripPairing(this);
   m_ExpoStripPairing->SetEnergiesHistogramParameters(1500, 0, 1500);
   m_Expos.push_back(m_ExpoStripPairing);
+  
+  m_ExpoStripPairingHits = new MGUIExpoStripPairingHits(this);
+  m_ExpoStripPairingHits->SetHitsHistogramParameters(5, 0.5, 5.5);
+  m_Expos.push_back(m_ExpoStripPairingHits);
+
+  m_ExpoStripPairingStripHits = new MGUIExpoStripPairingStripHits(this);
+  m_ExpoStripPairingStripHits->SetStripHitsHistogramParameters(10, 0.5, 10.5);
+  m_Expos.push_back(m_ExpoStripPairingStripHits);
 }
 
 
@@ -480,7 +488,11 @@ bool MModuleStripPairingChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
     double XEnergyTotal = 0;
     double YEnergyTotal = 0;
     double EnergyTotal = 0;
-
+      
+    // Create a list for plotting X and Y energies
+    vector<double> XEnergies;
+    vector<double> YEnergies;
+      
     for (unsigned int h = 0; h < min(BestXSideCombo.size(), BestYSideCombo.size()); ++h) {
       XPos = 0;
       YPos = 0;
@@ -515,9 +527,8 @@ bool MModuleStripPairingChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
       }
       EnergyTotal += Energy;
 
-      if (HasExpos() == true) {
-        m_ExpoStripPairing->AddEnergies(XEnergy, YEnergy);
-      }
+      XEnergies.push_back(XEnergy);
+      YEnergies.push_back(YEnergy);
 
       MHit* Hit = new MHit();
       Hit->SetEnergy(Energy);
@@ -536,6 +547,25 @@ bool MModuleStripPairingChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
       Event->SetAnalysisProgress(MAssembly::c_StripPairing);
       return false;
     }
+    else if (HasExpos() == true){
+          m_ExpoStripPairingHits->AddHits(Event->GetNHits());
+          for (unsigned int i = 0; i < XEnergies.size(); ++i){
+            m_ExpoStripPairing->AddEnergies(XEnergies[i], YEnergies[i]);
+          }
+          for (unsigned int h = 0; h<Event->GetNHits(); h++){
+            double HVStrips = 0;
+            double LVStrips = 0;
+            for (unsigned int sh=0; sh<Event->GetHit(h)->GetNStripHits(); sh++){
+              if (Event->GetHit(h)->GetStripHit(sh)->IsLowVoltageStrip()==true){
+                LVStrips++;
+              }
+              else{
+                HVStrips++;
+              }
+            }
+            m_ExpoStripPairingStripHits->AddStripHits(LVStrips, HVStrips);
+          }
+        }
 
     //
 

--- a/src/MModuleStripPairingChiSquareUpdated.cxx
+++ b/src/MModuleStripPairingChiSquareUpdated.cxx
@@ -216,9 +216,9 @@ float MModuleStripPairingChiSquareUpdated::ChargeTrappingCorrection(unsigned int
     // I'm going to make another function "FindDominantStrip" to just get out the strip on LV or HV side that has the highest energy
     // Return a corrected energy after applying charge trapping correction. Does there need to be two values or is correcting one side enough?
     
-    float CorrectedEnergy = 0;
+    float EnergyCorrection = 0;
 
-    return CorrectedEnergy;
+    return EnergyCorrection;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -341,14 +341,6 @@ vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquar
     return Combinations;
 }
 
-////////////////////////////////////////////////////////////////////////////////
-//! Find the "dominant" strip in a grouping of strips
-// unsigned int MModuleStripPairingChiSquareUpdated::FindDominantStrip(vector<unsigned int> StripGroup) {
-//
-//}
-
-////////////////////////////////////////////////////////////////////////////////
-
 //! Evaluate the reduced chi square for all possible strip pairings
 tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModuleStripPairingChiSquareUpdated::EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits) {
     
@@ -378,6 +370,11 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
             for (unsigned int en = 0; en < MinSize; ++en) { // en and ep are on the strip grouping level (ie if there's charge sharing)
                 unsigned int ep = en;
                 
+                // Collect LV and HV strips for current hit pairing
+                vector<vector<MStripHit*>> CurrentHitPairing;
+                CurrentHitPairing.push_back(vector<MStripHit*>());
+                CurrentHitPairing.push_back(vector<MStripHit*>());
+                
                 double LVEnergy = 0;
                 double LVResolution = 0;
                 
@@ -397,6 +394,9 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
                      
                     LVEnergy += StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
                     LVResolution += pow(StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergyResolution(), 2);
+                    
+                    // Add strip to current hit pairing
+                    CurrentHitPairing[0].push_back(StripHits[d][0][Combinations[d][0][lv][en][entry]]);
                 }
                 
                 // Repeats for HV side
@@ -406,7 +406,15 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
                 for (unsigned int entry = 0; entry < Combinations[d][1][hv][ep].size(); ++entry) {
                     HVEnergy += StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
                     HVResolution += pow(StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergyResolution(), 2);
+                    
+                    // Add strip to current hit pairing
+                    CurrentHitPairing[1].push_back(StripHits[d][1][Combinations[d][1][hv][ep][entry]]);
                 }
+                
+                // Apply charge trapping correction for each LV/HV pairing
+                // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
+                // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
+                HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
                 
                 // Sum chi square over entire LV/HV combination
                 ChiSquare += (LVEnergy - HVEnergy)*(LVEnergy - HVEnergy) / (LVResolution + HVResolution);
@@ -467,6 +475,11 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
         LVEnergyRes = 0;
         HVEnergyRes = 0;
         
+        // Collect LV and HV strips for current hit pairing
+        vector<vector<MStripHit*>> CurrentHitPairing;
+        CurrentHitPairing.push_back(vector<MStripHit*>());
+        CurrentHitPairing.push_back(vector<MStripHit*>());
+        
         // Check if there are any non-adjacent groupings of strips
         bool AllAdjacentLV = true;
         bool AllAdjacentHV = true;
@@ -496,6 +509,9 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
                 //cout<<"x-pos: "<<StripHits[d][0][BestXSideCombo[h][sh]]->GetNonStripPosition()<<endl;
                 LVEnergy += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
                 LVEnergyRes += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
+                
+                // Add strip to current hit pairing
+                CurrentHitPairing[0].push_back(StripHits[d][0][BestLVSideCombo[h][sh]]);
             }
             
             LVEnergyResTotal += LVEnergyRes;
@@ -506,7 +522,19 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
             for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
                 HVEnergy += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
                 HVEnergyRes += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
+                
+                // Add strip to current hit pairing
+                CurrentHitPairing[1].push_back(StripHits[d][1][BestHVSideCombo[h][sh]]);
             }
+            
+            // Apply charge trapping correction for each LV/HV pairing
+            // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
+            // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
+            HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
+            
+            // LVTau = StripHits[d][0][BestLVSideCombo[h][dominantLV]]->GetTiming();
+            // HVTau = StripHits[d][1][BestHVSideCombo[h][dominantHV]]->GetTiming();
+            
             
             HVEnergyResTotal += HVEnergyRes;
             HVEnergyTotal += HVEnergy;
@@ -553,6 +581,8 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
         
         // If there are non-adjacent strip groupings, then have to separate them out again to form multiple (physical) hits
         // Multiple hits on LV side
+        
+        // !!! TODO: Figure out how to apply charge trapping correction to events with multiple hits on a single strip
         if (AllAdjacentHV == false && AllAdjacentLV == true ) {
             //cout<<"Multiple hits on single LV strip"<<endl;
             bool MultipleHitsOnLV = true;

--- a/src/MModuleStripPairingChiSquareUpdated.cxx
+++ b/src/MModuleStripPairingChiSquareUpdated.cxx
@@ -139,27 +139,26 @@ bool MModuleStripPairingChiSquareUpdated::Initialize()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// Following function returns a 3D vector of integers
-// Input is 3D vector of ints called "Old Ones" and a vector of "Strip Hits" (pointing to an object of type StripHit, defined in MStripHit.cxx)
+//! Function returns new combinations of strips based on seed combinations
 vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo)
 {
-    // define new vector of ints NewOnes
+    // Define new vector of ints NewOnes
   vector<vector<vector<unsigned int>>> NewOnes; // <list> of <combinations> of <combined strips>
     
-  for (unsigned int listspot = 0; listspot < OldOnes.size(); ++listspot) { // iterate over set of combinations
+  for (unsigned int listspot = 0; listspot < OldOnes.size(); ++listspot) { // Iterate over set of seed combinations
     // New single merges
-    for (unsigned int combi1 = 0; combi1 < OldOnes[listspot].size(); ++combi1) { //iterate over individual combos within set
-      for (unsigned int combi2 = combi1+1; combi2 < OldOnes[listspot].size(); ++combi2) { //iterate through all the combos AFTER combi1
+    for (unsigned int combi1 = 0; combi1 < OldOnes[listspot].size(); ++combi1) { // Iterate over individual combos within set
+      for (unsigned int combi2 = combi1+1; combi2 < OldOnes[listspot].size(); ++combi2) { // Iterate through all the combos AFTER combi1
         vector<unsigned int> NewCombinedStrips;
         NewCombinedStrips.insert(NewCombinedStrips.end(), OldOnes[listspot][combi1].begin(), OldOnes[listspot][combi1].end());
         NewCombinedStrips.insert(NewCombinedStrips.end(), OldOnes[listspot][combi2].begin(), OldOnes[listspot][combi2].end());
         sort(NewCombinedStrips.begin(), NewCombinedStrips.end());
         
-        // the above combines each combination with all the subsequent combinations in order to produce new combinations of strips
+        // The above combines each combination with all the subsequent combinations in order to produce new combinations of strips
 
         vector<unsigned int> NewCombinedAsIDs;
         for (unsigned int s = 0; s < NewCombinedStrips.size(); ++s) {
-          NewCombinedAsIDs.push_back(StripHits[NewCombinedStrips[s]]->GetStripID()); //translates the hit number to the actual strip ID
+          NewCombinedAsIDs.push_back(StripHits[NewCombinedStrips[s]]->GetStripID()); // Translates the hit number to the actual strip ID
         }
         sort(NewCombinedAsIDs.begin(), NewCombinedAsIDs.end());
         
@@ -170,7 +169,7 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
                 AllAdjacent = false;
                 break;
               }
-            } //checks if the new combo is of adjacent strips
+            } // Checks if the new combo is of adjacent strips
 
             if (AllAdjacent == true) {
               vector<vector<unsigned int>> NewCombo;
@@ -179,7 +178,7 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
                   NewCombo.push_back(OldOnes[listspot][news]);
                 }
                 if (news == combi1) {
-                  NewCombo.push_back(NewCombinedStrips); //Should this be NewCombinedStripsAsIDs????
+                  NewCombo.push_back(NewCombinedStrips);
                 }
               }
               NewOnes.push_back(NewCombo);
@@ -191,7 +190,7 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
                 NewCombo.push_back(OldOnes[listspot][news]);
               }
               if (news == combi1) {
-                NewCombo.push_back(NewCombinedStrips); //Should this be NewCombinedStripsAsIDs????
+                NewCombo.push_back(NewCombinedStrips);
               }
             }
             NewOnes.push_back(NewCombo);
@@ -258,25 +257,6 @@ vector<vector<vector<MStripHit*>>> MModuleStripPairingChiSquareUpdated::CollectS
         DetectorIDs.push_back(SH->GetDetectorID());
       }
     }
-    
-    /* Debugging: Check strip hits
-          cout<<"Strip hits: "<<endl;
-          for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
-            cout<<"Detector: "<<d<<endl;
-            for (unsigned int side = 0; side <=1; ++side) { // side loop
-              cout<<"  Side: "<<side<<endl;
-              if (StripHits[d][side].size() > 0) {
-                cout<<"    Hits: "<<endl;;
-                for (unsigned int sh = 0; sh < StripHits[d][side].size(); ++sh) { // side loop
-                  cout<<StripHits[d][side][sh]->ToString();
-                }
-              } else {
-                cout<<"no hits"<<endl;
-              }
-            }
-          }
-    */
-    
     return StripHits;
     
 }
@@ -303,27 +283,7 @@ bool MModuleStripPairingChiSquareUpdated::EventSelection(MReadOutAssembly* Event
           }
       }
     }
-    
-    /* Debugging: Verify there's enough energy deposited on each side of detector
-    
-    for (unsigned int d = 0; d < StripHits.size(); ++d) {
-        double LVEnergy = 0;
-        double LVEnergyRes = 0;
-        for (unsigned int sh = 0; sh < StripHits[d][0].size(); ++sh) {
-            LVEnergy += StripHits[d][0][sh]->GetEnergy();
-            LVEnergyRes += StripHits[d][0][sh]->GetEnergyResolution()*StripHits[d][0][sh]->GetEnergyResolution();
-        }
-        double HVEnergy = 0;
-        double HVEnergyRes = 0;
-        for (unsigned int sh = 0; sh < StripHits[d][1].size(); ++sh) {
-            HVEnergy += StripHits[d][1][sh]->GetEnergy();
-            HVEnergyRes += StripHits[d][1][sh]->GetEnergyResolution()*StripHits[d][1][sh]->GetEnergyResolution();
-        }
-    }
-
-    cout<<"Energies: "<<xEnergy<<":"<<xEnergyRes<<" -- "<<yEnergy<<":"<<yEnergyRes<<endl;
-    */
-    
+   
     return true;
 }
 
@@ -377,33 +337,7 @@ vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquar
             }
         }
     } // End Side loop
-    
-    /* Debugging: Output all combinations
-     cout<<"All combinations:"<<endl;
-     for (unsigned int xc = 0; xc < Combinations[d][0].size(); ++xc) {
-     cout<<"X - "<<xc<<": ";
-     for (unsigned h = 0; h < Combinations[d][0][xc].size(); ++h) {
-     cout<<" (";
-     for (unsigned int sh = 0; sh < Combinations[d][0][xc][h].size(); ++sh) {
-     cout<<Combinations[d][0][xc][h][sh]<<" ";
-     }
-     cout<<")";
-     }
-     cout<<endl;
-     }
-     for (unsigned int yc = 0; yc < Combinations[d][1].size(); ++yc) {
-     cout<<"Y - "<<yc<<": ";
-     for (unsigned h = 0; h < Combinations[d][1][yc].size(); ++h) {
-     cout<<" (";
-     for (unsigned int sh = 0; sh < Combinations[d][1][yc][h].size(); ++sh) {
-     cout<<Combinations[d][1][yc][h][sh]<<" ";
-     }
-     cout<<")";
-     }
-     cout<<endl;
-     }
-     */
-    
+ 
     return Combinations;
 }
 
@@ -438,28 +372,8 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
         
         bool MorePermutations = true;
         while (MorePermutations == true) {
-            
-            /* Debugging: Output current combination
-            //cout<<"New permutation..."<<endl;
-            //         if (Combinations[d][1][yc].size() > Combinations[d][0][xc].size()) {
-            //           PrintCombi(Combinations[d][1][yc]);
-            //         } else {
-            //           PrintCombi(NCombi[p]);
-            //         }
-            */
-            
+             
             double ChiSquare = 0;
-            
-            /* Timing is not yet implemented into strip pairing. But maybe one day...
-            vector<double> HVtauList;
-            vector<double> LVtauList;
-            vector<double> HVtauResolutionList;
-            vector<double> LVtauResolutionList;
-            double HVtauMeanResolution = 0;
-            double LVtauMeanResolution = 0;
-            double HVtauMean = 0;
-            double LVtauMean = 0;
-            */
             
             for (unsigned int en = 0; en < MinSize; ++en) { // en and ep are on the strip grouping level (ie if there's charge sharing)
                 unsigned int ep = en;
@@ -488,101 +402,14 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
                 // Repeats for HV side
                 double HVEnergy = 0;
                 double HVResolution = 0;
-                // unsigned int dominantHV;
-                // MaxEnergy = -numeric_limits<double>::max();
+                
                 for (unsigned int entry = 0; entry < Combinations[d][1][hv][ep].size(); ++entry) {
-                    /* Currently I don't believe the dominant strip is used in strip pairing, so let's comment it out
-                     
-                    double tempEnergy = StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
-                    if (tempEnergy > MaxEnergy){
-                        dominantHV = entry;
-                        MaxEnergy = tempEnergy;
-                    }
-                    */
-                    
                     HVEnergy += StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
                     HVResolution += pow(StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergyResolution(), 2);
                 }
                 
                 // Sum chi square over entire LV/HV combination
                 ChiSquare += (LVEnergy - HVEnergy)*(LVEnergy - HVEnergy) / (LVResolution + HVResolution);
-                
-                /*
-                 
-                In the future, this chunk will be used to implement timing info into strip pairing. It has not yet been implemented.
- 
-                double LVtau = StripHits[d][0][Combinations[d][0][lv][en][dominantLV]]->GetTiming();
-                double HVtau = StripHits[d][1][Combinations[d][1][hv][ep][dominantHV]]->GetTiming();
-                
-                // Charge trapping correction
-                // correction made based only on the dominant X and Y strip in a grouping of strips (eg neighboring strips)
-                // double CTDHVShift = LVtau - HVtau + 200;
-                // double slope = ChargeTrappingMap[d][Combinations[d][0][xc][en][dominantX]->GetStripID()][Combinations[d][1][yc][ep][dominantY]->GetStripID()][0];
-                // double intercept = ChargeTrappingMap[d][Combinations[d][0][xc][en][dominantX]->GetStripID()][Combinations[d][1][yc][ep][dominantY]->GetStripID()][1];
-                // yEnergy /= 1 - (slope*CTDHVShift - intercept)/100;
-                
-                // Right now, adding up all the strips in the grouping's Yenergies then applying the CTD correction to the sum... is that correct?
-                
-                HVtauList.push_back(HVtau);
-                LVtauList.push_back(-LVtau);
-                HVtauMean += HVtau;
-                LVtauMean += LVtau;
-                
-                // !!! TODO: Fix timing resolution. Maybe put GetTimingResolution into MStripHit
-                double LVtauResolution = 3*60/StripHits[d][0][Combinations[d][0][lv][en][dominantLV]]->GetEnergy();
-                double HVtauResolution = 3*60/StripHits[d][1][Combinations[d][1][hv][ep][dominantHV]]->GetEnergy();
-                
-                HVtauResolutionList.push_back(HVtauResolution*HVtauResolution);
-                LVtauResolutionList.push_back(LVtauResolution*LVtauResolution);
-                
-                HVtauMeanResolution += HVtauResolution*HVtauResolution;
-                LVtauMeanResolution += LVtauResolution*LVtauResolution;
- 
- 
-                HVtauMean /= MinSize;
-                LVtauMean /= MinSize;
-                HVtauMeanResolution /= MinSize*MinSize;
-                LVtauMeanResolution /= MinSize*MinSize;
-                 
-                vector<size_t> HVTauArgsort = Argsort(HVtauList);
-                vector<size_t> LVTauArgsort = Argsort(LVtauList);
-                bool TimesOrdered = true;
-                // for (unsigned int i=0; i<HVTauArgsort.size(); ++i) {
-                //   if (HVTauArgsort[i]!=LVTauArgsort[i]){
-                //     TimesOrdered = false;
-                //   }
-                // }
-                 
-                // Calculate the distance between measurements and properly order lists of drift times --> time ordering!!
-                double HVTimeOrderDistance = 0;
-                double LVTimeOrderDistance = 0;
-                for (unsigned int i=0; i<HVTauArgsort.size(); ++i) {
-                     if (HVTauArgsort[i]!=LVTauArgsort[i]){
-                         HVTimeOrderDistance += (HVtauList[HVTauArgsort[i]] - HVtauList[LVTauArgsort[i]])*(HVtauList[HVTauArgsort[i]] - HVtauList[LVTauArgsort[i]])/(HVtauResolutionList[HVTauArgsort[i]] + HVtauResolutionList[LVTauArgsort[i]]);
-                         LVTimeOrderDistance += (LVtauList[HVTauArgsort[i]] - LVtauList[LVTauArgsort[i]])*(LVtauList[HVTauArgsort[i]] - LVtauList[LVTauArgsort[i]])/(LVtauResolutionList[HVTauArgsort[i]] + LVtauResolutionList[LVTauArgsort[i]]);
-                     }
-                }
-                 
-                // if ((HVTimeOrderDistance < LVTimeOrderDistance) && (HVTimeOrderDistance > 50)) {
-                //   TimesOrdered = false;
-                // }
-                // else if ((LVTimeOrderDistance < HVTimeOrderDistance) && (LVTimeOrderDistance > 50)) {
-                //   TimesOrdered = false;
-                // }
-                 
-                // !!! TODO: Do we need to take into account difference in hole and electron drift times?
-                // for( unsigned int h=0; h < HVtauList.size(); ++h ){
-                //   ChiSquare += ((HVtauList[h] - HVtauMean) + (LVtauList[h] - LVtauMean)) * ((HVtauList[h] - HVtauMean) + (LVtauList[h] - LVtauMean))/(HVtauMeanResolution + LVtauMeanResolution + HVtauResolutionList[h] + LVtauResolutionList[h]);
-                // }
-                */
-                
-                /* Debugging: Output energies and energy resolution of each strip grouping
-                //cout << "yEnergy: " << yEnergy << endl;
-                //cout << "  Sub - Test en=" << en << " (" << xEnergy << ") with ep="
-                //     << ep << " (" << yEnergy << "):" << endl;
-                //cout<<xResolution<<":"<<yResolution<<endl;
-                */
-                
             }
             
             // Calculate reduced chi^2 be dividing by number of strip groupings within the combination
@@ -594,8 +421,6 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
                 BestHVSideCombo = Combinations[d][1][hv];
             }
             
-            //cout<<"ChiSquare: "<<ChiSquare<<endl;
-            
             // Cycle through all permutations to reach every possible strip pairing
             if (Combinations[d][1][hv].size() > Combinations[d][0][lv].size()) {
                 MorePermutations = next_permutation(Combinations[d][1][hv].begin(), Combinations[d][1][hv].end());
@@ -606,29 +431,6 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
         }
     }
 }
-    
-    /* Debugging: Output best LV and HV combinations
-     cout<<"Best combo:"<<endl;
-     cout<<"X: ";
-     for (unsigned h = 0; h < BestXSideCombo.size(); ++h) {
-     cout<<" (";
-     for (unsigned int sh = 0; sh < BestXSideCombo[h].size(); ++sh) {
-     cout<<StripHits[d][0][BestXSideCombo[h][sh]]->GetStripID()<<" ";
-     }
-     cout<<")";
-     }
-     cout<<endl;
-     cout<<"Y: ";
-     for (unsigned h = 0; h < BestYSideCombo.size(); ++h) {
-     cout<<" (";
-     for (unsigned int sh = 0; sh < BestYSideCombo[h].size(); ++sh) {
-     cout<<StripHits[d][1][BestYSideCombo[h][sh]]->GetStripID()<<" ";
-     }
-     cout<<")";
-     }
-     cout<<endl;
-     */
-    
     return { BestLVSideCombo, BestHVSideCombo, BestChiSquare };
 }
 
@@ -636,9 +438,6 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
 
 //! Create hits
 bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo) {
-    
-    // double LVPos = 0;
-    // double HVPos = 0;
     
     
     double LVEnergy = 0;
@@ -663,8 +462,6 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
     
     for (unsigned int h = 0; h < min(BestLVSideCombo.size(), BestHVSideCombo.size()); ++h) { // Loop over groupings of strips
         
-        // LVPos = 0;
-        // HVPos = 0;
         LVEnergy = 0;
         HVEnergy = 0;
         LVEnergyRes = 0;
@@ -691,7 +488,7 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
             }
         }
         
-        //If there are no non-adjacent strip groupings, continue pairing as normal
+        // If there are no non-adjacent strip groupings, continue pairing as normal
         if (AllAdjacent) {
             
             // Add up energy and energy resolution for each grouping of strips
@@ -710,10 +507,6 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
                 HVEnergy += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
                 HVEnergyRes += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
             }
-            
-            // LVTau = StripHits[d][0][BestLVSideCombo[h][dominantLV]]->GetTiming();
-            // HVTau = StripHits[d][1][BestHVSideCombo[h][dominantHV]]->GetTiming();
-            
             
             HVEnergyResTotal += HVEnergyRes;
             HVEnergyTotal += HVEnergy;
@@ -751,8 +544,6 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
             // Populate hit with strip hits
             for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
                 Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
-                //cout<<"Paired Strip:"<<endl;
-                //cout<<"StripID: "<<StripHits[d][0][BestXSideCombo[h][sh]]->GetStripID()<<endl;
                 
             }
             for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
@@ -982,27 +773,6 @@ bool MModuleStripPairingChiSquareUpdated::AnalyzeEvent(MReadOutAssembly* Event) 
     Event->SetAnalysisProgress(MAssembly::c_StripPairing);
     
     return true;
-    
-    
-// (2.5) Create and populate charge trapping map for energy correction
-/*
-  vector<array<array<array<double, 2>, 64>, 64>> ChargeTrappingMap; //64 x 64 grid
-    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
-        ChargeTrappingMap.push_back(array<array<array<double, 2>, 64>, 64>());
-        for (unsigned int i = 0; i < 64; ++i) {
-            for (unsigned int j = 0; j < 64; ++j) {
-                ChargeTrappingMap[d][i][j][0] = 0;
-                ChargeTrappingMap[d][i][j][1] = 0; //populate with 0s for now
- Have to make sure I'm indexing correctly!!! Do the Strip IDs start at 0???
- Also need to make sure the indexing on the detectors is consistent. Ie, what is detector 0, 1, etc.
-            }
-        }
-    }
-  
-*/
-    
-  
-    
 }
 
 

--- a/src/MModuleStripPairingChiSquareUpdated.cxx
+++ b/src/MModuleStripPairingChiSquareUpdated.cxx
@@ -1,0 +1,1090 @@
+/*
+ * MModuleStripPairingChiSquareUpdated.cxx
+ * Chi Square Version (Updated 2025)
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// MModuleStripPairingChiSquareUpdated
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Include the header:
+#include "MModuleStripPairingChiSquareUpdated.h"
+
+// Standard libs:
+#include <fstream>
+#include <iostream>
+
+// ROOT libs:
+#include "TGClient.h"
+
+// MEGAlib libs:
+#include "MModule.h"
+#include "MGUIOptionsStripPairing.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MModuleStripPairingChiSquareUpdated)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Define constants to be used in strip pairing
+
+const unsigned int MaxCombinations = 5; // Defines maximum number of strip combinations allowed in pairing
+const unsigned int MaxStripHits = 6; // Define maximum number of strip hits on any one side
+const unsigned int ChiSquareThreshold = 100; // If strip pairing does not reach this threshold, it will enter round two
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleStripPairingChiSquareUpdated::MModuleStripPairingChiSquareUpdated() : MModule()
+{
+  // Construct an instance of MModuleStripPairingChiSquareUpdated
+
+  // Set all module relevant information
+
+  // Set the module name --- has to be unique
+  m_Name = "Strip pairing - chi square (updated - 2025)";
+
+  // Set the XML tag --- has to be unique --- no spaces allowed
+  m_XmlTag = "XmlTagStripPairingChiSquareUpdated";
+
+  // Set all modules, which have to be done before this module
+  AddPreceedingModuleType(MAssembly::c_EventLoader);
+  AddPreceedingModuleType(MAssembly::c_EnergyCalibration);
+  AddPreceedingModuleType(MAssembly::c_TACcut);
+
+  // Set all types this modules handles
+  AddModuleType(MAssembly::c_StripPairing);
+
+  // Set all modules, which can follow this module
+  AddSucceedingModuleType(MAssembly::c_NoRestriction);
+
+  // Set if this module has an options GUI
+  // Overwrite ShowOptionsGUI() with the call to the GUI!
+  m_HasOptionsGUI = false;
+  // If true, you have to derive a class from MGUIOptions (use MGUIOptionsTemplate)
+  // and implement all your GUI options
+
+  // Can the program be run multi-threaded
+  m_AllowMultiThreading = true;
+
+  // Can we use multiple instances of this class
+  m_AllowMultipleInstances = true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleStripPairingChiSquareUpdated::~MModuleStripPairingChiSquareUpdated()
+{
+  // Delete this instance of MModuleStripPairingChiSquareUpdated
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleStripPairingChiSquareUpdated::CreateExpos()
+{
+  // Create all expos
+
+  if (HasExpos() == true) return;
+
+  // Set the histogram display
+  m_ExpoStripPairing = new MGUIExpoStripPairing(this);
+  m_ExpoStripPairing->SetEnergiesHistogramParameters(1500, 0, 1500);
+  m_Expos.push_back(m_ExpoStripPairing);
+
+  m_ExpoStripPairingHits = new MGUIExpoStripPairingHits(this);
+  m_ExpoStripPairingHits->SetHitsHistogramParameters(5, 0.5, 5.5);
+  m_Expos.push_back(m_ExpoStripPairingHits);
+
+  m_ExpoStripPairingStripHits = new MGUIExpoStripPairingStripHits(this);
+  m_ExpoStripPairingStripHits->SetStripHitsHistogramParameters(10, 0.5, 10.5);
+  m_Expos.push_back(m_ExpoStripPairingStripHits);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleStripPairingChiSquareUpdated::Initialize()
+{
+  // Initialize the module
+
+  return MModule::Initialize();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+// Following function returns a 3D vector of integers
+// Input is 3D vector of ints called "Old Ones" and a vector of "Strip Hits" (pointing to an object of type StripHit, defined in MStripHit.cxx)
+vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo)
+{
+    // define new vector of ints NewOnes
+  vector<vector<vector<unsigned int>>> NewOnes; // <list> of <combinations> of <combined strips>
+    
+  for (unsigned int listspot = 0; listspot < OldOnes.size(); ++listspot) { // iterate over set of combinations
+    // New single merges
+    for (unsigned int combi1 = 0; combi1 < OldOnes[listspot].size(); ++combi1) { //iterate over individual combos within set
+      for (unsigned int combi2 = combi1+1; combi2 < OldOnes[listspot].size(); ++combi2) { //iterate through all the combos AFTER combi1
+        vector<unsigned int> NewCombinedStrips;
+        NewCombinedStrips.insert(NewCombinedStrips.end(), OldOnes[listspot][combi1].begin(), OldOnes[listspot][combi1].end());
+        NewCombinedStrips.insert(NewCombinedStrips.end(), OldOnes[listspot][combi2].begin(), OldOnes[listspot][combi2].end());
+        sort(NewCombinedStrips.begin(), NewCombinedStrips.end());
+        
+        // the above combines each combination with all the subsequent combinations in order to produce new combinations of strips
+
+        vector<unsigned int> NewCombinedAsIDs;
+        for (unsigned int s = 0; s < NewCombinedStrips.size(); ++s) {
+          NewCombinedAsIDs.push_back(StripHits[NewCombinedStrips[s]]->GetStripID()); //translates the hit number to the actual strip ID
+        }
+        sort(NewCombinedAsIDs.begin(), NewCombinedAsIDs.end());
+        
+        if (RoundTwo == false) {
+            bool AllAdjacent = true;
+            for (unsigned int c = 1; c < NewCombinedAsIDs.size(); ++c) {
+              if (NewCombinedAsIDs[c-1] + 1 != NewCombinedAsIDs[c]) {
+                AllAdjacent = false;
+                break;
+              }
+            } //checks if the new combo is of adjacent strips
+
+            if (AllAdjacent == true) {
+              vector<vector<unsigned int>> NewCombo;
+              for (unsigned int news = 0; news < OldOnes[listspot].size(); ++news) {
+                if (news != combi1 && news != combi2) {
+                  NewCombo.push_back(OldOnes[listspot][news]);
+                }
+                if (news == combi1) {
+                  NewCombo.push_back(NewCombinedStrips); //Should this be NewCombinedStripsAsIDs????
+                }
+              }
+              NewOnes.push_back(NewCombo);
+            }
+        } else {
+            vector<vector<unsigned int>> NewCombo;
+            for (unsigned int news = 0; news < OldOnes[listspot].size(); ++news) {
+              if (news != combi1 && news != combi2) {
+                NewCombo.push_back(OldOnes[listspot][news]);
+              }
+              if (news == combi1) {
+                NewCombo.push_back(NewCombinedStrips); //Should this be NewCombinedStripsAsIDs????
+              }
+            }
+            NewOnes.push_back(NewCombo);
+        }
+      }
+    }
+  }
+
+  return NewOnes;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Apply a charge trapping correction to each potential pair of LV/HV strips
+float MModuleStripPairingChiSquareUpdated::ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits) {
+    
+    // Dummy Function
+    // Idea: Read in detector number and set of LV/HV strips to be paired
+    // Will also need to read in actual charge trapping parameters from text file
+    // The LV/HVStripSet will only be multiple strips if there is charge sharing going on. Otherwise it'll just be a vector with a single number. That number will have to be converted to the actual stripID
+    // In the case of charge sharing, will have to find "dominant" LV/HV strip to get correct CTD
+    // I'm going to make another function "FindDominantStrip" to just get out the strip on LV or HV side that has the highest energy
+    // Return a corrected energy after applying charge trapping correction. Does there need to be two values or is correcting one side enough?
+    
+    float CorrectedEnergy = 0;
+
+    return CorrectedEnergy;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Divide an event's strip hits by detector and LV/HV side
+vector<vector<vector<MStripHit*>>> MModuleStripPairingChiSquareUpdated::CollectStripHits(MReadOutAssembly* Event) {
+    
+    // Split hits by detector ID
+    vector<unsigned int> DetectorIDs;
+    vector<vector<vector<MStripHit*>>> StripHits; // list of detector IDs, list of sides (LV and HV), list of hits
+
+    for (unsigned int sh = 0; sh < Event->GetNStripHits(); ++sh) { // Populate StripHits with this event's strip hits
+      MStripHit* SH = Event->GetStripHit(sh);
+      unsigned int Side = (SH->IsLowVoltageStrip() == true) ? 0 : 1;
+
+      // Check if detector is on list
+      bool DetectorFound = false;
+      unsigned int DetectorPos = 0;
+      for (unsigned int d = 0; d < DetectorIDs.size(); ++d) {
+        if (DetectorIDs[d] == SH->GetDetectorID()) {
+          DetectorFound = true;
+          DetectorPos = d;
+        }
+      }
+
+      // Once the correct detector is found, add strip hit to StripHits
+      if (DetectorFound == true) {
+        StripHits[DetectorPos][Side].push_back(SH);
+      }
+      else { // If encountering a new detector, initialize list of sides/hits corresponding to that detector
+        vector<vector<MStripHit*>> List; // list of sides, list of hits
+        List.push_back(vector<MStripHit*>()); // LV
+        List.push_back(vector<MStripHit*>()); // HV
+        List[Side].push_back(SH);
+        StripHits.push_back(List);
+        DetectorIDs.push_back(SH->GetDetectorID());
+      }
+    }
+    
+    /* Debugging: Check strip hits
+          cout<<"Strip hits: "<<endl;
+          for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+            cout<<"Detector: "<<d<<endl;
+            for (unsigned int side = 0; side <=1; ++side) { // side loop
+              cout<<"  Side: "<<side<<endl;
+              if (StripHits[d][side].size() > 0) {
+                cout<<"    Hits: "<<endl;;
+                for (unsigned int sh = 0; sh < StripHits[d][side].size(); ++sh) { // side loop
+                  cout<<StripHits[d][side][sh]->ToString();
+                }
+              } else {
+                cout<<"no hits"<<endl;
+              }
+            }
+          }
+    */
+    
+    return StripHits;
+    
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Read in strip hits on each side for each detector and perform quality selections
+bool MModuleStripPairingChiSquareUpdated::EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits) {
+    
+    // Limit the number of strip hits on each side
+    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+      for (unsigned int side = 0; side <=1; ++side) { // Side loop
+        if (StripHits[d][side].size() > MaxStripHits) {
+          Event->SetStripPairingIncomplete(true, "More than 6 hit strips on one side");
+          Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+          return false;
+        }
+        
+        // Check if one side of the detector has no strip hits
+        if (StripHits[d][side].size() == 0) {
+          Event->SetStripPairingIncomplete(true, "One detector side has no strip hits");
+          Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+          return false;
+          }
+      }
+    }
+    
+    /* Debugging: Verify there's enough energy deposited on each side of detector
+    
+    for (unsigned int d = 0; d < StripHits.size(); ++d) {
+        double LVEnergy = 0;
+        double LVEnergyRes = 0;
+        for (unsigned int sh = 0; sh < StripHits[d][0].size(); ++sh) {
+            LVEnergy += StripHits[d][0][sh]->GetEnergy();
+            LVEnergyRes += StripHits[d][0][sh]->GetEnergyResolution()*StripHits[d][0][sh]->GetEnergyResolution();
+        }
+        double HVEnergy = 0;
+        double HVEnergyRes = 0;
+        for (unsigned int sh = 0; sh < StripHits[d][1].size(); ++sh) {
+            HVEnergy += StripHits[d][1][sh]->GetEnergy();
+            HVEnergyRes += StripHits[d][1][sh]->GetEnergyResolution()*StripHits[d][1][sh]->GetEnergyResolution();
+        }
+    }
+
+    cout<<"Energies: "<<xEnergy<<":"<<xEnergyRes<<" -- "<<yEnergy<<":"<<yEnergyRes<<endl;
+    */
+    
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Find all strip combinations for each detector on LV and HV sides given seed combinations
+vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquareUpdated::FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo) {
+
+    for (unsigned int side = 0; side <=1; ++side) { // Side loop (LV and HV)
+        
+        vector<vector<vector<unsigned int>>> NewCombinations;
+        
+        bool CombinationsAdded = true;
+        while (CombinationsAdded == true) {
+            CombinationsAdded = false;
+            
+            NewCombinations = FindNewCombinations(Combinations[d][side], StripHits[d][side], RoundTwo);
+            //cout<<"Size: "<<NewCombinations.size()<<endl;
+            
+            // Find equal combinations and eliminate them from the new list
+            for (unsigned int c = 0; c < Combinations[d][side].size(); ++c) {
+                auto Iter = NewCombinations.begin();
+                while (Iter != NewCombinations.end()) {
+                    if (Combinations[d][side][c] == (*Iter)) {
+                        bool Equal = true;
+                        for (unsigned int deep = 0; deep < Combinations[d][side][c].size(); ++deep) {
+                            if (Combinations[d][side][c][deep] != (*Iter)[deep]) {
+                                Equal = false;
+                                break;
+                            }
+                        }
+                        if (Equal == true) {
+                            Iter = NewCombinations.erase(Iter);
+                        }
+                        else {
+                            Iter++;
+                        }
+                    }
+                    else {
+                        Iter++;
+                    }
+                }
+            }
+            // If there are new combinations left, add them, and restart
+            if (NewCombinations.size() > 0) {
+                //cout<<NewCombinations.size()<<" new combinations found"<<endl;
+                for (auto C: NewCombinations) {
+                    Combinations[d][side].push_back(C);
+                }
+                CombinationsAdded = true; //keep going until no more combos added
+            }
+        }
+    } // End Side loop
+    
+    /* Debugging: Output all combinations
+     cout<<"All combinations:"<<endl;
+     for (unsigned int xc = 0; xc < Combinations[d][0].size(); ++xc) {
+     cout<<"X - "<<xc<<": ";
+     for (unsigned h = 0; h < Combinations[d][0][xc].size(); ++h) {
+     cout<<" (";
+     for (unsigned int sh = 0; sh < Combinations[d][0][xc][h].size(); ++sh) {
+     cout<<Combinations[d][0][xc][h][sh]<<" ";
+     }
+     cout<<")";
+     }
+     cout<<endl;
+     }
+     for (unsigned int yc = 0; yc < Combinations[d][1].size(); ++yc) {
+     cout<<"Y - "<<yc<<": ";
+     for (unsigned h = 0; h < Combinations[d][1][yc].size(); ++h) {
+     cout<<" (";
+     for (unsigned int sh = 0; sh < Combinations[d][1][yc][h].size(); ++sh) {
+     cout<<Combinations[d][1][yc][h][sh]<<" ";
+     }
+     cout<<")";
+     }
+     cout<<endl;
+     }
+     */
+    
+    return Combinations;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//! Find the "dominant" strip in a grouping of strips
+// unsigned int MModuleStripPairingChiSquareUpdated::FindDominantStrip(vector<unsigned int> StripGroup) {
+//
+//}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Evaluate the reduced chi square for all possible strip pairings
+tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModuleStripPairingChiSquareUpdated::EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits) {
+    
+    double BestChiSquare = numeric_limits<double>::max();
+    vector<vector<unsigned int>> BestLVSideCombo;
+    vector<vector<unsigned int>> BestHVSideCombo;
+    
+    for (unsigned int lv = 0; lv < Combinations[d][0].size(); ++lv) { // Loop over combinations of lv-strips (lv represents a list of sets of strips,  and each set is a proposed Hit)
+        for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
+            // Skip if lv and hv strip combos differ in size by more than one
+            if (abs(long(Combinations[d][0][lv].size()) - long(Combinations[d][1][hv].size())) > 1) {
+            continue;
+        }
+        
+        unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
+        
+        // Skip pairing if either side has more than 5 sets of strips
+        if (max(Combinations[d][0][lv].size(), Combinations[d][1][hv].size()) > MaxCombinations) {
+            continue;
+        }
+        
+        bool MorePermutations = true;
+        while (MorePermutations == true) {
+            
+            /* Debugging: Output current combination
+            //cout<<"New permutation..."<<endl;
+            //         if (Combinations[d][1][yc].size() > Combinations[d][0][xc].size()) {
+            //           PrintCombi(Combinations[d][1][yc]);
+            //         } else {
+            //           PrintCombi(NCombi[p]);
+            //         }
+            */
+            
+            double ChiSquare = 0;
+            
+            /* Timing is not yet implemented into strip pairing. But maybe one day...
+            vector<double> HVtauList;
+            vector<double> LVtauList;
+            vector<double> HVtauResolutionList;
+            vector<double> LVtauResolutionList;
+            double HVtauMeanResolution = 0;
+            double LVtauMeanResolution = 0;
+            double HVtauMean = 0;
+            double LVtauMean = 0;
+            */
+            
+            for (unsigned int en = 0; en < MinSize; ++en) { // en and ep are on the strip grouping level (ie if there's charge sharing)
+                unsigned int ep = en;
+                
+                double LVEnergy = 0;
+                double LVResolution = 0;
+                
+                // unsigned int dominantLV;
+                // double MaxEnergy = -numeric_limits<double>::max();
+                
+                // Add up LV energy and energy resolution for grouping of strips
+                for (unsigned int entry = 0; entry < Combinations[d][0][lv][en].size(); ++entry) { // entry is on the strip level
+                    /* Currently I don't believe the dominant strip is used in strip pairing, so let's comment it out
+                     
+                    double tempEnergy = StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
+                    if (tempEnergy > MaxEnergy){
+                        dominantLV = entry;
+                        MaxEnergy = tempEnergy; //keeps track of max energy on a single strip
+                    }
+                    */
+                     
+                    LVEnergy += StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
+                    LVResolution += pow(StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergyResolution(), 2);
+                }
+                
+                // Repeats for HV side
+                double HVEnergy = 0;
+                double HVResolution = 0;
+                // unsigned int dominantHV;
+                // MaxEnergy = -numeric_limits<double>::max();
+                for (unsigned int entry = 0; entry < Combinations[d][1][hv][ep].size(); ++entry) {
+                    /* Currently I don't believe the dominant strip is used in strip pairing, so let's comment it out
+                     
+                    double tempEnergy = StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
+                    if (tempEnergy > MaxEnergy){
+                        dominantHV = entry;
+                        MaxEnergy = tempEnergy;
+                    }
+                    */
+                    
+                    HVEnergy += StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
+                    HVResolution += pow(StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergyResolution(), 2);
+                }
+                
+                // Sum chi square over entire LV/HV combination
+                ChiSquare += (LVEnergy - HVEnergy)*(LVEnergy - HVEnergy) / (LVResolution + HVResolution);
+                
+                /*
+                 
+                In the future, this chunk will be used to implement timing info into strip pairing. It has not yet been implemented.
+ 
+                double LVtau = StripHits[d][0][Combinations[d][0][lv][en][dominantLV]]->GetTiming();
+                double HVtau = StripHits[d][1][Combinations[d][1][hv][ep][dominantHV]]->GetTiming();
+                
+                // Charge trapping correction
+                // correction made based only on the dominant X and Y strip in a grouping of strips (eg neighboring strips)
+                // double CTDHVShift = LVtau - HVtau + 200;
+                // double slope = ChargeTrappingMap[d][Combinations[d][0][xc][en][dominantX]->GetStripID()][Combinations[d][1][yc][ep][dominantY]->GetStripID()][0];
+                // double intercept = ChargeTrappingMap[d][Combinations[d][0][xc][en][dominantX]->GetStripID()][Combinations[d][1][yc][ep][dominantY]->GetStripID()][1];
+                // yEnergy /= 1 - (slope*CTDHVShift - intercept)/100;
+                
+                // Right now, adding up all the strips in the grouping's Yenergies then applying the CTD correction to the sum... is that correct?
+                
+                HVtauList.push_back(HVtau);
+                LVtauList.push_back(-LVtau);
+                HVtauMean += HVtau;
+                LVtauMean += LVtau;
+                
+                // !!! TODO: Fix timing resolution. Maybe put GetTimingResolution into MStripHit
+                double LVtauResolution = 3*60/StripHits[d][0][Combinations[d][0][lv][en][dominantLV]]->GetEnergy();
+                double HVtauResolution = 3*60/StripHits[d][1][Combinations[d][1][hv][ep][dominantHV]]->GetEnergy();
+                
+                HVtauResolutionList.push_back(HVtauResolution*HVtauResolution);
+                LVtauResolutionList.push_back(LVtauResolution*LVtauResolution);
+                
+                HVtauMeanResolution += HVtauResolution*HVtauResolution;
+                LVtauMeanResolution += LVtauResolution*LVtauResolution;
+ 
+ 
+                HVtauMean /= MinSize;
+                LVtauMean /= MinSize;
+                HVtauMeanResolution /= MinSize*MinSize;
+                LVtauMeanResolution /= MinSize*MinSize;
+                 
+                vector<size_t> HVTauArgsort = Argsort(HVtauList);
+                vector<size_t> LVTauArgsort = Argsort(LVtauList);
+                bool TimesOrdered = true;
+                // for (unsigned int i=0; i<HVTauArgsort.size(); ++i) {
+                //   if (HVTauArgsort[i]!=LVTauArgsort[i]){
+                //     TimesOrdered = false;
+                //   }
+                // }
+                 
+                // Calculate the distance between measurements and properly order lists of drift times --> time ordering!!
+                double HVTimeOrderDistance = 0;
+                double LVTimeOrderDistance = 0;
+                for (unsigned int i=0; i<HVTauArgsort.size(); ++i) {
+                     if (HVTauArgsort[i]!=LVTauArgsort[i]){
+                         HVTimeOrderDistance += (HVtauList[HVTauArgsort[i]] - HVtauList[LVTauArgsort[i]])*(HVtauList[HVTauArgsort[i]] - HVtauList[LVTauArgsort[i]])/(HVtauResolutionList[HVTauArgsort[i]] + HVtauResolutionList[LVTauArgsort[i]]);
+                         LVTimeOrderDistance += (LVtauList[HVTauArgsort[i]] - LVtauList[LVTauArgsort[i]])*(LVtauList[HVTauArgsort[i]] - LVtauList[LVTauArgsort[i]])/(LVtauResolutionList[HVTauArgsort[i]] + LVtauResolutionList[LVTauArgsort[i]]);
+                     }
+                }
+                 
+                // if ((HVTimeOrderDistance < LVTimeOrderDistance) && (HVTimeOrderDistance > 50)) {
+                //   TimesOrdered = false;
+                // }
+                // else if ((LVTimeOrderDistance < HVTimeOrderDistance) && (LVTimeOrderDistance > 50)) {
+                //   TimesOrdered = false;
+                // }
+                 
+                // !!! TODO: Do we need to take into account difference in hole and electron drift times?
+                // for( unsigned int h=0; h < HVtauList.size(); ++h ){
+                //   ChiSquare += ((HVtauList[h] - HVtauMean) + (LVtauList[h] - LVtauMean)) * ((HVtauList[h] - HVtauMean) + (LVtauList[h] - LVtauMean))/(HVtauMeanResolution + LVtauMeanResolution + HVtauResolutionList[h] + LVtauResolutionList[h]);
+                // }
+                */
+                
+                /* Debugging: Output energies and energy resolution of each strip grouping
+                //cout << "yEnergy: " << yEnergy << endl;
+                //cout << "  Sub - Test en=" << en << " (" << xEnergy << ") with ep="
+                //     << ep << " (" << yEnergy << "):" << endl;
+                //cout<<xResolution<<":"<<yResolution<<endl;
+                */
+                
+            }
+            
+            // Calculate reduced chi^2 be dividing by number of strip groupings within the combination
+            ChiSquare /= MinSize;
+            
+            if (ChiSquare < BestChiSquare) {
+                BestChiSquare = ChiSquare;
+                BestLVSideCombo = Combinations[d][0][lv];
+                BestHVSideCombo = Combinations[d][1][hv];
+            }
+            
+            //cout<<"ChiSquare: "<<ChiSquare<<endl;
+            
+            // Cycle through all permutations to reach every possible strip pairing
+            if (Combinations[d][1][hv].size() > Combinations[d][0][lv].size()) {
+                MorePermutations = next_permutation(Combinations[d][1][hv].begin(), Combinations[d][1][hv].end());
+            } else {
+                MorePermutations = next_permutation(Combinations[d][0][lv].begin(), Combinations[d][0][lv].end());
+
+            }
+        }
+    }
+}
+    
+    /* Debugging: Output best LV and HV combinations
+     cout<<"Best combo:"<<endl;
+     cout<<"X: ";
+     for (unsigned h = 0; h < BestXSideCombo.size(); ++h) {
+     cout<<" (";
+     for (unsigned int sh = 0; sh < BestXSideCombo[h].size(); ++sh) {
+     cout<<StripHits[d][0][BestXSideCombo[h][sh]]->GetStripID()<<" ";
+     }
+     cout<<")";
+     }
+     cout<<endl;
+     cout<<"Y: ";
+     for (unsigned h = 0; h < BestYSideCombo.size(); ++h) {
+     cout<<" (";
+     for (unsigned int sh = 0; sh < BestYSideCombo[h].size(); ++sh) {
+     cout<<StripHits[d][1][BestYSideCombo[h][sh]]->GetStripID()<<" ";
+     }
+     cout<<")";
+     }
+     cout<<endl;
+     */
+    
+    return { BestLVSideCombo, BestHVSideCombo, BestChiSquare };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Create hits
+bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo) {
+    
+    // double LVPos = 0;
+    // double HVPos = 0;
+    
+    
+    double LVEnergy = 0;
+    double LVEnergyRes = 0;
+    
+    double HVEnergy = 0;
+    double HVEnergyRes = 0;
+    
+    double Energy = 0;
+    double EnergyResolution = 0;
+   
+    // "Total" is across event
+    double EnergyTotal = 0;
+    double LVEnergyTotal = 0;
+    double HVEnergyTotal = 0;
+    double LVEnergyResTotal = 0;
+    double HVEnergyResTotal = 0;
+    
+    // Create vectors for plotting LV and HV energies
+    vector<double> LVEnergies;
+    vector<double> HVEnergies;
+    
+    for (unsigned int h = 0; h < min(BestLVSideCombo.size(), BestHVSideCombo.size()); ++h) { // Loop over groupings of strips
+        
+        // LVPos = 0;
+        // HVPos = 0;
+        LVEnergy = 0;
+        HVEnergy = 0;
+        LVEnergyRes = 0;
+        HVEnergyRes = 0;
+        
+        // Check if there are any non-adjacent groupings of strips
+        bool AllAdjacentLV = true;
+        bool AllAdjacentHV = true;
+        bool AllAdjacent = true;
+        
+        for (unsigned int sh = 0; sh < BestLVSideCombo[h].size() - 1; ++sh) {
+            if (StripHits[d][0][BestLVSideCombo[h][sh]]->GetStripID() + 1 != StripHits[d][0][BestLVSideCombo[h][sh+1]]->GetStripID()) {
+                AllAdjacentLV = false;
+                AllAdjacent = false;
+                break;
+            }
+        }
+        
+        for (unsigned int sh = 0; sh < BestHVSideCombo[h].size() - 1; ++sh) {
+            if (StripHits[d][1][BestHVSideCombo[h][sh]]->GetStripID() + 1 != StripHits[d][1][BestHVSideCombo[h][sh+1]]->GetStripID()) {
+                AllAdjacentHV = false;
+                AllAdjacent = false;
+                break;
+            }
+        }
+        
+        //If there are no non-adjacent strip groupings, continue pairing as normal
+        if (AllAdjacent) {
+            
+            // Add up energy and energy resolution for each grouping of strips
+            for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+                //cout<<"x-pos: "<<StripHits[d][0][BestXSideCombo[h][sh]]->GetNonStripPosition()<<endl;
+                LVEnergy += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
+                LVEnergyRes += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
+            }
+            
+            LVEnergyResTotal += LVEnergyRes;
+            LVEnergyTotal += LVEnergy;
+            
+            LVEnergyRes = sqrt(LVEnergyRes);
+            
+            for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+                HVEnergy += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
+                HVEnergyRes += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
+            }
+            
+            // LVTau = StripHits[d][0][BestLVSideCombo[h][dominantLV]]->GetTiming();
+            // HVTau = StripHits[d][1][BestHVSideCombo[h][dominantHV]]->GetTiming();
+            
+            
+            HVEnergyResTotal += HVEnergyRes;
+            HVEnergyTotal += HVEnergy;
+            
+            HVEnergyRes = sqrt(HVEnergyRes);
+            
+            // Assign hit energy based on HV and LV energies
+            Energy = 0.0;
+            if (LVEnergy > HVEnergy + 3*HVEnergyRes) {
+                Energy = LVEnergy;
+                EnergyResolution = LVEnergyRes;
+            }
+            else if (HVEnergy > LVEnergy + 3*LVEnergyRes) {
+                Energy = HVEnergy;
+                EnergyResolution = HVEnergyRes;
+            }
+            else { // Take weighted average of LV and HV energies if one is not significantly higher than the other
+                Energy = (LVEnergy/(LVEnergyRes*LVEnergyRes) + HVEnergy/(HVEnergyRes*HVEnergyRes)) / (1.0/(LVEnergyRes*LVEnergyRes) + 1.0/(HVEnergyRes*HVEnergyRes));
+                EnergyResolution = sqrt( 1.0 / (1.0/(LVEnergyRes*LVEnergyRes) + 1.0/(HVEnergyRes*HVEnergyRes)) );
+            }
+            
+            EnergyTotal += Energy;
+            
+            LVEnergies.push_back(LVEnergy);
+            HVEnergies.push_back(HVEnergy);
+            
+            // Populate event with hits
+            MHit* Hit = new MHit();
+            Hit->SetEnergy(Energy);
+            Hit->SetLVEnergy(LVEnergy);
+            Hit->SetHVEnergy(HVEnergy);
+            Hit->SetEnergyResolution(EnergyResolution);
+            Event->AddHit(Hit);
+            
+            // Populate hit with strip hits
+            for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+                Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
+                //cout<<"Paired Strip:"<<endl;
+                //cout<<"StripID: "<<StripHits[d][0][BestXSideCombo[h][sh]]->GetStripID()<<endl;
+                
+            }
+            for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+                Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+            }
+        }
+        
+        // If there are non-adjacent strip groupings, then have to separate them out again to form multiple (physical) hits
+        // Multiple hits on LV side
+        if (AllAdjacentHV == false && AllAdjacentLV == true ) {
+            //cout<<"Multiple hits on single LV strip"<<endl;
+            bool MultipleHitsOnLV = true;
+            
+            Event->SetMultipleHitsOnLVStrip(MultipleHitsOnLV);
+            
+            // Assign hit energy based on energy measured on HV side
+            for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+                Energy = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
+                EnergyTotal += Energy;
+                EnergyResolution = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
+                
+                HVEnergy = Energy;
+                LVEnergy = Energy;
+                LVEnergyRes = EnergyResolution;
+                HVEnergyRes = EnergyResolution;
+                LVEnergyResTotal += LVEnergyRes * LVEnergyRes;
+                HVEnergyResTotal += HVEnergyRes * HVEnergyRes;
+                
+                // Populate event with hits
+                MHit* Hit = new MHit();
+                Hit->SetEnergy(Energy);
+                Hit->SetEnergyResolution(EnergyResolution);
+                Hit->SetLVEnergy(LVEnergy);
+                Hit->SetHVEnergy(HVEnergy);
+                Event->AddHit(Hit);
+                
+                HVEnergyTotal += HVEnergy;
+                LVEnergyTotal += LVEnergy;
+                
+                LVEnergies.push_back(LVEnergy);
+                HVEnergies.push_back(HVEnergy);
+                
+                // Populate hit with strip hits
+                Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+                for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+                    Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
+                    }
+                }
+            }
+        
+        // Multiple hits on HV side
+        else if (AllAdjacentLV == false && AllAdjacentHV == true) {
+           // cout<<"Multiple hits on single HV strip"<<endl;
+            bool MultipleHitsOnHV = true;
+            
+            Event->SetMultipleHitsOnHVStrip(MultipleHitsOnHV);
+            
+            // Assign hit energy based on energy measured on LV side
+            for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+                Energy = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
+                EnergyTotal += Energy;
+                EnergyResolution = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
+                
+                HVEnergy = Energy;
+                LVEnergy = Energy;
+                LVEnergyRes = EnergyResolution;
+                HVEnergyRes = EnergyResolution;
+                LVEnergyResTotal += LVEnergyRes * LVEnergyRes;
+                HVEnergyResTotal += HVEnergyRes * HVEnergyRes;
+                
+                // Populate event with hits
+                MHit* Hit = new MHit();
+                Hit->SetEnergy(Energy);
+                Hit->SetEnergyResolution(EnergyResolution);
+                Hit->SetLVEnergy(LVEnergy);
+                Hit->SetHVEnergy(HVEnergy);
+                Event->AddHit(Hit);
+
+                HVEnergyTotal += HVEnergy;
+                LVEnergyTotal += LVEnergy;
+                LVEnergies.push_back(LVEnergy);
+                HVEnergies.push_back(HVEnergy);
+                
+                // Populate hit with strip hits
+                Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
+                for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+                    Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+                    }
+                }
+        }
+        
+        // If both HV and LV have multiple hits per strip, can't pair
+        else if (AllAdjacentLV == false and AllAdjacentHV == false) {
+            Event->SetStripPairingIncomplete(true, "Strips not pairable. Multiple hits per strip on LV and HV sides");
+            Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+            return false;
+        }
+    }
+    
+    LVEnergyResTotal = sqrt(LVEnergyResTotal);
+    HVEnergyResTotal = sqrt(HVEnergyResTotal);
+    
+    // One last quality selection based on total event energies
+    if ((EnergyTotal > max(LVEnergyTotal, HVEnergyTotal) + 2.5*max(LVEnergyResTotal, HVEnergyResTotal) || EnergyTotal < min(LVEnergyTotal, HVEnergyTotal) - 2.5*max(LVEnergyResTotal, HVEnergyResTotal))) {
+        Event->SetStripPairingIncomplete(true, "Strips not pairable wihin 2.5 sigma of measured energy");
+        Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+        return false;
+    }
+    // Plot the good events
+    else if ((HasExpos() == true) and Event->IsGood() == true){
+        m_ExpoStripPairingHits->AddHits(Event->GetNHits());
+        for (unsigned int i = 0; i < LVEnergies.size(); ++i){
+            m_ExpoStripPairing->AddEnergies(LVEnergies[i], HVEnergies[i]);
+        }
+        for (unsigned int h = 0; h<Event->GetNHits(); h++){
+            double HVStrips = 0;
+            double LVStrips = 0;
+            for (unsigned int sh=0; sh<Event->GetHit(h)->GetNStripHits(); sh++){
+                if (Event->GetHit(h)->GetStripHit(sh)->IsLowVoltageStrip()==true){
+                    LVStrips++;
+                }
+                else{
+                    HVStrips++;
+                }
+            }
+            m_ExpoStripPairingStripHits->AddStripHits(LVStrips, HVStrips);
+        }
+    }
+    
+    return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+//! Main data analysis routine, which updates the event to a new level
+bool MModuleStripPairingChiSquareUpdated::AnalyzeEvent(MReadOutAssembly* Event) {
+    
+    // Check if there are actually any strip hits
+    if (Event->GetNStripHits() == 0) {
+      Event->SetStripPairingIncomplete(true, "No strip hits");
+      Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+      return false;
+    }
+    
+    // Collect strip hits from input event
+    vector<vector<vector<MStripHit*>>> StripHits = CollectStripHits(Event);
+    
+    // Perform some event selections
+    bool CheckStripHits = EventSelection(Event, StripHits);
+    
+    if (CheckStripHits == false) {
+        return false;
+    }
+    
+    // Find seed combinations from which all strip combinations will be computed
+    
+    // Define Combinations as list of: detector IDs, sides, strip combinations, set of grouped strips (ex. charge sharing on adjacent strip), strip
+    vector<vector<vector<vector<vector<unsigned int>>>>> Combinations;
+    
+    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+      Combinations.push_back(vector<vector<vector<vector<unsigned int>>>>()); // Create 4D vectors for each detector
+      Combinations[d].push_back(vector<vector<vector<unsigned int>>>()); // Create 3D vectors within each detector vector for each side
+      Combinations[d].push_back(vector<vector<vector<unsigned int>>>());
+
+      // Create the seed combinations that will be added (and expanded upon) for each side of each detector
+      for (unsigned int s = 0 ; s <= 1 ; ++s) {
+        vector<vector<unsigned int>> Combination;
+        for (unsigned int sh = 0; sh < StripHits[d][s].size(); ++sh) {
+          vector<unsigned int> CombinedStrips = { sh }; // Use grouping of single strip hit as seed for subsequent groupings
+          // sort(CombinedStrips.begin(), CombinedStrips.end());
+          Combination.push_back(CombinedStrips);
+        }
+          Combinations[d][s].push_back(Combination);
+      }
+    }
+    
+    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+    
+        // Begin the first round of strip pairing
+        bool RoundTwo = false;
+        
+        // Find all possible combinations based on the above seed combination
+        Combinations = FindAllCombinations(d, Combinations, StripHits, RoundTwo);
+        
+        // Evaluate reduced chi square for all combinations and select best LV/HV combinations
+        auto [ BestLVSideCombo, BestHVSideCombo, BestChiSquare ] = EvaluateAllCombinations(d, Combinations, StripHits);
+        
+        if (BestChiSquare > ChiSquareThreshold) {
+            RoundTwo = true;
+            
+            // Repeat strip pairing, now allowing groupings of non adjacent strips
+            Combinations = FindAllCombinations(d, Combinations, StripHits, RoundTwo);
+            auto [ BestLVSideComboRoundTwo, BestHVSideComboRoundTwo, BestChiSquareRoundTwo ] = EvaluateAllCombinations(d, Combinations, StripHits);
+            
+            // Update best LV/HV combos if a better pairing is found
+            if (BestChiSquareRoundTwo < BestChiSquare) {
+                BestChiSquare = BestChiSquareRoundTwo;
+                BestLVSideCombo = BestLVSideComboRoundTwo;
+                BestHVSideCombo = BestHVSideComboRoundTwo;
+            }
+        }
+        // Check if chi^2 was ever actually updated
+        if (BestChiSquare == numeric_limits<double>::max()) {
+            Event->SetStripPairingIncomplete(true, "Pairing did not find a single match");
+            Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+            return false;
+        }
+        // Flag events with a reduced chi square > 25
+        else if (BestChiSquare > 25) {
+            Event->SetStripPairingIncomplete(true, "Best reduced chi square is not below 25");
+            Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+            return false;
+        }
+        
+        // Assign the best reduced chi square to the event
+        Event->SetRedChiSquare(BestChiSquare);
+        
+        // Populate hits with best strip paired combination
+        bool PopulateHits = CreateHits(d, Event, StripHits, BestLVSideCombo, BestHVSideCombo);
+        
+        if (PopulateHits == false) {
+            return false;
+        }
+    
+    } // End Detector loop
+    
+    Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+    
+    return true;
+    
+    
+// (2.5) Create and populate charge trapping map for energy correction
+/*
+  vector<array<array<array<double, 2>, 64>, 64>> ChargeTrappingMap; //64 x 64 grid
+    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+        ChargeTrappingMap.push_back(array<array<array<double, 2>, 64>, 64>());
+        for (unsigned int i = 0; i < 64; ++i) {
+            for (unsigned int j = 0; j < 64; ++j) {
+                ChargeTrappingMap[d][i][j][0] = 0;
+                ChargeTrappingMap[d][i][j][1] = 0; //populate with 0s for now
+ Have to make sure I'm indexing correctly!!! Do the Strip IDs start at 0???
+ Also need to make sure the indexing on the detectors is consistent. Ie, what is detector 0, 1, etc.
+            }
+        }
+    }
+  
+*/
+    
+  
+    
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+vector<size_t> MModuleStripPairingChiSquareUpdated::Argsort(vector<double> &list)
+{
+  // Return the order of indices resulting from list sorting
+  // initialize original index locations
+  vector<size_t> idx(list.size());
+  iota(idx.begin(), idx.end(), 0);
+
+  // sort indexes based on comparing values in v
+  // using std::stable_sort instead of std::sort
+  // to avoid unnecessary index re-orderings
+  // when v contains elements of equal values
+  stable_sort(idx.begin(), idx.end(),
+       [&list](size_t i1, size_t i2) {return list[i1] < list[i2];});
+
+  return idx;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleStripPairingChiSquareUpdated::Finalize()
+{
+  // Finalize the analysis - do all cleanup, i.e., undo Initialize()
+
+  MModule::Finalize();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleStripPairingChiSquareUpdated::ShowOptionsGUI()
+{
+  //! Show the options GUI --- has to be overwritten!
+
+  MGUIOptionsStripPairing* Options = new MGUIOptionsStripPairing(this);
+  Options->Create();
+  gClient->WaitForUnmap(Options);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleStripPairingChiSquareUpdated::ReadXmlConfiguration(MXmlNode* Node)
+{
+  //! Read the configuration data from an XML node
+
+  /*
+  MXmlNode* SomeTagNode = Node->GetNode("SomeTag");
+  if (SomeTagNode != 0) {
+    m_SomeTagValue = SomeTagNode->GetValue();
+  }
+  */
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MXmlNode* MModuleStripPairingChiSquareUpdated::CreateXmlConfiguration()
+{
+  //! Create an XML node tree from the configuration
+
+  MXmlNode* Node = new MXmlNode(0, m_XmlTag);
+  
+  /*
+  MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
+  */
+
+  return Node;
+}
+
+
+// MModuleStripPairingChiSquareUpdated.cxx: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MModuleStripPairingChiSquareUpdated.cxx
+++ b/src/MModuleStripPairingChiSquareUpdated.cxx
@@ -378,20 +378,8 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
                 double LVEnergy = 0;
                 double LVResolution = 0;
                 
-                // unsigned int dominantLV;
-                // double MaxEnergy = -numeric_limits<double>::max();
-                
                 // Add up LV energy and energy resolution for grouping of strips
-                for (unsigned int entry = 0; entry < Combinations[d][0][lv][en].size(); ++entry) { // entry is on the strip level
-                    /* Currently I don't believe the dominant strip is used in strip pairing, so let's comment it out
-                     
-                    double tempEnergy = StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
-                    if (tempEnergy > MaxEnergy){
-                        dominantLV = entry;
-                        MaxEnergy = tempEnergy; //keeps track of max energy on a single strip
-                    }
-                    */
-                     
+                for (unsigned int entry = 0; entry < Combinations[d][0][lv][en].size(); ++entry) { // Entry is on the strip level
                     LVEnergy += StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
                     LVResolution += pow(StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergyResolution(), 2);
                     
@@ -531,10 +519,6 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
             // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
             // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
             HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
-            
-            // LVTau = StripHits[d][0][BestLVSideCombo[h][dominantLV]]->GetTiming();
-            // HVTau = StripHits[d][1][BestHVSideCombo[h][dominantHV]]->GetTiming();
-            
             
             HVEnergyResTotal += HVEnergyRes;
             HVEnergyTotal += HVEnergy;

--- a/src/MModuleStripPairingChiSquareUpdated.cxx
+++ b/src/MModuleStripPairingChiSquareUpdated.cxx
@@ -110,7 +110,9 @@ void MModuleStripPairingChiSquareUpdated::CreateExpos()
 {
   // Create all expos
 
-  if (HasExpos() == true) return;
+  if (HasExpos() == true) {
+    return;
+  }
 
   // Set the histogram display
   m_ExpoStripPairing = new MGUIExpoStripPairing(this);
@@ -142,18 +144,18 @@ bool MModuleStripPairingChiSquareUpdated::Initialize()
 //! Function returns new combinations of strips based on seed combinations
 vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo)
 {
-    // Define new vector of ints NewOnes
+  // Define new vector of ints NewOnes
   vector<vector<vector<unsigned int>>> NewOnes; // <list> of <combinations> of <combined strips>
-    
+
   for (unsigned int listspot = 0; listspot < OldOnes.size(); ++listspot) { // Iterate over set of seed combinations
     // New single merges
     for (unsigned int combi1 = 0; combi1 < OldOnes[listspot].size(); ++combi1) { // Iterate over individual combos within set
-      for (unsigned int combi2 = combi1+1; combi2 < OldOnes[listspot].size(); ++combi2) { // Iterate through all the combos AFTER combi1
+      for (unsigned int combi2 = combi1 + 1; combi2 < OldOnes[listspot].size(); ++combi2) { // Iterate through all the combos AFTER combi1
         vector<unsigned int> NewCombinedStrips;
         NewCombinedStrips.insert(NewCombinedStrips.end(), OldOnes[listspot][combi1].begin(), OldOnes[listspot][combi1].end());
         NewCombinedStrips.insert(NewCombinedStrips.end(), OldOnes[listspot][combi2].begin(), OldOnes[listspot][combi2].end());
         sort(NewCombinedStrips.begin(), NewCombinedStrips.end());
-        
+
         // The above combines each combination with all the subsequent combinations in order to produce new combinations of strips
 
         vector<unsigned int> NewCombinedAsIDs;
@@ -161,29 +163,17 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
           NewCombinedAsIDs.push_back(StripHits[NewCombinedStrips[s]]->GetStripID()); // Translates the hit number to the actual strip ID
         }
         sort(NewCombinedAsIDs.begin(), NewCombinedAsIDs.end());
-        
-        if (RoundTwo == false) {
-            bool AllAdjacent = true;
-            for (unsigned int c = 1; c < NewCombinedAsIDs.size(); ++c) {
-              if (NewCombinedAsIDs[c-1] + 1 != NewCombinedAsIDs[c]) {
-                AllAdjacent = false;
-                break;
-              }
-            } // Checks if the new combo is of adjacent strips
 
-            if (AllAdjacent == true) {
-              vector<vector<unsigned int>> NewCombo;
-              for (unsigned int news = 0; news < OldOnes[listspot].size(); ++news) {
-                if (news != combi1 && news != combi2) {
-                  NewCombo.push_back(OldOnes[listspot][news]);
-                }
-                if (news == combi1) {
-                  NewCombo.push_back(NewCombinedStrips);
-                }
-              }
-              NewOnes.push_back(NewCombo);
+        if (RoundTwo == false) {
+          bool AllAdjacent = true;
+          for (unsigned int c = 1; c < NewCombinedAsIDs.size(); ++c) {
+            if (NewCombinedAsIDs[c - 1] + 1 != NewCombinedAsIDs[c]) {
+              AllAdjacent = false;
+              break;
             }
-        } else {
+          } // Checks if the new combo is of adjacent strips
+
+          if (AllAdjacent == true) {
             vector<vector<unsigned int>> NewCombo;
             for (unsigned int news = 0; news < OldOnes[listspot].size(); ++news) {
               if (news != combi1 && news != combi2) {
@@ -194,6 +184,18 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
               }
             }
             NewOnes.push_back(NewCombo);
+          }
+        } else {
+          vector<vector<unsigned int>> NewCombo;
+          for (unsigned int news = 0; news < OldOnes[listspot].size(); ++news) {
+            if (news != combi1 && news != combi2) {
+              NewCombo.push_back(OldOnes[listspot][news]);
+            }
+            if (news == combi1) {
+              NewCombo.push_back(NewCombinedStrips);
+            }
+          }
+          NewOnes.push_back(NewCombo);
         }
       }
     }
@@ -206,594 +208,592 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Apply a charge trapping correction to each potential pair of LV/HV strips
-float MModuleStripPairingChiSquareUpdated::ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits) {
-    
-    // Dummy Function
-    // Idea: Read in detector number and set of LV/HV strips to be paired
-    // Will also need to read in actual charge trapping parameters from text file
-    // The LV/HVStripSet will only be multiple strips if there is charge sharing going on. Otherwise it'll just be a vector with a single number. That number will have to be converted to the actual stripID
-    // In the case of charge sharing, will have to find "dominant" LV/HV strip to get correct CTD
-    // I'm going to make another function "FindDominantStrip" to just get out the strip on LV or HV side that has the highest energy
-    // Return a corrected energy after applying charge trapping correction. Does there need to be two values or is correcting one side enough?
-    
-    float EnergyCorrection = 0;
+float MModuleStripPairingChiSquareUpdated::ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits)
+{
 
-    return EnergyCorrection;
+  // Dummy Function
+  // Idea: Read in detector number and set of LV/HV strips to be paired
+  // Will also need to read in actual charge trapping parameters from text file
+  // The LV/HVStripSet will only be multiple strips if there is charge sharing going on. Otherwise it'll just be a vector with a single number. That number will have to be converted to the actual stripID
+  // In the case of charge sharing, will have to find "dominant" LV/HV strip to get correct CTD
+  // I'm going to make another function "FindDominantStrip" to just get out the strip on LV or HV side that has the highest energy
+  // Return a corrected energy after applying charge trapping correction. Does there need to be two values or is correcting one side enough?
+
+  float EnergyCorrection = 0;
+
+  return EnergyCorrection;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Divide an event's strip hits by detector and LV/HV side
-vector<vector<vector<MStripHit*>>> MModuleStripPairingChiSquareUpdated::CollectStripHits(MReadOutAssembly* Event) {
-    
-    // Split hits by detector ID
-    vector<unsigned int> DetectorIDs;
-    vector<vector<vector<MStripHit*>>> StripHits; // list of detector IDs, list of sides (LV and HV), list of hits
+vector<vector<vector<MStripHit*>>> MModuleStripPairingChiSquareUpdated::CollectStripHits(MReadOutAssembly* Event)
+{
 
-    for (unsigned int sh = 0; sh < Event->GetNStripHits(); ++sh) { // Populate StripHits with this event's strip hits
-      MStripHit* SH = Event->GetStripHit(sh);
-      unsigned int Side = (SH->IsLowVoltageStrip() == true) ? 0 : 1;
+  // Split hits by detector ID
+  vector<unsigned int> DetectorIDs;
+  vector<vector<vector<MStripHit*>>> StripHits; // list of detector IDs, list of sides (LV and HV), list of hits
 
-      // Check if detector is on list
-      bool DetectorFound = false;
-      unsigned int DetectorPos = 0;
-      for (unsigned int d = 0; d < DetectorIDs.size(); ++d) {
-        if (DetectorIDs[d] == SH->GetDetectorID()) {
-          DetectorFound = true;
-          DetectorPos = d;
-        }
-      }
+  for (unsigned int sh = 0; sh < Event->GetNStripHits(); ++sh) { // Populate StripHits with this event's strip hits
+    MStripHit* SH = Event->GetStripHit(sh);
+    unsigned int Side = (SH->IsLowVoltageStrip() == true) ? 0 : 1;
 
-      // Once the correct detector is found, add strip hit to StripHits
-      if (DetectorFound == true) {
-        StripHits[DetectorPos][Side].push_back(SH);
-      }
-      else { // If encountering a new detector, initialize list of sides/hits corresponding to that detector
-        vector<vector<MStripHit*>> List; // list of sides, list of hits
-        List.push_back(vector<MStripHit*>()); // LV
-        List.push_back(vector<MStripHit*>()); // HV
-        List[Side].push_back(SH);
-        StripHits.push_back(List);
-        DetectorIDs.push_back(SH->GetDetectorID());
+    // Check if detector is on list
+    bool DetectorFound = false;
+    unsigned int DetectorPos = 0;
+    for (unsigned int d = 0; d < DetectorIDs.size(); ++d) {
+      if (DetectorIDs[d] == SH->GetDetectorID()) {
+        DetectorFound = true;
+        DetectorPos = d;
       }
     }
-    return StripHits;
-    
+
+    // Once the correct detector is found, add strip hit to StripHits
+    if (DetectorFound == true) {
+      StripHits[DetectorPos][Side].push_back(SH);
+    } else { // If encountering a new detector, initialize list of sides/hits corresponding to that detector
+      vector<vector<MStripHit*>> List; // list of sides, list of hits
+      List.push_back(vector<MStripHit*>()); // LV
+      List.push_back(vector<MStripHit*>()); // HV
+      List[Side].push_back(SH);
+      StripHits.push_back(List);
+      DetectorIDs.push_back(SH->GetDetectorID());
+    }
+  }
+  return StripHits;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Read in strip hits on each side for each detector and perform quality selections
-bool MModuleStripPairingChiSquareUpdated::EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits) {
-    
-    // Limit the number of strip hits on each side
-    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
-      for (unsigned int side = 0; side <=1; ++side) { // Side loop
-        if (StripHits[d][side].size() > MaxStripHits) {
-          Event->SetStripPairingIncomplete(true, "More than 6 hit strips on one side");
-          Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-          return false;
-        }
-        
-        // Check if one side of the detector has no strip hits
-        if (StripHits[d][side].size() == 0) {
-          Event->SetStripPairingIncomplete(true, "One detector side has no strip hits");
-          Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-          return false;
-          }
+bool MModuleStripPairingChiSquareUpdated::EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits)
+{
+
+  // Limit the number of strip hits on each side
+  for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+    for (unsigned int side = 0; side <= 1; ++side) { // Side loop
+      if (StripHits[d][side].size() > MaxStripHits) {
+        Event->SetStripPairingIncomplete(true, "More than 6 hit strips on one side");
+        Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+        return false;
+      }
+
+      // Check if one side of the detector has no strip hits
+      if (StripHits[d][side].size() == 0) {
+        Event->SetStripPairingIncomplete(true, "One detector side has no strip hits");
+        Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+        return false;
       }
     }
-   
-    return true;
+  }
+
+  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Find all strip combinations for each detector on LV and HV sides given seed combinations
-vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquareUpdated::FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo) {
+vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquareUpdated::FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo)
+{
 
-    for (unsigned int side = 0; side <=1; ++side) { // Side loop (LV and HV)
-        
-        vector<vector<vector<unsigned int>>> NewCombinations;
-        
-        bool CombinationsAdded = true;
-        while (CombinationsAdded == true) {
-            CombinationsAdded = false;
-            
-            NewCombinations = FindNewCombinations(Combinations[d][side], StripHits[d][side], RoundTwo);
-            //cout<<"Size: "<<NewCombinations.size()<<endl;
-            
-            // Find equal combinations and eliminate them from the new list
-            for (unsigned int c = 0; c < Combinations[d][side].size(); ++c) {
-                auto Iter = NewCombinations.begin();
-                while (Iter != NewCombinations.end()) {
-                    if (Combinations[d][side][c] == (*Iter)) {
-                        bool Equal = true;
-                        for (unsigned int deep = 0; deep < Combinations[d][side][c].size(); ++deep) {
-                            if (Combinations[d][side][c][deep] != (*Iter)[deep]) {
-                                Equal = false;
-                                break;
-                            }
-                        }
-                        if (Equal == true) {
-                            Iter = NewCombinations.erase(Iter);
-                        }
-                        else {
-                            Iter++;
-                        }
-                    }
-                    else {
-                        Iter++;
-                    }
-                }
+  for (unsigned int side = 0; side <= 1; ++side) { // Side loop (LV and HV)
+
+    vector<vector<vector<unsigned int>>> NewCombinations;
+
+    bool CombinationsAdded = true;
+    while (CombinationsAdded == true) {
+      CombinationsAdded = false;
+
+      NewCombinations = FindNewCombinations(Combinations[d][side], StripHits[d][side], RoundTwo);
+      //cout<<"Size: "<<NewCombinations.size()<<endl;
+
+      // Find equal combinations and eliminate them from the new list
+      for (unsigned int c = 0; c < Combinations[d][side].size(); ++c) {
+        auto Iter = NewCombinations.begin();
+        while (Iter != NewCombinations.end()) {
+          if (Combinations[d][side][c] == (*Iter)) {
+            bool Equal = true;
+            for (unsigned int deep = 0; deep < Combinations[d][side][c].size(); ++deep) {
+              if (Combinations[d][side][c][deep] != (*Iter)[deep]) {
+                Equal = false;
+                break;
+              }
             }
-            // If there are new combinations left, add them, and restart
-            if (NewCombinations.size() > 0) {
-                //cout<<NewCombinations.size()<<" new combinations found"<<endl;
-                for (auto C: NewCombinations) {
-                    Combinations[d][side].push_back(C);
-                }
-                CombinationsAdded = true; //keep going until no more combos added
+            if (Equal == true) {
+              Iter = NewCombinations.erase(Iter);
+            } else {
+              Iter++;
             }
+          } else {
+            Iter++;
+          }
         }
-    } // End Side loop
- 
-    return Combinations;
+      }
+      // If there are new combinations left, add them, and restart
+      if (NewCombinations.size() > 0) {
+        //cout<<NewCombinations.size()<<" new combinations found"<<endl;
+        for (auto C : NewCombinations) {
+          Combinations[d][side].push_back(C);
+        }
+        CombinationsAdded = true; //keep going until no more combos added
+      }
+    }
+  } // End Side loop
+
+  return Combinations;
 }
 
 //! Evaluate the reduced chi square for all possible strip pairings
-tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModuleStripPairingChiSquareUpdated::EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits) {
-    
-    double BestChiSquare = numeric_limits<double>::max();
-    vector<vector<unsigned int>> BestLVSideCombo;
-    vector<vector<unsigned int>> BestHVSideCombo;
-    
-    for (unsigned int lv = 0; lv < Combinations[d][0].size(); ++lv) { // Loop over combinations of lv-strips (lv represents a list of sets of strips,  and each set is a proposed Hit)
-        for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
-            // Skip if lv and hv strip combos differ in size by more than one
-            if (abs(long(Combinations[d][0][lv].size()) - long(Combinations[d][1][hv].size())) > 1) {
-            continue;
-        }
-        
-        unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
-        
-        // Skip pairing if either side has more than 5 sets of strips
-        if (max(Combinations[d][0][lv].size(), Combinations[d][1][hv].size()) > MaxCombinations) {
-            continue;
-        }
-        
-        bool MorePermutations = true;
-        while (MorePermutations == true) {
-             
-            double ChiSquare = 0;
-            
-            for (unsigned int en = 0; en < MinSize; ++en) { // en and ep are on the strip grouping level (ie if there's charge sharing)
-                unsigned int ep = en;
-                
-                // Collect LV and HV strips for current hit pairing
-                vector<vector<MStripHit*>> CurrentHitPairing;
-                CurrentHitPairing.push_back(vector<MStripHit*>());
-                CurrentHitPairing.push_back(vector<MStripHit*>());
-                
-                double LVEnergy = 0;
-                double LVResolution = 0;
-                
-                // Add up LV energy and energy resolution for grouping of strips
-                for (unsigned int entry = 0; entry < Combinations[d][0][lv][en].size(); ++entry) { // Entry is on the strip level
-                    LVEnergy += StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
-                    LVResolution += pow(StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergyResolution(), 2);
-                    
-                    // Add strip to current hit pairing
-                    CurrentHitPairing[0].push_back(StripHits[d][0][Combinations[d][0][lv][en][entry]]);
-                }
-                
-                // Repeats for HV side
-                double HVEnergy = 0;
-                double HVResolution = 0;
-                
-                for (unsigned int entry = 0; entry < Combinations[d][1][hv][ep].size(); ++entry) {
-                    HVEnergy += StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
-                    HVResolution += pow(StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergyResolution(), 2);
-                    
-                    // Add strip to current hit pairing
-                    CurrentHitPairing[1].push_back(StripHits[d][1][Combinations[d][1][hv][ep][entry]]);
-                }
-                
-                // Apply charge trapping correction for each LV/HV pairing
-                // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
-                // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
-                HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
-                
-                // Sum chi square over entire LV/HV combination
-                ChiSquare += (LVEnergy - HVEnergy)*(LVEnergy - HVEnergy) / (LVResolution + HVResolution);
-            }
-            
-            // Calculate reduced chi^2 be dividing by number of strip groupings within the combination
-            ChiSquare /= MinSize;
-            
-            if (ChiSquare < BestChiSquare) {
-                BestChiSquare = ChiSquare;
-                BestLVSideCombo = Combinations[d][0][lv];
-                BestHVSideCombo = Combinations[d][1][hv];
-            }
-            
-            // Cycle through all permutations to reach every possible strip pairing
-            if (Combinations[d][1][hv].size() > Combinations[d][0][lv].size()) {
-                MorePermutations = next_permutation(Combinations[d][1][hv].begin(), Combinations[d][1][hv].end());
-            } else {
-                MorePermutations = next_permutation(Combinations[d][0][lv].begin(), Combinations[d][0][lv].end());
+tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModuleStripPairingChiSquareUpdated::EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits)
+{
 
-            }
+  double BestChiSquare = numeric_limits<double>::max();
+  vector<vector<unsigned int>> BestLVSideCombo;
+  vector<vector<unsigned int>> BestHVSideCombo;
+
+  for (unsigned int lv = 0; lv < Combinations[d][0].size(); ++lv) { // Loop over combinations of lv-strips (lv represents a list of sets of strips,  and each set is a proposed Hit)
+    for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
+      // Skip if lv and hv strip combos differ in size by more than one
+      if (abs(long(Combinations[d][0][lv].size()) - long(Combinations[d][1][hv].size())) > 1) {
+        continue;
+      }
+
+      unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
+
+      // Skip pairing if either side has more than 5 sets of strips
+      if (max(Combinations[d][0][lv].size(), Combinations[d][1][hv].size()) > MaxCombinations) {
+        continue;
+      }
+
+      bool MorePermutations = true;
+      while (MorePermutations == true) {
+
+        double ChiSquare = 0;
+
+        for (unsigned int en = 0; en < MinSize; ++en) { // en and ep are on the strip grouping level (ie if there's charge sharing)
+          unsigned int ep = en;
+
+          // Collect LV and HV strips for current hit pairing
+          vector<vector<MStripHit*>> CurrentHitPairing;
+          CurrentHitPairing.push_back(vector<MStripHit*>());
+          CurrentHitPairing.push_back(vector<MStripHit*>());
+
+          double LVEnergy = 0;
+          double LVResolution = 0;
+
+          // Add up LV energy and energy resolution for grouping of strips
+          for (unsigned int entry = 0; entry < Combinations[d][0][lv][en].size(); ++entry) { // Entry is on the strip level
+            LVEnergy += StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergy();
+            LVResolution += pow(StripHits[d][0][Combinations[d][0][lv][en][entry]]->GetEnergyResolution(), 2);
+
+            // Add strip to current hit pairing
+            CurrentHitPairing[0].push_back(StripHits[d][0][Combinations[d][0][lv][en][entry]]);
+          }
+
+          // Repeats for HV side
+          double HVEnergy = 0;
+          double HVResolution = 0;
+
+          for (unsigned int entry = 0; entry < Combinations[d][1][hv][ep].size(); ++entry) {
+            HVEnergy += StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergy();
+            HVResolution += pow(StripHits[d][1][Combinations[d][1][hv][ep][entry]]->GetEnergyResolution(), 2);
+
+            // Add strip to current hit pairing
+            CurrentHitPairing[1].push_back(StripHits[d][1][Combinations[d][1][hv][ep][entry]]);
+          }
+
+          // Apply charge trapping correction for each LV/HV pairing
+          // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
+          // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
+          HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
+
+          // Sum chi square over entire LV/HV combination
+          ChiSquare += (LVEnergy - HVEnergy) * (LVEnergy - HVEnergy) / (LVResolution + HVResolution);
         }
+
+        // Calculate reduced chi^2 be dividing by number of strip groupings within the combination
+        ChiSquare /= MinSize;
+
+        if (ChiSquare < BestChiSquare) {
+          BestChiSquare = ChiSquare;
+          BestLVSideCombo = Combinations[d][0][lv];
+          BestHVSideCombo = Combinations[d][1][hv];
+        }
+
+        // Cycle through all permutations to reach every possible strip pairing
+        if (Combinations[d][1][hv].size() > Combinations[d][0][lv].size()) {
+          MorePermutations = next_permutation(Combinations[d][1][hv].begin(), Combinations[d][1][hv].end());
+        } else {
+          MorePermutations = next_permutation(Combinations[d][0][lv].begin(), Combinations[d][0][lv].end());
+        }
+      }
     }
-}
-    return { BestLVSideCombo, BestHVSideCombo, BestChiSquare };
+  }
+  return { BestLVSideCombo, BestHVSideCombo, BestChiSquare };
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Create hits
-bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo) {
-    
-    
-    double LVEnergy = 0;
-    double LVEnergyRes = 0;
-    
-    double HVEnergy = 0;
-    double HVEnergyRes = 0;
-    
-    double Energy = 0;
-    double EnergyResolution = 0;
-   
-    // "Total" is across event
-    double EnergyTotal = 0;
-    double LVEnergyTotal = 0;
-    double HVEnergyTotal = 0;
-    double LVEnergyResTotal = 0;
-    double HVEnergyResTotal = 0;
-    
-    // Create vectors for plotting LV and HV energies
-    vector<double> LVEnergies;
-    vector<double> HVEnergies;
-    
-    for (unsigned int h = 0; h < min(BestLVSideCombo.size(), BestHVSideCombo.size()); ++h) { // Loop over groupings of strips
-        
-        LVEnergy = 0;
-        HVEnergy = 0;
-        LVEnergyRes = 0;
-        HVEnergyRes = 0;
-        
-        // Collect LV and HV strips for current hit pairing
-        vector<vector<MStripHit*>> CurrentHitPairing;
-        CurrentHitPairing.push_back(vector<MStripHit*>());
-        CurrentHitPairing.push_back(vector<MStripHit*>());
-        
-        // Check if there are any non-adjacent groupings of strips
-        bool AllAdjacentLV = true;
-        bool AllAdjacentHV = true;
-        bool AllAdjacent = true;
-        
-        for (unsigned int sh = 0; sh < BestLVSideCombo[h].size() - 1; ++sh) {
-            if (StripHits[d][0][BestLVSideCombo[h][sh]]->GetStripID() + 1 != StripHits[d][0][BestLVSideCombo[h][sh+1]]->GetStripID()) {
-                AllAdjacentLV = false;
-                AllAdjacent = false;
-                break;
-            }
-        }
-        
-        for (unsigned int sh = 0; sh < BestHVSideCombo[h].size() - 1; ++sh) {
-            if (StripHits[d][1][BestHVSideCombo[h][sh]]->GetStripID() + 1 != StripHits[d][1][BestHVSideCombo[h][sh+1]]->GetStripID()) {
-                AllAdjacentHV = false;
-                AllAdjacent = false;
-                break;
-            }
-        }
-        
-        // If there are no non-adjacent strip groupings, continue pairing as normal
-        if (AllAdjacent) {
-            
-            // Add up energy and energy resolution for each grouping of strips
-            for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
-                //cout<<"x-pos: "<<StripHits[d][0][BestXSideCombo[h][sh]]->GetNonStripPosition()<<endl;
-                LVEnergy += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
-                LVEnergyRes += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
-                
-                // Add strip to current hit pairing
-                CurrentHitPairing[0].push_back(StripHits[d][0][BestLVSideCombo[h][sh]]);
-            }
-            
-            LVEnergyResTotal += LVEnergyRes;
-            LVEnergyTotal += LVEnergy;
-            
-            LVEnergyRes = sqrt(LVEnergyRes);
-            
-            for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
-                HVEnergy += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
-                HVEnergyRes += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution()*StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
-                
-                // Add strip to current hit pairing
-                CurrentHitPairing[1].push_back(StripHits[d][1][BestHVSideCombo[h][sh]]);
-            }
-            
-            // Apply charge trapping correction for each LV/HV pairing
-            // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
-            // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
-            HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
-            
-            HVEnergyResTotal += HVEnergyRes;
-            HVEnergyTotal += HVEnergy;
-            
-            HVEnergyRes = sqrt(HVEnergyRes);
-            
-            // Assign hit energy based on HV and LV energies
-            Energy = 0.0;
-            if (LVEnergy > HVEnergy + 3*HVEnergyRes) {
-                Energy = LVEnergy;
-                EnergyResolution = LVEnergyRes;
-            }
-            else if (HVEnergy > LVEnergy + 3*LVEnergyRes) {
-                Energy = HVEnergy;
-                EnergyResolution = HVEnergyRes;
-            }
-            else { // Take weighted average of LV and HV energies if one is not significantly higher than the other
-                Energy = (LVEnergy/(LVEnergyRes*LVEnergyRes) + HVEnergy/(HVEnergyRes*HVEnergyRes)) / (1.0/(LVEnergyRes*LVEnergyRes) + 1.0/(HVEnergyRes*HVEnergyRes));
-                EnergyResolution = sqrt( 1.0 / (1.0/(LVEnergyRes*LVEnergyRes) + 1.0/(HVEnergyRes*HVEnergyRes)) );
-            }
-            
-            EnergyTotal += Energy;
-            
-            LVEnergies.push_back(LVEnergy);
-            HVEnergies.push_back(HVEnergy);
-            
-            // Populate event with hits
-            MHit* Hit = new MHit();
-            Hit->SetEnergy(Energy);
-            Hit->SetLVEnergy(LVEnergy);
-            Hit->SetHVEnergy(HVEnergy);
-            Hit->SetEnergyResolution(EnergyResolution);
-            Event->AddHit(Hit);
-            
-            // Populate hit with strip hits
-            for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
-                Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
-                
-            }
-            for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
-                Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
-            }
-        }
-        
-        // If there are non-adjacent strip groupings, then have to separate them out again to form multiple (physical) hits
-        // Multiple hits on LV side
-        
-        // !!! TODO: Figure out how to apply charge trapping correction to events with multiple hits on a single strip
-        if (AllAdjacentHV == false && AllAdjacentLV == true ) {
-            //cout<<"Multiple hits on single LV strip"<<endl;
-            bool MultipleHitsOnLV = true;
-            
-            Event->SetMultipleHitsOnLVStrip(MultipleHitsOnLV);
-            
-            // Assign hit energy based on energy measured on HV side
-            for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
-                Energy = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
-                EnergyTotal += Energy;
-                EnergyResolution = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
-                
-                HVEnergy = Energy;
-                LVEnergy = Energy;
-                LVEnergyRes = EnergyResolution;
-                HVEnergyRes = EnergyResolution;
-                LVEnergyResTotal += LVEnergyRes * LVEnergyRes;
-                HVEnergyResTotal += HVEnergyRes * HVEnergyRes;
-                
-                // Populate event with hits
-                MHit* Hit = new MHit();
-                Hit->SetEnergy(Energy);
-                Hit->SetEnergyResolution(EnergyResolution);
-                Hit->SetLVEnergy(LVEnergy);
-                Hit->SetHVEnergy(HVEnergy);
-                Event->AddHit(Hit);
-                
-                HVEnergyTotal += HVEnergy;
-                LVEnergyTotal += LVEnergy;
-                
-                LVEnergies.push_back(LVEnergy);
-                HVEnergies.push_back(HVEnergy);
-                
-                // Populate hit with strip hits
-                Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
-                for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
-                    Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
-                    }
-                }
-            }
-        
-        // Multiple hits on HV side
-        else if (AllAdjacentLV == false && AllAdjacentHV == true) {
-           // cout<<"Multiple hits on single HV strip"<<endl;
-            bool MultipleHitsOnHV = true;
-            
-            Event->SetMultipleHitsOnHVStrip(MultipleHitsOnHV);
-            
-            // Assign hit energy based on energy measured on LV side
-            for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
-                Energy = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
-                EnergyTotal += Energy;
-                EnergyResolution = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
-                
-                HVEnergy = Energy;
-                LVEnergy = Energy;
-                LVEnergyRes = EnergyResolution;
-                HVEnergyRes = EnergyResolution;
-                LVEnergyResTotal += LVEnergyRes * LVEnergyRes;
-                HVEnergyResTotal += HVEnergyRes * HVEnergyRes;
-                
-                // Populate event with hits
-                MHit* Hit = new MHit();
-                Hit->SetEnergy(Energy);
-                Hit->SetEnergyResolution(EnergyResolution);
-                Hit->SetLVEnergy(LVEnergy);
-                Hit->SetHVEnergy(HVEnergy);
-                Event->AddHit(Hit);
+bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo)
+{
 
-                HVEnergyTotal += HVEnergy;
-                LVEnergyTotal += LVEnergy;
-                LVEnergies.push_back(LVEnergy);
-                HVEnergies.push_back(HVEnergy);
-                
-                // Populate hit with strip hits
-                Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
-                for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
-                    Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
-                    }
-                }
-        }
-        
-        // If both HV and LV have multiple hits per strip, can't pair
-        else if (AllAdjacentLV == false and AllAdjacentHV == false) {
-            Event->SetStripPairingIncomplete(true, "Strips not pairable. Multiple hits per strip on LV and HV sides");
-            Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-            return false;
-        }
+
+  double LVEnergy = 0;
+  double LVEnergyRes = 0;
+
+  double HVEnergy = 0;
+  double HVEnergyRes = 0;
+
+  double Energy = 0;
+  double EnergyResolution = 0;
+
+  // "Total" is across event
+  double EnergyTotal = 0;
+  double LVEnergyTotal = 0;
+  double HVEnergyTotal = 0;
+  double LVEnergyResTotal = 0;
+  double HVEnergyResTotal = 0;
+
+  // Create vectors for plotting LV and HV energies
+  vector<double> LVEnergies;
+  vector<double> HVEnergies;
+
+  for (unsigned int h = 0; h < min(BestLVSideCombo.size(), BestHVSideCombo.size()); ++h) { // Loop over groupings of strips
+
+    LVEnergy = 0;
+    HVEnergy = 0;
+    LVEnergyRes = 0;
+    HVEnergyRes = 0;
+
+    // Collect LV and HV strips for current hit pairing
+    vector<vector<MStripHit*>> CurrentHitPairing;
+    CurrentHitPairing.push_back(vector<MStripHit*>());
+    CurrentHitPairing.push_back(vector<MStripHit*>());
+
+    // Check if there are any non-adjacent groupings of strips
+    bool AllAdjacentLV = true;
+    bool AllAdjacentHV = true;
+    bool AllAdjacent = true;
+
+    for (unsigned int sh = 0; sh < BestLVSideCombo[h].size() - 1; ++sh) {
+      if (StripHits[d][0][BestLVSideCombo[h][sh]]->GetStripID() + 1 != StripHits[d][0][BestLVSideCombo[h][sh + 1]]->GetStripID()) {
+        AllAdjacentLV = false;
+        AllAdjacent = false;
+        break;
+      }
     }
-    
-    LVEnergyResTotal = sqrt(LVEnergyResTotal);
-    HVEnergyResTotal = sqrt(HVEnergyResTotal);
-    
-    // One last quality selection based on total event energies
-    if ((EnergyTotal > max(LVEnergyTotal, HVEnergyTotal) + 2.5*max(LVEnergyResTotal, HVEnergyResTotal) || EnergyTotal < min(LVEnergyTotal, HVEnergyTotal) - 2.5*max(LVEnergyResTotal, HVEnergyResTotal))) {
-        Event->SetStripPairingIncomplete(true, "Strips not pairable wihin 2.5 sigma of measured energy");
-        Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-        return false;
+
+    for (unsigned int sh = 0; sh < BestHVSideCombo[h].size() - 1; ++sh) {
+      if (StripHits[d][1][BestHVSideCombo[h][sh]]->GetStripID() + 1 != StripHits[d][1][BestHVSideCombo[h][sh + 1]]->GetStripID()) {
+        AllAdjacentHV = false;
+        AllAdjacent = false;
+        break;
+      }
     }
-    // Plot the good events
-    else if ((HasExpos() == true) and Event->IsGood() == true){
-        m_ExpoStripPairingHits->AddHits(Event->GetNHits());
-        for (unsigned int i = 0; i < LVEnergies.size(); ++i){
-            m_ExpoStripPairing->AddEnergies(LVEnergies[i], HVEnergies[i]);
-        }
-        for (unsigned int h = 0; h<Event->GetNHits(); h++){
-            double HVStrips = 0;
-            double LVStrips = 0;
-            for (unsigned int sh=0; sh<Event->GetHit(h)->GetNStripHits(); sh++){
-                if (Event->GetHit(h)->GetStripHit(sh)->IsLowVoltageStrip()==true){
-                    LVStrips++;
-                }
-                else{
-                    HVStrips++;
-                }
-            }
-            m_ExpoStripPairingStripHits->AddStripHits(LVStrips, HVStrips);
-        }
+
+    // If there are no non-adjacent strip groupings, continue pairing as normal
+    if (AllAdjacent) {
+
+      // Add up energy and energy resolution for each grouping of strips
+      for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+        //cout<<"x-pos: "<<StripHits[d][0][BestXSideCombo[h][sh]]->GetNonStripPosition()<<endl;
+        LVEnergy += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
+        LVEnergyRes += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution() * StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
+
+        // Add strip to current hit pairing
+        CurrentHitPairing[0].push_back(StripHits[d][0][BestLVSideCombo[h][sh]]);
+      }
+
+      LVEnergyResTotal += LVEnergyRes;
+      LVEnergyTotal += LVEnergy;
+
+      LVEnergyRes = sqrt(LVEnergyRes);
+
+      for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+        HVEnergy += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
+        HVEnergyRes += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution() * StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
+
+        // Add strip to current hit pairing
+        CurrentHitPairing[1].push_back(StripHits[d][1][BestHVSideCombo[h][sh]]);
+      }
+
+      // Apply charge trapping correction for each LV/HV pairing
+      // !!! TODO: Fill ChargeTrappingCorrection function with actual trapping parameters
+      // Is it sufficient to only correct one side's energy or should a correction be applied to LV as well?
+      HVEnergy += ChargeTrappingCorrection(d, CurrentHitPairing);
+
+      HVEnergyResTotal += HVEnergyRes;
+      HVEnergyTotal += HVEnergy;
+
+      HVEnergyRes = sqrt(HVEnergyRes);
+
+      // Assign hit energy based on HV and LV energies
+      Energy = 0.0;
+      if (LVEnergy > HVEnergy + 3 * HVEnergyRes) {
+        Energy = LVEnergy;
+        EnergyResolution = LVEnergyRes;
+      } else if (HVEnergy > LVEnergy + 3 * LVEnergyRes) {
+        Energy = HVEnergy;
+        EnergyResolution = HVEnergyRes;
+      } else { // Take weighted average of LV and HV energies if one is not significantly higher than the other
+        Energy = (LVEnergy / (LVEnergyRes * LVEnergyRes) + HVEnergy / (HVEnergyRes * HVEnergyRes)) / (1.0 / (LVEnergyRes * LVEnergyRes) + 1.0 / (HVEnergyRes * HVEnergyRes));
+        EnergyResolution = sqrt(1.0 / (1.0 / (LVEnergyRes * LVEnergyRes) + 1.0 / (HVEnergyRes * HVEnergyRes)));
+      }
+
+      EnergyTotal += Energy;
+
+      LVEnergies.push_back(LVEnergy);
+      HVEnergies.push_back(HVEnergy);
+
+      // Populate event with hits
+      MHit* Hit = new MHit();
+      Hit->SetEnergy(Energy);
+      Hit->SetLVEnergy(LVEnergy);
+      Hit->SetHVEnergy(HVEnergy);
+      Hit->SetEnergyResolution(EnergyResolution);
+      Event->AddHit(Hit);
+
+      // Populate hit with strip hits
+      for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+        Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
+      }
+      for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+        Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+      }
     }
-    
-    return true;
+
+    // If there are non-adjacent strip groupings, then have to separate them out again to form multiple (physical) hits
+    // Multiple hits on LV side
+
+    // !!! TODO: Figure out how to apply charge trapping correction to events with multiple hits on a single strip
+    if (AllAdjacentHV == false && AllAdjacentLV == true) {
+      //cout<<"Multiple hits on single LV strip"<<endl;
+      bool MultipleHitsOnLV = true;
+
+      Event->SetMultipleHitsOnLVStrip(MultipleHitsOnLV);
+
+      // Assign hit energy based on energy measured on HV side
+      for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+        Energy = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
+        EnergyTotal += Energy;
+        EnergyResolution = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergyResolution();
+
+        HVEnergy = Energy;
+        LVEnergy = Energy;
+        LVEnergyRes = EnergyResolution;
+        HVEnergyRes = EnergyResolution;
+        LVEnergyResTotal += LVEnergyRes * LVEnergyRes;
+        HVEnergyResTotal += HVEnergyRes * HVEnergyRes;
+
+        // Populate event with hits
+        MHit* Hit = new MHit();
+        Hit->SetEnergy(Energy);
+        Hit->SetEnergyResolution(EnergyResolution);
+        Hit->SetLVEnergy(LVEnergy);
+        Hit->SetHVEnergy(HVEnergy);
+        Event->AddHit(Hit);
+
+        HVEnergyTotal += HVEnergy;
+        LVEnergyTotal += LVEnergy;
+
+        LVEnergies.push_back(LVEnergy);
+        HVEnergies.push_back(HVEnergy);
+
+        // Populate hit with strip hits
+        Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+        for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+          Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
+        }
+      }
+    }
+
+    // Multiple hits on HV side
+    else if (AllAdjacentLV == false && AllAdjacentHV == true) {
+      // cout<<"Multiple hits on single HV strip"<<endl;
+      bool MultipleHitsOnHV = true;
+
+      Event->SetMultipleHitsOnHVStrip(MultipleHitsOnHV);
+
+      // Assign hit energy based on energy measured on LV side
+      for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+        Energy = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
+        EnergyTotal += Energy;
+        EnergyResolution = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergyResolution();
+
+        HVEnergy = Energy;
+        LVEnergy = Energy;
+        LVEnergyRes = EnergyResolution;
+        HVEnergyRes = EnergyResolution;
+        LVEnergyResTotal += LVEnergyRes * LVEnergyRes;
+        HVEnergyResTotal += HVEnergyRes * HVEnergyRes;
+
+        // Populate event with hits
+        MHit* Hit = new MHit();
+        Hit->SetEnergy(Energy);
+        Hit->SetEnergyResolution(EnergyResolution);
+        Hit->SetLVEnergy(LVEnergy);
+        Hit->SetHVEnergy(HVEnergy);
+        Event->AddHit(Hit);
+
+        HVEnergyTotal += HVEnergy;
+        LVEnergyTotal += LVEnergy;
+        LVEnergies.push_back(LVEnergy);
+        HVEnergies.push_back(HVEnergy);
+
+        // Populate hit with strip hits
+        Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
+        for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+          Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+        }
+      }
+    }
+
+    // If both HV and LV have multiple hits per strip, can't pair
+    else if (AllAdjacentLV == false and AllAdjacentHV == false) {
+      Event->SetStripPairingIncomplete(true, "Strips not pairable. Multiple hits per strip on LV and HV sides");
+      Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+      return false;
+    }
+  }
+
+  LVEnergyResTotal = sqrt(LVEnergyResTotal);
+  HVEnergyResTotal = sqrt(HVEnergyResTotal);
+
+  // One last quality selection based on total event energies
+  if ((EnergyTotal > max(LVEnergyTotal, HVEnergyTotal) + 2.5 * max(LVEnergyResTotal, HVEnergyResTotal) || EnergyTotal < min(LVEnergyTotal, HVEnergyTotal) - 2.5 * max(LVEnergyResTotal, HVEnergyResTotal))) {
+    Event->SetStripPairingIncomplete(true, "Strips not pairable wihin 2.5 sigma of measured energy");
+    Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+    return false;
+  }
+  // Plot the good events
+  else if ((HasExpos() == true) and Event->IsGood() == true) {
+    m_ExpoStripPairingHits->AddHits(Event->GetNHits());
+    for (unsigned int i = 0; i < LVEnergies.size(); ++i) {
+      m_ExpoStripPairing->AddEnergies(LVEnergies[i], HVEnergies[i]);
+    }
+    for (unsigned int h = 0; h < Event->GetNHits(); h++) {
+      double HVStrips = 0;
+      double LVStrips = 0;
+      for (unsigned int sh = 0; sh < Event->GetHit(h)->GetNStripHits(); sh++) {
+        if (Event->GetHit(h)->GetStripHit(sh)->IsLowVoltageStrip() == true) {
+          LVStrips++;
+        } else {
+          HVStrips++;
+        }
+      }
+      m_ExpoStripPairingStripHits->AddStripHits(LVStrips, HVStrips);
+    }
+  }
+
+  return true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Main data analysis routine, which updates the event to a new level
-bool MModuleStripPairingChiSquareUpdated::AnalyzeEvent(MReadOutAssembly* Event) {
-    
-    // Check if there are actually any strip hits
-    if (Event->GetNStripHits() == 0) {
-      Event->SetStripPairingIncomplete(true, "No strip hits");
+bool MModuleStripPairingChiSquareUpdated::AnalyzeEvent(MReadOutAssembly* Event)
+{
+
+  // Check if there are actually any strip hits
+  if (Event->GetNStripHits() == 0) {
+    Event->SetStripPairingIncomplete(true, "No strip hits");
+    Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+    return false;
+  }
+
+  // Collect strip hits from input event
+  vector<vector<vector<MStripHit*>>> StripHits = CollectStripHits(Event);
+
+  // Perform some event selections
+  bool CheckStripHits = EventSelection(Event, StripHits);
+
+  if (CheckStripHits == false) {
+    return false;
+  }
+
+  // Find seed combinations from which all strip combinations will be computed
+
+  // Define Combinations as list of: detector IDs, sides, strip combinations, set of grouped strips (ex. charge sharing on adjacent strip), strip
+  vector<vector<vector<vector<vector<unsigned int>>>>> Combinations;
+
+  for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+    Combinations.push_back(vector<vector<vector<vector<unsigned int>>>>()); // Create 4D vectors for each detector
+    Combinations[d].push_back(vector<vector<vector<unsigned int>>>()); // Create 3D vectors within each detector vector for each side
+    Combinations[d].push_back(vector<vector<vector<unsigned int>>>());
+
+    // Create the seed combinations that will be added (and expanded upon) for each side of each detector
+    for (unsigned int s = 0; s <= 1; ++s) {
+      vector<vector<unsigned int>> Combination;
+      for (unsigned int sh = 0; sh < StripHits[d][s].size(); ++sh) {
+        vector<unsigned int> CombinedStrips = { sh }; // Use grouping of single strip hit as seed for subsequent groupings
+        // sort(CombinedStrips.begin(), CombinedStrips.end());
+        Combination.push_back(CombinedStrips);
+      }
+      Combinations[d][s].push_back(Combination);
+    }
+  }
+
+  for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
+
+    // Begin the first round of strip pairing
+    bool RoundTwo = false;
+
+    // Find all possible combinations based on the above seed combination
+    Combinations = FindAllCombinations(d, Combinations, StripHits, RoundTwo);
+
+    // Evaluate reduced chi square for all combinations and select best LV/HV combinations
+    auto [BestLVSideCombo, BestHVSideCombo, BestChiSquare] = EvaluateAllCombinations(d, Combinations, StripHits);
+
+    if (BestChiSquare > ChiSquareThreshold) {
+      RoundTwo = true;
+
+      // Repeat strip pairing, now allowing groupings of non adjacent strips
+      Combinations = FindAllCombinations(d, Combinations, StripHits, RoundTwo);
+      auto [BestLVSideComboRoundTwo, BestHVSideComboRoundTwo, BestChiSquareRoundTwo] = EvaluateAllCombinations(d, Combinations, StripHits);
+
+      // Update best LV/HV combos if a better pairing is found
+      if (BestChiSquareRoundTwo < BestChiSquare) {
+        BestChiSquare = BestChiSquareRoundTwo;
+        BestLVSideCombo = BestLVSideComboRoundTwo;
+        BestHVSideCombo = BestHVSideComboRoundTwo;
+      }
+    }
+    // Check if chi^2 was ever actually updated
+    if (BestChiSquare == numeric_limits<double>::max()) {
+      Event->SetStripPairingIncomplete(true, "Pairing did not find a single match");
       Event->SetAnalysisProgress(MAssembly::c_StripPairing);
       return false;
     }
-    
-    // Collect strip hits from input event
-    vector<vector<vector<MStripHit*>>> StripHits = CollectStripHits(Event);
-    
-    // Perform some event selections
-    bool CheckStripHits = EventSelection(Event, StripHits);
-    
-    if (CheckStripHits == false) {
-        return false;
+    // Flag events with a reduced chi square > 25
+    else if (BestChiSquare > 25) {
+      Event->SetStripPairingIncomplete(true, "Best reduced chi square is not below 25");
+      Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+      return false;
     }
-    
-    // Find seed combinations from which all strip combinations will be computed
-    
-    // Define Combinations as list of: detector IDs, sides, strip combinations, set of grouped strips (ex. charge sharing on adjacent strip), strip
-    vector<vector<vector<vector<vector<unsigned int>>>>> Combinations;
-    
-    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
-      Combinations.push_back(vector<vector<vector<vector<unsigned int>>>>()); // Create 4D vectors for each detector
-      Combinations[d].push_back(vector<vector<vector<unsigned int>>>()); // Create 3D vectors within each detector vector for each side
-      Combinations[d].push_back(vector<vector<vector<unsigned int>>>());
 
-      // Create the seed combinations that will be added (and expanded upon) for each side of each detector
-      for (unsigned int s = 0 ; s <= 1 ; ++s) {
-        vector<vector<unsigned int>> Combination;
-        for (unsigned int sh = 0; sh < StripHits[d][s].size(); ++sh) {
-          vector<unsigned int> CombinedStrips = { sh }; // Use grouping of single strip hit as seed for subsequent groupings
-          // sort(CombinedStrips.begin(), CombinedStrips.end());
-          Combination.push_back(CombinedStrips);
-        }
-          Combinations[d][s].push_back(Combination);
-      }
+    // Assign the best reduced chi square to the event
+    Event->SetRedChiSquare(BestChiSquare);
+
+    // Populate hits with best strip paired combination
+    bool PopulateHits = CreateHits(d, Event, StripHits, BestLVSideCombo, BestHVSideCombo);
+
+    if (PopulateHits == false) {
+      return false;
     }
-    
-    for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
-    
-        // Begin the first round of strip pairing
-        bool RoundTwo = false;
-        
-        // Find all possible combinations based on the above seed combination
-        Combinations = FindAllCombinations(d, Combinations, StripHits, RoundTwo);
-        
-        // Evaluate reduced chi square for all combinations and select best LV/HV combinations
-        auto [ BestLVSideCombo, BestHVSideCombo, BestChiSquare ] = EvaluateAllCombinations(d, Combinations, StripHits);
-        
-        if (BestChiSquare > ChiSquareThreshold) {
-            RoundTwo = true;
-            
-            // Repeat strip pairing, now allowing groupings of non adjacent strips
-            Combinations = FindAllCombinations(d, Combinations, StripHits, RoundTwo);
-            auto [ BestLVSideComboRoundTwo, BestHVSideComboRoundTwo, BestChiSquareRoundTwo ] = EvaluateAllCombinations(d, Combinations, StripHits);
-            
-            // Update best LV/HV combos if a better pairing is found
-            if (BestChiSquareRoundTwo < BestChiSquare) {
-                BestChiSquare = BestChiSquareRoundTwo;
-                BestLVSideCombo = BestLVSideComboRoundTwo;
-                BestHVSideCombo = BestHVSideComboRoundTwo;
-            }
-        }
-        // Check if chi^2 was ever actually updated
-        if (BestChiSquare == numeric_limits<double>::max()) {
-            Event->SetStripPairingIncomplete(true, "Pairing did not find a single match");
-            Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-            return false;
-        }
-        // Flag events with a reduced chi square > 25
-        else if (BestChiSquare > 25) {
-            Event->SetStripPairingIncomplete(true, "Best reduced chi square is not below 25");
-            Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-            return false;
-        }
-        
-        // Assign the best reduced chi square to the event
-        Event->SetRedChiSquare(BestChiSquare);
-        
-        // Populate hits with best strip paired combination
-        bool PopulateHits = CreateHits(d, Event, StripHits, BestLVSideCombo, BestHVSideCombo);
-        
-        if (PopulateHits == false) {
-            return false;
-        }
-    
-    } // End Detector loop
-    
-    Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-    
-    return true;
+
+  } // End Detector loop
+
+  Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+
+  return true;
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
 
-vector<size_t> MModuleStripPairingChiSquareUpdated::Argsort(vector<double> &list)
+vector<size_t> MModuleStripPairingChiSquareUpdated::Argsort(vector<double>& list)
 {
   // Return the order of indices resulting from list sorting
   // initialize original index locations
@@ -805,7 +805,7 @@ vector<size_t> MModuleStripPairingChiSquareUpdated::Argsort(vector<double> &list
   // to avoid unnecessary index re-orderings
   // when v contains elements of equal values
   stable_sort(idx.begin(), idx.end(),
-       [&list](size_t i1, size_t i2) {return list[i1] < list[i2];});
+              [&list](size_t i1, size_t i2) { return list[i1] < list[i2]; });
 
   return idx;
 }
@@ -861,7 +861,7 @@ MXmlNode* MModuleStripPairingChiSquareUpdated::CreateXmlConfiguration()
   //! Create an XML node tree from the configuration
 
   MXmlNode* Node = new MXmlNode(0, m_XmlTag);
-  
+
   /*
   MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
   */

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -1,13 +1,13 @@
 /*
- * MModuleStripPairingChiSquareUpdated.cxx
- * Chi Square Version (Updated 2025)
+ * MModuleStripPairingMultiRoundChiSquare.cxx
+ * Multi Round Chi Square Version
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Julian Gerber & Andreas Zoglauer.
  * All rights reserved.
  *
  *
  * This code implementation is the intellectual property of
- * Andreas Zoglauer.
+ * Julian Gerber & Andreas Zoglauer.
  *
  * By copying, distributing or modifying the Program (or any work
  * based on the Program) you indicate your acceptance of this statement,
@@ -18,13 +18,13 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 //
-// MModuleStripPairingChiSquareUpdated
+// MModuleStripPairingMultiRoundChiSquare
 //
 ////////////////////////////////////////////////////////////////////////////////
 
 
 // Include the header:
-#include "MModuleStripPairingChiSquareUpdated.h"
+#include "MModuleStripPairingMultiRoundChiSquare.h"
 
 // Standard libs:
 #include <fstream>
@@ -42,7 +42,7 @@
 
 
 #ifdef ___CLING___
-ClassImp(MModuleStripPairingChiSquareUpdated)
+ClassImp(MModuleStripPairingMultiRoundChiSquare)
 #endif
 
 
@@ -57,17 +57,17 @@ const unsigned int ChiSquareThreshold = 100; // If strip pairing does not reach 
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MModuleStripPairingChiSquareUpdated::MModuleStripPairingChiSquareUpdated() : MModule()
+MModuleStripPairingMultiRoundChiSquare::MModuleStripPairingMultiRoundChiSquare() : MModule()
 {
-  // Construct an instance of MModuleStripPairingChiSquareUpdated
+  // Construct an instance of MModuleStripPairingMultiRoundChiSquare
 
   // Set all module relevant information
 
   // Set the module name --- has to be unique
-  m_Name = "Strip pairing - chi square (updated - 2025)";
+  m_Name = "Strip pairing - Multi Round Chi Square";
 
   // Set the XML tag --- has to be unique --- no spaces allowed
-  m_XmlTag = "XmlTagStripPairingChiSquareUpdated";
+  m_XmlTag = "XmlTagStripPairingMultiRoundChiSquare";
 
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EventLoader);
@@ -97,16 +97,16 @@ MModuleStripPairingChiSquareUpdated::MModuleStripPairingChiSquareUpdated() : MMo
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MModuleStripPairingChiSquareUpdated::~MModuleStripPairingChiSquareUpdated()
+MModuleStripPairingMultiRoundChiSquare::~MModuleStripPairingMultiRoundChiSquare()
 {
-  // Delete this instance of MModuleStripPairingChiSquareUpdated
+  // Delete this instance of MModuleStripPairingMultiRoundChiSquare
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MModuleStripPairingChiSquareUpdated::CreateExpos()
+void MModuleStripPairingMultiRoundChiSquare::CreateExpos()
 {
   // Create all expos
 
@@ -132,7 +132,7 @@ void MModuleStripPairingChiSquareUpdated::CreateExpos()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool MModuleStripPairingChiSquareUpdated::Initialize()
+bool MModuleStripPairingMultiRoundChiSquare::Initialize()
 {
   // Initialize the module
 
@@ -140,9 +140,8 @@ bool MModuleStripPairingChiSquareUpdated::Initialize()
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-
 //! Function returns new combinations of strips based on seed combinations
-vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo)
+vector<vector<vector<unsigned int>>> MModuleStripPairingMultiRoundChiSquare::FindNewCombinations(vector<vector<vector<unsigned int>>> OldOnes, vector<MStripHit*> StripHits, bool RoundTwo)
 {
   // Define new vector of ints NewOnes
   vector<vector<vector<unsigned int>>> NewOnes; // <list> of <combinations> of <combined strips>
@@ -208,7 +207,7 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingChiSquareUpdated::FindNe
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Apply a charge trapping correction to each potential pair of LV/HV strips
-float MModuleStripPairingChiSquareUpdated::ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits)
+float MModuleStripPairingMultiRoundChiSquare::ChargeTrappingCorrection(unsigned int d, vector<vector<MStripHit*>> StripHits)
 {
 
   // Dummy Function
@@ -227,7 +226,7 @@ float MModuleStripPairingChiSquareUpdated::ChargeTrappingCorrection(unsigned int
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Divide an event's strip hits by detector and LV/HV side
-vector<vector<vector<MStripHit*>>> MModuleStripPairingChiSquareUpdated::CollectStripHits(MReadOutAssembly* Event)
+vector<vector<vector<MStripHit*>>> MModuleStripPairingMultiRoundChiSquare::CollectStripHits(MReadOutAssembly* Event)
 {
 
   // Split hits by detector ID
@@ -266,7 +265,7 @@ vector<vector<vector<MStripHit*>>> MModuleStripPairingChiSquareUpdated::CollectS
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Read in strip hits on each side for each detector and perform quality selections
-bool MModuleStripPairingChiSquareUpdated::EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits)
+bool MModuleStripPairingMultiRoundChiSquare::EventSelection(MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits)
 {
 
   // Limit the number of strip hits on each side
@@ -293,7 +292,7 @@ bool MModuleStripPairingChiSquareUpdated::EventSelection(MReadOutAssembly* Event
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Find all strip combinations for each detector on LV and HV sides given seed combinations
-vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquareUpdated::FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo)
+vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingMultiRoundChiSquare::FindAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits, bool RoundTwo)
 {
 
   for (unsigned int side = 0; side <= 1; ++side) { // Side loop (LV and HV)
@@ -344,7 +343,7 @@ vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingChiSquar
 }
 
 //! Evaluate the reduced chi square for all possible strip pairings
-tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModuleStripPairingChiSquareUpdated::EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits)
+tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModuleStripPairingMultiRoundChiSquare::EvaluateAllCombinations(unsigned int d, vector<vector<vector<vector<vector<unsigned int>>>>> Combinations, vector<vector<vector<MStripHit*>>> StripHits)
 {
 
   double BestChiSquare = numeric_limits<double>::max();
@@ -435,7 +434,7 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Create hits
-bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo)
+bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOutAssembly* Event, vector<vector<vector<MStripHit*>>> StripHits, vector<vector<unsigned int>> BestLVSideCombo, vector<vector<unsigned int>> BestHVSideCombo)
 {
 
 
@@ -692,7 +691,7 @@ bool MModuleStripPairingChiSquareUpdated::CreateHits(unsigned int d, MReadOutAss
 ////////////////////////////////////////////////////////////////////////////////
 
 //! Main data analysis routine, which updates the event to a new level
-bool MModuleStripPairingChiSquareUpdated::AnalyzeEvent(MReadOutAssembly* Event)
+bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Event)
 {
 
   // Check if there are actually any strip hits
@@ -793,7 +792,7 @@ bool MModuleStripPairingChiSquareUpdated::AnalyzeEvent(MReadOutAssembly* Event)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-vector<size_t> MModuleStripPairingChiSquareUpdated::Argsort(vector<double>& list)
+vector<size_t> MModuleStripPairingMultiRoundChiSquare::Argsort(vector<double>& list)
 {
   // Return the order of indices resulting from list sorting
   // initialize original index locations
@@ -814,7 +813,7 @@ vector<size_t> MModuleStripPairingChiSquareUpdated::Argsort(vector<double>& list
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MModuleStripPairingChiSquareUpdated::Finalize()
+void MModuleStripPairingMultiRoundChiSquare::Finalize()
 {
   // Finalize the analysis - do all cleanup, i.e., undo Initialize()
 
@@ -825,7 +824,7 @@ void MModuleStripPairingChiSquareUpdated::Finalize()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MModuleStripPairingChiSquareUpdated::ShowOptionsGUI()
+void MModuleStripPairingMultiRoundChiSquare::ShowOptionsGUI()
 {
   //! Show the options GUI --- has to be overwritten!
 
@@ -838,7 +837,7 @@ void MModuleStripPairingChiSquareUpdated::ShowOptionsGUI()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool MModuleStripPairingChiSquareUpdated::ReadXmlConfiguration(MXmlNode* Node)
+bool MModuleStripPairingMultiRoundChiSquare::ReadXmlConfiguration(MXmlNode* Node)
 {
   //! Read the configuration data from an XML node
 
@@ -856,7 +855,7 @@ bool MModuleStripPairingChiSquareUpdated::ReadXmlConfiguration(MXmlNode* Node)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MXmlNode* MModuleStripPairingChiSquareUpdated::CreateXmlConfiguration()
+MXmlNode* MModuleStripPairingMultiRoundChiSquare::CreateXmlConfiguration()
 {
   //! Create an XML node tree from the configuration
 
@@ -870,5 +869,5 @@ MXmlNode* MModuleStripPairingChiSquareUpdated::CreateXmlConfiguration()
 }
 
 
-// MModuleStripPairingChiSquareUpdated.cxx: the end...
+// MModuleStripPairingMultiRoundChiSquare.cxx: the end...
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -570,8 +570,6 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
       //cout<<"Multiple hits on single LV strip"<<endl;
       bool MultipleHitsOnLV = true;
 
-      Event->SetMultipleHitsOnLVStrip(MultipleHitsOnLV);
-
       // Assign hit energy based on energy measured on HV side
       for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
         Energy = StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy();
@@ -591,7 +589,9 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->SetEnergyResolution(EnergyResolution);
         Hit->SetLVEnergy(LVEnergy);
         Hit->SetHVEnergy(HVEnergy);
+        Hit->SetStripHitMultipleTimesX(MultipleHitsOnLV);
         Event->AddHit(Hit);
+          
 
         HVEnergyTotal += HVEnergy;
         LVEnergyTotal += LVEnergy;
@@ -612,8 +612,6 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
       // cout<<"Multiple hits on single HV strip"<<endl;
       bool MultipleHitsOnHV = true;
 
-      Event->SetMultipleHitsOnHVStrip(MultipleHitsOnHV);
-
       // Assign hit energy based on energy measured on LV side
       for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
         Energy = StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy();
@@ -633,6 +631,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->SetEnergyResolution(EnergyResolution);
         Hit->SetLVEnergy(LVEnergy);
         Hit->SetHVEnergy(HVEnergy);
+        Hit->SetStripHitMultipleTimesY(MultipleHitsOnHV);
         Event->AddHit(Hit);
 
         HVEnergyTotal += HVEnergy;

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -173,7 +173,7 @@ vector<vector<vector<unsigned int>>> MModuleStripPairingMultiRoundChiSquare::Fin
           } // Checks if the new combo is of adjacent strips
 
           if (AllAdjacent == true) {
-            vector<vector<unsigned int>> NewCombo;
+            vector<vector<unsigned int>> NewCombo; // List of newly combined strips
             for (unsigned int news = 0; news < OldOnes[listspot].size(); ++news) {
               if (news != combi1 && news != combi2) {
                 NewCombo.push_back(OldOnes[listspot][news]);
@@ -230,8 +230,8 @@ vector<vector<vector<MStripHit*>>> MModuleStripPairingMultiRoundChiSquare::Colle
 {
 
   // Split hits by detector ID
-  vector<unsigned int> DetectorIDs;
-  vector<vector<vector<MStripHit*>>> StripHits; // list of detector IDs, list of sides (LV and HV), list of hits
+  vector<unsigned int> DetectorIDs; // List of detector IDs
+  vector<vector<vector<MStripHit*>>> StripHits; // list of detector IDs, list of sides (LV and HV), list of strip hits
 
   for (unsigned int sh = 0; sh < Event->GetNStripHits(); ++sh) { // Populate StripHits with this event's strip hits
     MStripHit* SH = Event->GetStripHit(sh);
@@ -297,7 +297,7 @@ vector<vector<vector<vector<vector<unsigned int>>>>> MModuleStripPairingMultiRou
 
   for (unsigned int side = 0; side <= 1; ++side) { // Side loop (LV and HV)
 
-    vector<vector<vector<unsigned int>>> NewCombinations;
+    vector<vector<vector<unsigned int>>> NewCombinations; // List of combinations of combined strips
 
     bool CombinationsAdded = true;
     while (CombinationsAdded == true) {
@@ -347,8 +347,8 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
 {
 
   double BestChiSquare = numeric_limits<double>::max();
-  vector<vector<unsigned int>> BestLVSideCombo;
-  vector<vector<unsigned int>> BestHVSideCombo;
+  vector<vector<unsigned int>> BestLVSideCombo; // List of combined strips that comprise the best LV side combination
+  vector<vector<unsigned int>> BestHVSideCombo; // List of combined strips that comprise the best HV side combination
 
   for (unsigned int lv = 0; lv < Combinations[d][0].size(); ++lv) { // Loop over combinations of lv-strips (lv represents a list of sets of strips,  and each set is a proposed Hit)
     for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
@@ -373,7 +373,7 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
           unsigned int ep = en;
 
           // Collect LV and HV strips for current hit pairing
-          vector<vector<MStripHit*>> CurrentHitPairing;
+          vector<vector<MStripHit*>> CurrentHitPairing; // List of combined strips that are being analyzed currently
           CurrentHitPairing.push_back(vector<MStripHit*>());
           CurrentHitPairing.push_back(vector<MStripHit*>());
 
@@ -466,7 +466,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
     HVEnergyRes = 0;
 
     // Collect LV and HV strips for current hit pairing
-    vector<vector<MStripHit*>> CurrentHitPairing;
+    vector<vector<MStripHit*>> CurrentHitPairing; // List of combined strips that are being analyzed currently
     CurrentHitPairing.push_back(vector<MStripHit*>());
     CurrentHitPairing.push_back(vector<MStripHit*>());
 
@@ -702,7 +702,7 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
   }
 
   // Collect strip hits from input event
-  vector<vector<vector<MStripHit*>>> StripHits = CollectStripHits(Event);
+  vector<vector<vector<MStripHit*>>> StripHits = CollectStripHits(Event); // List of detectors, list of sides, list of strip hits
 
   // Perform some event selections
   bool CheckStripHits = EventSelection(Event, StripHits);

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -772,7 +772,7 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
     }
 
     // Assign the best reduced chi square to the event
-    Event->SetRedChiSquare(BestChiSquare);
+    Event->SetReducedChiSquare(BestChiSquare);
 
     // Populate hits with best strip paired combination
     bool PopulateHits = CreateHits(d, Event, StripHits, BestLVSideCombo, BestHVSideCombo);

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -190,9 +190,6 @@ void MReadOutAssembly::Clear()
   m_DepthCalibrationIncompleteString = "";
   m_DepthCalibration_OutofRange = false;
   m_DepthCalibration_OutofRangeString = "";
-    
-  m_MultipleHitsOnLVStrip = false;
-  m_MultipleHitsOnHVStrip = false;
 
   m_FilteredOut = false;
 
@@ -615,12 +612,18 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
   if (m_ShieldVeto == true) {
     S<<"BD Shield Veto"<<endl;
   }
-  if (m_MultipleHitsOnLVStrip == true) {
-    S<<"Multiple Hits on LV Strip"<<endl;
+  for (auto H : m_Hits) {
+    if (H->GetStripHitMultipleTimesX()) {
+      S<<"BD Multiple Hits on LV Strip"<<endl;
+      break;
     }
-  if (m_MultipleHitsOnHVStrip == true) {
-    S<<"Multiple Hits on HV Strip"<<endl;
+  }
+  for (auto H : m_Hits) {
+    if (H->GetStripHitMultipleTimesY()) {
+      S<<"BD Multiple Hits on HV Strip"<<endl;
+      break;
     }
+  }
   
   return true;
 }
@@ -709,7 +712,18 @@ void MReadOutAssembly::StreamEvta(ostream& S)
   if (m_ShieldVeto == true) {
     S<<"BD Shield Veto"<<endl;
   }
-
+  for (auto H : m_Hits) {
+    if (H->GetStripHitMultipleTimesX()) {
+      S<<"BD Multiple Hits on LV Strip"<<endl;
+      break;
+    }
+  }
+  for (auto H : m_Hits) {
+    if (H->GetStripHitMultipleTimesY()) {
+      S<<"BD Multiple Hits on HV Strip"<<endl;
+      break;
+    }
+  }
 
 
 }

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -127,7 +127,7 @@ void MReadOutAssembly::Clear()
   m_Time = 0;
   m_EventTimeUTC = 0;
   m_MJD = 0.0;
-  m_RedChiSquare = -1;
+  m_ReducedChiSquare = -1;
 
   m_ShieldVeto = false;
   m_GuardRingVeto = false;
@@ -535,7 +535,7 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
   S<<"ID "<<m_ID<<endl;
   S<<"CL "<<m_Time<<endl;
   S<<"TI "<<m_EventTimeUTC<<endl;
-  S<<"QP "<<m_RedChiSquare<<endl; // Read out strip pairing qualiy factor
+  S<<"QP "<<m_ReducedChiSquare<<endl; // Read out strip pairing qualiy factor
     
   for (MSimIA& IA: m_SimIAs) {
     S<<IA.ToSimString()<<endl; 

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -557,6 +557,10 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
     for (auto H : m_Hits) {
       H->StreamDat(S, 2);
     }
+  } else if (Version == 3) {
+     for (auto H : m_Hits) {
+       H->StreamDat(S, 3);
+    }
   }
 
   if (m_AspectIncomplete == true) {

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -535,7 +535,7 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
   S<<"ID "<<m_ID<<endl;
   S<<"CL "<<m_Time<<endl;
   S<<"TI "<<m_EventTimeUTC<<endl;
-  S<<"Red Chi^2: "<<m_RedChiSquare<<endl;
+  S<<"QP "<<m_RedChiSquare<<endl; // Read out strip pairing qualiy factor
     
   for (MSimIA& IA: m_SimIAs) {
     S<<IA.ToSimString()<<endl; 

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -127,6 +127,7 @@ void MReadOutAssembly::Clear()
   m_Time = 0;
   m_EventTimeUTC = 0;
   m_MJD = 0.0;
+  m_RedChiSquare = -1;
 
   m_ShieldVeto = false;
   m_GuardRingVeto = false;
@@ -188,7 +189,10 @@ void MReadOutAssembly::Clear()
   m_DepthCalibrationIncomplete = false;
   m_DepthCalibrationIncompleteString = "";
   m_DepthCalibration_OutofRange = false;
-  m_DepthCalibration_OutofRangeString = ""; 
+  m_DepthCalibration_OutofRangeString = "";
+    
+  m_MultipleHitsOnLVStrip = false;
+  m_MultipleHitsOnHVStrip = false;
 
   m_FilteredOut = false;
 
@@ -531,7 +535,8 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
   S<<"ID "<<m_ID<<endl;
   S<<"CL "<<m_Time<<endl;
   S<<"TI "<<m_EventTimeUTC<<endl;
-
+  S<<"Red Chi^2: "<<m_RedChiSquare<<endl;
+    
   for (MSimIA& IA: m_SimIAs) {
     S<<IA.ToSimString()<<endl; 
   }
@@ -606,7 +611,12 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
   if (m_ShieldVeto == true) {
     S<<"BD Shield Veto"<<endl;
   }
-
+  if (m_MultipleHitsOnLVStrip == true) {
+    S<<"Multiple Hits on LV Strip"<<endl;
+    }
+  if (m_MultipleHitsOnHVStrip == true) {
+    S<<"Multiple Hits on HV Strip"<<endl;
+    }
   
   return true;
 }


### PR DESCRIPTION
**Summary of Changes**
Strip Pairing Algorithm:
1. Implement second round of strip pairing in which non-adjacent strips may be grouped together in order to account for multiple hits on a single strip
2. Filter out events with a best reduced chi square > 25
3. Correct energy of each potential pairing to account for charge trapping (still need to read in actual charge trapping parameters though)
4. Split main strip pairing code into several functions
5. Changed X and Y to LV and HV 

Flags:
1. Add bad flag for events with a reduced chi square > 25

Event Filter:
1. Added option to filter on strip pairing chi square into the Event Filter module/GUI

GUIs:
1. Strip pairing GUI includes more information (number of strip hits per hit, number of hits per event)

Class Attributes:
1. Added LV and HV energies to MHit class that is then read out in StreamDAT
2. Added Best Reduced Chi Square to MReadOutAssembly that is then read out in StreamDAT
3. Added "Multiple hits on a single LV/HV strip" attribute to MReadOutAssembly that is then read out in StreamDAT
