### PR TITLE
Ability to read calibrated energy values from ROA files

### DIFF
--- a/include/MReadOutDataEnergy.h
+++ b/include/MReadOutDataEnergy.h
@@ -1,0 +1,111 @@
+/*
+ * MReadOutDataEnergy.h
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MReadOutDataEnergy__
+#define __MReadOutDataEnergy__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Standard libs:
+#include <iostream>
+using namespace std;
+
+// ROOT libs:
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MTokenizer.h"
+#include "MReadOutData.h"
+
+// Forward declarations:
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! This basic read-out data just consisting of one energy value as double
+class MReadOutDataEnergy : public MReadOutData
+{
+  // public interface:
+ public:
+  //! The type name --- must be unique
+  static const MString m_Type;
+  //! The type name ID --- must be unique
+  static const long m_TypeID;
+
+  //! Default constructor
+  MReadOutDataEnergy();
+  //! Constructor given the data
+  MReadOutDataEnergy(MReadOutData* Data);
+  //! Simple default destructor
+  virtual ~MReadOutDataEnergy();
+
+  //! Return the type of this read-out data --- hard coded to save space
+  virtual MString GetType() const { return m_Type; }
+  //! Return the type ID of this read-out data --- hard coded to save memory
+  virtual long GetTypeID() const { return m_TypeID; }
+
+  //! Clear the content of this read-out data element
+  virtual void Clear();
+
+  //! Set the energy
+  void SetEnergy(double Energy) { m_Energy = Energy; }
+  //! Get the energy
+  double GetEnergy() const { return m_Energy; }
+
+  //! Clone this data element - the returned element must be deleted
+  virtual MReadOutDataEnergy* Clone() const;
+  
+  //! Return the number of parsable elements
+  virtual unsigned int GetNumberOfParsableElements() const;  
+  //! Return the data as parsable string
+  virtual MString ToParsableString(bool WithDescriptor = false) const; 
+  //! Parse the data from the tokenizer 
+  virtual bool Parse(const MTokenizer& T, unsigned int StartElement);
+  
+  //! Dump a string
+  virtual MString ToString() const;
+  
+  
+  // protected methods:
+ protected:
+
+  // private methods:
+ private:
+
+
+
+  // protected members:
+ protected:
+  //! The energy
+  double m_Energy;
+
+  // private members:
+ private:
+
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MReadOutDataEnergy, 0) // no description
+#endif
+
+};
+
+//! Streamify the read-out data
+ostream& operator<<(ostream& os, const MReadOutDataEnergy& R);
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -54,6 +54,7 @@ using namespace std;
 // Nuclearizer libs:
 #include "MFretalonRegistry.h"
 #include "MReadOutDataTAC.h"
+#include "MReadOutDataEnergy.h"
 #include "MReadOutAssembly.h"
 #include "MModule.h"
 #include "MGUIExpoCombinedViewer.h"
@@ -104,6 +105,9 @@ MAssembly::MAssembly()
   //! Register new read out data:
   MReadOutDataTAC TAC;
   MFretalonRegistry::Instance().Register(TAC);
+
+  MReadOutDataEnergy Energy;
+  MFretalonRegistry::Instance().Register(Energy);
 
   // Create the supervisor
   m_Supervisor = MSupervisor::GetSupervisor();

--- a/src/MModuleLoaderMeasurementsROA.cxx
+++ b/src/MModuleLoaderMeasurementsROA.cxx
@@ -40,6 +40,7 @@
 #include "MReadOutDataADCValue.h"
 #include "MReadOutDataTiming.h"
 #include "MReadOutDataTAC.h"
+#include "MReadOutDataEnergy.h"
 #include "MReadOutDataOrigins.h"
 
 
@@ -195,6 +196,8 @@ bool MModuleLoaderMeasurementsROA::ReadNextEvent(MReadOutAssembly* Event)
       dynamic_cast<const MReadOutDataTiming*>(RO.GetReadOutData().Get(MReadOutDataTiming::m_TypeID));
     const MReadOutDataTAC* TAC =
       dynamic_cast<const MReadOutDataTAC*>(RO.GetReadOutData().Get(MReadOutDataTAC::m_TypeID));
+    const MReadOutDataEnergy* Energy =
+      dynamic_cast<const MReadOutDataEnergy*>(RO.GetReadOutData().Get(MReadOutDataEnergy::m_TypeID));
     const MReadOutDataOrigins* Origins =
       dynamic_cast<const MReadOutDataOrigins*>(RO.GetReadOutData().Get(MReadOutDataOrigins::m_TypeID));
     
@@ -209,6 +212,9 @@ bool MModuleLoaderMeasurementsROA::ReadNextEvent(MReadOutAssembly* Event)
     }
     if (TAC != nullptr) {
       SH->SetTAC(TAC->GetTAC());
+    }
+    if (Energy != nullptr) {
+      SH->SetEnergy(Energy->GetEnergy());
     }
     if (ADC != nullptr) {
       SH->SetADCUnits(ADC->GetADCValue());

--- a/src/MReadOutDataEnergy.cxx
+++ b/src/MReadOutDataEnergy.cxx
@@ -1,0 +1,171 @@
+/*
+ * MReadOutDataEnergy.cxx
+ *
+ *
+ * Copyright (C) by Andreas Zoglauer.
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// MReadOutDataEnergy
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Include the header:
+#include "MReadOutDataEnergy.h"
+
+// Standard libs:
+
+// ROOT libs:
+
+// MEGAlib libs:
+#include "MStreams.h"
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MReadOutDataEnergy)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! The type name --- must be unique
+const MString MReadOutDataEnergy::m_Type = "energy";
+//! The type name ID --- must be unique
+const long MReadOutDataEnergy::m_TypeID = m_Type.GetHash();
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Default constructor
+MReadOutDataEnergy::MReadOutDataEnergy() : MReadOutData(nullptr), m_Energy(0.)
+{
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Constructor given the data
+MReadOutDataEnergy::MReadOutDataEnergy(MReadOutData* Data) : MReadOutData(Data), m_Energy(0.)
+{
+}
+  
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Default destructor
+MReadOutDataEnergy::~MReadOutDataEnergy()
+{
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Clone this element
+MReadOutDataEnergy* MReadOutDataEnergy::Clone() const
+{
+  MReadOutDataEnergy* ROD = new MReadOutDataEnergy();
+  ROD->SetEnergy(m_Energy);
+  if (m_Wrapped != 0) {
+    ROD->SetWrapped(m_Wrapped->Clone());
+  }
+  return ROD;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Clear the content of this read-out element
+void MReadOutDataEnergy::Clear()
+{
+  MReadOutData::Clear();
+  m_Energy = 0.;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+ 
+//! Return the number of parsable elements
+unsigned int MReadOutDataEnergy::GetNumberOfParsableElements() const
+{
+  return MReadOutData::GetNumberOfParsableElements() + 1;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Parse the data from the tokenizer 
+bool MReadOutDataEnergy::Parse(const MTokenizer& T, unsigned int StartElement)
+{
+  // Go deep first:
+  if (MReadOutData::Parse(T, StartElement) == false) return false;
+  
+  // Then here:
+  m_Energy = T.GetTokenAtAsDouble(StartElement + MReadOutData::GetNumberOfParsableElements());
+  
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Dump the content into a string
+MString MReadOutDataEnergy::ToString() const
+{
+  ostringstream os;
+  os<<MReadOutData::ToString()<<m_Energy<<" ";
+  return os.str();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Dump the content into a parsable string
+MString MReadOutDataEnergy::ToParsableString(bool WithDescriptor) const
+{
+  ostringstream os;
+  if (WithDescriptor == true) {
+    os<<GetCombinedType()<<" ";
+  }
+  os<<ToString();
+  return os.str();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Append the context as text 
+ostream& operator<<(ostream& os, const MReadOutDataEnergy& R)
+{
+  os<<R.ToString();
+  return os;
+}
+
+  
+// MReadOutDataEnergy.cxx: the end...
+////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I shamelessly copied the code from https://github.com/cositools/nuclearizer/commit/876ef0dd3e5e23ecfa0900c028ab00ef9c1202b5 (to read in TAC values from ROA files) and used it to write a parser for calibrated energy, which is saved using the identifier `energy` and then parsed as `double`.

To do a quick cross-check that it works, I ran this (reading an ROA file and writing another ROA file again)
<img width="517" height="367" alt="image" src="https://github.com/user-attachments/assets/e1b57373-4be8-4eac-b348-00a5d5ca370a" />
and compared the results

Left is the old file and right is the new file
<img width="826" height="834" alt="image" src="https://github.com/user-attachments/assets/8c6889d4-631b-43e7-979b-24c425f7634a" />

Energies seem to be parsed correctly and written to the file, yielding the same results.
Only difference right now is that the values for `CL` (?) are lost, but I'll leave this to a future PR.


