### PR TITLE
[DEE] Update dummy implementation of strip IDs

### DIFF
--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -98,11 +98,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   for (MDEEStripHit& SH: LVHits) {
     MVector Pos = SH.m_SimulatedPositionInDetector;
     int ID = (Pos.X() + 7.4/2) / (7.4/64);
-    if (ID > 0 && ID < 64) {
+    if (ID >= 0 && ID < 64 && Pos.X() >= -7.4/2) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
     } else {
-      SH.m_ROE.SetStripID(65);
+      SH.m_ROE.SetStripID(64);
       SH.m_IsGuardRing = true;
     }
     SH.m_Energy = SH.m_SimulatedEnergy;
@@ -112,11 +112,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   for (MDEEStripHit& SH: HVHits) {
     MVector Pos = SH.m_SimulatedPositionInDetector;
     int ID = (Pos.Y() + 7.4/2) / (7.4/64);
-    if (ID > 0 && ID < 64) {
+    if (ID >= 0 && ID < 64 && Pos.Y() >= -7.4/2) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
     } else {
-      SH.m_ROE.SetStripID(65);
+      SH.m_ROE.SetStripID(64);
       SH.m_IsGuardRing = true;
     }
     SH.m_Energy = SH.m_SimulatedEnergy;

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -97,8 +97,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
   for (MDEEStripHit& SH: LVHits) {
     MVector Pos = SH.m_SimulatedPositionInDetector;
-    int ID = (Pos.X() + 7.4/2) / (7.4/64);
-    if (ID >= 0 && ID < 64 && Pos.X() >= -7.4/2) {
+
+    // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
+    int ID = static_cast<int>(std::floor((Pos.X() + 7.4/2.0) / (7.4/64.0)));
+
+    if (ID >= 0 && ID < 64) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
     } else {
@@ -111,8 +114,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   list<MDEEStripHit>& HVHits = Event->GetDEEStripHitHVListReference();
   for (MDEEStripHit& SH: HVHits) {
     MVector Pos = SH.m_SimulatedPositionInDetector;
-    int ID = (Pos.Y() + 7.4/2) / (7.4/64);
-    if (ID >= 0 && ID < 64 && Pos.Y() >= -7.4/2) {
+
+    // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
+    int ID = static_cast<int>(std::floor((Pos.Y() + 7.4/2.0) / (7.4/64.0)));
+
+    if (ID >= 0 && ID < 64) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
     } else {


### PR DESCRIPTION
I was getting warnings in nuclearizer when applying a realistic Ecal file to DEE output, 
saying that no energy-fit was found for HV and LV strip 65.

To my knowledge, we use strip IDs 0-63 for the strips and 64 for the guard ring (at least that's how I read the ecal file),
so I updated the implementation of this to return strip IDs from 0 to 63 for the strips and 64 for the GR.

After updating this, I was able to simulate my first pixel/strip maps for an Am241 source placed at the same distance that we use in lab measurements :tada:

<img width="480" height="371" alt="image" src="https://github.com/user-attachments/assets/92cfe96a-23cf-4667-9565-e8d587276a61" />
<img width="480" height="371" alt="image" src="https://github.com/user-attachments/assets/fb082161-c73c-4ecc-af91-a3838e16a55e" />
<img width="479" height="405" alt="image" src="https://github.com/user-attachments/assets/317af716-4538-463f-8a14-9bacea895c0a" />

