### PR TITLE
DEE Shield energy correction - loading the file

### DIFF
--- a/include/MGUIOptionsDEESMEX.h
+++ b/include/MGUIOptionsDEESMEX.h
@@ -59,14 +59,12 @@ class MGUIOptionsDEESMEX : public MGUIOptions
 
   // protected methods:
  protected:
-
   //! Actions after the Apply or OK button has been pressed
   virtual bool OnApply();
 
 
   // protected members:
  protected:
-
   // private members:
  private:
   //! Select which file to load
@@ -77,32 +75,34 @@ class MGUIOptionsDEESMEX : public MGUIOptions
   MGUIEFileSelector* m_DeadStripFileSelector;
   //! Thresholds file name
   MGUIEFileSelector* m_ThresholdFileSelector;
-	//! Guard ring thresholds fil ename
-	MGUIEFileSelector* m_GuardRingThresholdFileSelector;
-	//! Charge sharing file name
-	MGUIEFileSelector* m_ChargeSharingFileSelector;
-	//! Crosstalk file name
-	MGUIEFileSelector* m_CrosstalkFileSelector;
-	//! Charge loss file name
-	MGUIEFileSelector* m_ChargeLossFileSelector;
+  //! Guard ring thresholds fil ename
+  MGUIEFileSelector* m_GuardRingThresholdFileSelector;
+  //! Charge sharing file name
+  MGUIEFileSelector* m_ChargeSharingFileSelector;
+  //! Crosstalk file name
+  MGUIEFileSelector* m_CrosstalkFileSelector;
+  //! Charge loss file name
+  MGUIEFileSelector* m_ChargeLossFileSelector;
   //! Depth calibration coefficients file name
   MGUIEFileSelector* m_DepthCalibrationCoeffsFileSelector;
   //! Depth calibration splines file name
   MGUIEFileSelector* m_DepthCalibrationSplinesFileSelector;
-	//! Apply fudge factor
-	TGCheckButton* m_ApplyFudgeFactorSelector;
+  //! Apply fudge factor
+  TGCheckButton* m_ApplyFudgeFactorSelector;
   //! Use stop after a maximum number of events
   TGCheckButton* m_StopAfter;
   //! Entry field for the maximum number of accepted events
   MGUIEEntry* m_MaximumAcceptedEvents;
-  
-  
-  
+
+
+  //! ACS DEE energy correction file
+  MGUIEFileSelector* m_ShieldEnergyCorrectionFileSelector;
+
+
 #ifdef ___CLING___
  public:
   ClassDef(MGUIOptionsDEESMEX, 1) // basic class for dialog windows
 #endif
-
 };
 
 #endif

--- a/include/MModuleDEESMEX.h
+++ b/include/MModuleDEESMEX.h
@@ -51,22 +51,32 @@ class MModuleDEESMEX : public MModule
   MModuleDEESMEX();
   //! Default destructor
   virtual ~MModuleDEESMEX();
-  
-  //! Create a new object of this class 
-  virtual MModuleDEESMEX* Clone() { return new MModuleDEESMEX(); }
- 
+
+  //! Create a new object of this class
+  virtual MModuleDEESMEX* Clone()
+  {
+    return new MModuleDEESMEX();
+  }
+
   //! Set the geometry
-  virtual void SetGeometry(MDGeometryQuest* Geometry) { MModule::SetGeometry(Geometry); }
-  
+  virtual void SetGeometry(MDGeometryQuest* Geometry)
+  {
+    MModule::SetGeometry(Geometry);
+  }
+
   //! Set geometry file name
-  void SetGeometryFileName(const MString& FileName) { cout<<"Use SetGeometry instead"<<endl; abort(); }
- 
+  void SetGeometryFileName(const MString& FileName)
+  {
+    cout << "Use SetGeometry instead" << endl;
+    abort();
+  }
+
   //! Initialize the module
   virtual bool Initialize();
 
-  //! Main data analysis routine, which updates the event to a new level 
+  //! Main data analysis routine, which updates the event to a new level
   virtual bool AnalyzeEvent(MReadOutAssembly* Event);
-  
+
   //! Finalize the module
   virtual void Finalize();
 
@@ -82,67 +92,76 @@ class MModuleDEESMEX : public MModule
   // Pass through interfaces to sub-modules
 
   //! Set energy calibration file name
-  void SetEnergyCalibrationFileName(const MString& FileName) { m_StripReadout.SetEnergyCalibrationFileName(FileName); }
+  void SetEnergyCalibrationFileName(const MString& FileName)
+  {
+    m_StripReadout.SetEnergyCalibrationFileName(FileName);
+  }
   //! Set energy calibration file name
-  MString GetEnergyCalibrationFileName() const { return m_StripReadout.GetEnergyCalibrationFileName(); }
+  MString GetEnergyCalibrationFileName() const
+  {
+    return m_StripReadout.GetEnergyCalibrationFileName();
+  }
 
+  //! Set shield energy correction file name
+  void SetShieldEnergyCorrectionFileName(const MString& FileName)
+  {
+    m_ShieldEnergyCorrection.SetShieldEnergyCorrectionFileName(FileName);
+  }
+  //! Set energy calibration file name
+  MString GetShieldEnergyCorrectionFileName() const
+  {
+    return m_ShieldEnergyCorrection.GetShieldEnergyCorrectionFileName();
+  }
 
   // protected methods:
  protected:
-
   // private methods:
  private:
-
-
-
   // protected members:
  protected:
-
-
   // private members:
  private:
-   //! Time when the dead time ends
-   MTime m_DeadTimeEnd;
+  //! Time when the dead time ends
+  MTime m_DeadTimeEnd;
 
-   //! The sub module handling random coincidences
-   MSubModuleRandomCoincidence m_RandomCoincidence;
+  //! The sub module handling random coincidences
+  MSubModuleRandomCoincidence m_RandomCoincidence;
 
-   //! The sub module handling the intake of the sim data into the event
-   MSubModuleDEEIntake m_Intake;
+  //! The sub module handling the intake of the sim data into the event
+  MSubModuleDEEIntake m_Intake;
 
-   //! The sub module handling the shield energy correction
-   MSubModuleShieldEnergyCorrection m_ShieldEnergyCorrection;
+  //! The sub module handling the shield energy correction
+  MSubModuleShieldEnergyCorrection m_ShieldEnergyCorrection;
 
-   //! The sub module handling the shield readout
-   MSubModuleShieldReadout m_ShieldReadout;
+  //! The sub module handling the shield readout
+  MSubModuleShieldReadout m_ShieldReadout;
 
-   //! The sub module handling the shield veto
-   MSubModuleShieldTrigger m_ShieldTrigger;
+  //! The sub module handling the shield veto
+  MSubModuleShieldTrigger m_ShieldTrigger;
 
-   //! The sub module handling charge transport to grid and voxelation into strips
-   MSubModuleChargeTransport m_ChargeTransport;
+  //! The sub module handling charge transport to grid and voxelation into strips
+  MSubModuleChargeTransport m_ChargeTransport;
 
-   //! The sub module handling the strip readout: energy -> ADCs and thresholds
-   MSubModuleStripReadout m_StripReadout;
+  //! The sub module handling the strip readout: energy -> ADCs and thresholds
+  MSubModuleStripReadout m_StripReadout;
 
-   //! The sub module handling the strip readout noise on non-triggered strips
-   MSubModuleStripReadoutNoise m_StripReadoutNoise;
+  //! The sub module handling the strip readout noise on non-triggered strips
+  MSubModuleStripReadoutNoise m_StripReadoutNoise;
 
-   //! The sub module handling triggers and guard ring vetoes
-   MSubModuleStripTrigger m_StripTrigger;
+  //! The sub module handling triggers and guard ring vetoes
+  MSubModuleStripTrigger m_StripTrigger;
 
-   //! The sub module handling depth and timing noise
-   MSubModuleDepthReadout m_DepthReadout;
+  //! The sub module handling depth and timing noise
+  MSubModuleDepthReadout m_DepthReadout;
 
-   //! The sub module handling the output of the DEE in to the standard nuclearizer classes
-   MSubModuleDEEOutput m_Output;
+  //! The sub module handling the output of the DEE in to the standard nuclearizer classes
+  MSubModuleDEEOutput m_Output;
 
 
 #ifdef ___CLING___
  public:
   ClassDef(MModuleDEESMEX, 0) // no description
 #endif
-
 };
 
 #endif

--- a/include/MSubModuleShieldEnergyCorrection.h
+++ b/include/MSubModuleShieldEnergyCorrection.h
@@ -1,7 +1,7 @@
 /*
  * MSubModuleShieldEnergyCorrection.h
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Andreas Zoglauer, Valentina Fioretti.
  * All rights reserved.
  *
  * Please see the source-file for the copyright-notice.
@@ -49,13 +49,24 @@ class MSubModuleShieldEnergyCorrection : public MSubModule
   //! Default destructor
   virtual ~MSubModuleShieldEnergyCorrection();
 
+  //! Set shield energy correction file name
+  void SetShieldEnergyCorrectionFileName(const MString& FileName)
+  {
+    m_ShieldEnergyCorrectionFileName = FileName;
+  }
+  //! Get shield energy correction file name
+  MString GetShieldEnergyCorrectionFileName() const
+  {
+    return m_ShieldEnergyCorrectionFileName;
+  }
+
   //! Initialize the module
   virtual bool Initialize();
 
   //! Clear event data from the module
   virtual void Clear();
 
-  //! Main data analysis routine, which updates the event to a new level 
+  //! Main data analysis routine, which updates the event to a new level
   virtual bool AnalyzeEvent(MReadOutAssembly* Event);
 
   //! Finalize the module
@@ -65,30 +76,22 @@ class MSubModuleShieldEnergyCorrection : public MSubModule
   virtual bool ReadXmlConfiguration(MXmlNode* Node);
   //! Create an XML node tree from the configuration
   virtual MXmlNode* CreateXmlConfiguration(MXmlNode* Node);
+  //! ACS energy correction file name
+  MString m_ShieldEnergyCorrectionFileName;
+
 
   // protected methods:
  protected:
-
   // private methods:
  private:
-
-
-
   // protected members:
  protected:
-
-
   // private members:
  private:
-
-
-
-
 #ifdef ___CLING___
  public:
   ClassDef(MSubModuleShieldEnergyCorrection, 0) // no description
 #endif
-
 };
 
 #endif

--- a/src/MGUIOptionsDEESMEX.cxx
+++ b/src/MGUIOptionsDEESMEX.cxx
@@ -44,7 +44,7 @@ ClassImp(MGUIOptionsDEESMEX)
 
 
 MGUIOptionsDEESMEX::MGUIOptionsDEESMEX(MModule* Module)
-  : MGUIOptions(Module)
+    : MGUIOptions(Module)
 {
   // standard constructor
 }
@@ -55,7 +55,7 @@ MGUIOptionsDEESMEX::MGUIOptionsDEESMEX(MModule* Module)
 
 MGUIOptionsDEESMEX::~MGUIOptionsDEESMEX()
 {
-  // kDeepCleanup is activated 
+  // kDeepCleanup is activated
 }
 
 
@@ -69,7 +69,7 @@ void MGUIOptionsDEESMEX::Create()
   TGLayoutHints* LabelLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
 
   m_EnergyCalibrationFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Please select an energy calibration file:",
-    dynamic_cast<MModuleDEESMEX*>(m_Module)->GetEnergyCalibrationFileName());
+                                                          dynamic_cast<MModuleDEESMEX*>(m_Module)->GetEnergyCalibrationFileName());
   m_EnergyCalibrationFileSelector->SetFileType("Ecal file", "*.ecal");
   m_OptionsFrame->AddFrame(m_EnergyCalibrationFileSelector, LabelLayout);
 
@@ -125,12 +125,13 @@ void MGUIOptionsDEESMEX::Create()
     dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->GetDepthCalibrationSplinesFileName());
   m_DepthCalibrationSplinesFileSelector->SetFileType("Splines file", "*.ctd");
   m_OptionsFrame->AddFrame(m_DepthCalibrationSplinesFileSelector, LabelLayout);
-
-  // ACS DEE energy correction file
-  m_ACSEnergyCorrectionFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Please select an energy correction file for the ACS DEE:",
-      dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->GetACSEnergyCorrectionFileName());
-  m_ACSEnergyCorrectionFileSelector->SetFileType("ACS DEE energy correction file", "*.txt");
-  m_OptionsFrame->AddFrame(m_ACSEnergyCorrectionFileSelector, LabelLayout);
+ */
+  // shield energy correction file
+  m_ShieldEnergyCorrectionFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Please select an energy correction file for the Shield DEE:",
+                                                               dynamic_cast<MModuleDEESMEX*>(m_Module)->GetShieldEnergyCorrectionFileName());
+  m_ShieldEnergyCorrectionFileSelector->SetFileType("Shield DEE energy correction file", "*.txt");
+  m_OptionsFrame->AddFrame(m_ShieldEnergyCorrectionFileSelector, LabelLayout);
+  /*
 
   m_ApplyFudgeFactorSelector = new TGCheckButton(m_OptionsFrame, "Apply fudge factor to better match fluxes", 1);
   m_ApplyFudgeFactorSelector->SetOn(dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->GetApplyFudgeFactor());
@@ -149,7 +150,7 @@ bool MGUIOptionsDEESMEX::ProcessMessage(long Message, long Parameter1, long Para
   // Modify here if you have more buttons
 
   bool Status = true;
-  
+
   switch (GET_MSG(Message)) {
   case kC_COMMAND:
     switch (GET_SUBMSG(Message)) {
@@ -164,7 +165,7 @@ bool MGUIOptionsDEESMEX::ProcessMessage(long Message, long Parameter1, long Para
   default:
     break;
   }
-  
+
   if (Status == false) {
     return false;
   }
@@ -180,7 +181,7 @@ bool MGUIOptionsDEESMEX::ProcessMessage(long Message, long Parameter1, long Para
 bool MGUIOptionsDEESMEX::OnApply()
 {
   // Modify this to store the data in the module!
-  
+
   dynamic_cast<MModuleDEESMEX*>(m_Module)->SetEnergyCalibrationFileName(m_EnergyCalibrationFileSelector->GetFileName());
 
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetDeadtimeFileName(m_DeadtimeFileSelector->GetFileName());

--- a/src/MSubModuleShieldEnergyCorrection.cxx
+++ b/src/MSubModuleShieldEnergyCorrection.cxx
@@ -2,12 +2,12 @@
  * MSubModuleShieldEnergyCorrection.cxx
  *
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Andreas Zoglauer, Valentina Fioretti.
  * All rights reserved.
  *
  *
  * This code implementation is the intellectual property of
- * Andreas Zoglauer.
+ * Andreas Zoglauer, Valentina Fioretti.
  *
  * By copying, distributing or modifying the Program (or any work
  * based on the Program) you indicate your acceptance of this statement,
@@ -45,11 +45,13 @@ ClassImp(MSubModuleShieldEnergyCorrection)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MSubModuleShieldEnergyCorrection::MSubModuleShieldEnergyCorrection() : MSubModule()
+MSubModuleShieldEnergyCorrection::MSubModuleShieldEnergyCorrection()
+    : MSubModule()
 {
   // Construct an instance of MSubModuleShieldEnergyCorrection
 
   m_Name = "DEE shield energy correction module";
+  m_ShieldEnergyCorrectionFileName = "";
 }
 
 
@@ -89,11 +91,11 @@ void MSubModuleShieldEnergyCorrection::Clear()
 
 bool MSubModuleShieldEnergyCorrection::AnalyzeEvent(MReadOutAssembly* Event)
 {
-  // Main data analysis routine, which updates the event to a new level 
+  // Main data analysis routine, which updates the event to a new level
 
   // Set the energy
   list<MDEECrystalHit>& Hits = Event->GetDEECrystalHitListReference();
-  for (MDEECrystalHit& CH: Hits) {
+  for (MDEECrystalHit& CH : Hits) {
     CH.m_Energy = CH.m_SimulatedEnergy;
   }
 
@@ -119,7 +121,7 @@ bool MSubModuleShieldEnergyCorrection::AnalyzeEvent(MReadOutAssembly* Event)
 
 void MSubModuleShieldEnergyCorrection::Finalize()
 {
-  // Finalize the analysis - do all cleanup, i.e., undo Initialize() 
+  // Finalize the analysis - do all cleanup, i.e., undo Initialize()
 
   MSubModule::Finalize();
 }
@@ -132,12 +134,11 @@ bool MSubModuleShieldEnergyCorrection::ReadXmlConfiguration(MXmlNode* Node)
 {
   //! Read the configuration data from an XML node
 
-  /*
-  MXmlNode* SomeTagNode = Node->GetNode("SomeTag");
-  if (SomeTagNode != 0) {
-    m_SomeTagValue = SomeTagNode->GetValue();
+  MXmlNode* ShieldEnergyCorrectionFileName = Node->GetNode("ShieldEnergyCorrectionFileName");
+  if (ShieldEnergyCorrectionFileName != 0) {
+    m_ShieldEnergyCorrectionFileName = ShieldEnergyCorrectionFileName->GetValue();
   }
-  */
+
 
   return true;
 }
@@ -149,10 +150,9 @@ bool MSubModuleShieldEnergyCorrection::ReadXmlConfiguration(MXmlNode* Node)
 MXmlNode* MSubModuleShieldEnergyCorrection::CreateXmlConfiguration(MXmlNode* Node)
 {
   //! Create an XML node tree from the configuration
-  
-  /*
-  MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
-  */
+
+  new MXmlNode(Node, "ShieldEnergyCorrectionFileName", m_ShieldEnergyCorrectionFileName);
+
 
   return Node;
 }


### PR DESCRIPTION
The DEE Shield Energy Correction sub module is modified to configure and read the correction file. The code still does nothing to it.

MModuleDEESMEX and MGUIOptionsDEESMEX files also modified to modify the GUI options.

Code checked with clang-factor with this line commented: InsertBraces: true