### PR TITLE
[DEE] Improve strip ID handling for guard ring events

### DIFF
--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -101,7 +101,8 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
     int ID = static_cast<int>(std::floor((Pos.X() + 7.4/2.0) / (7.4/64.0)));
 
-    if (ID >= 0 && ID < 64) {
+    // Check for strip ID and if the position is within the allowed strip length or on the guard ring
+    if (ID >= 0 && ID < 64 && std::abs(Pos.Y()) <= 7.4/2.0 && std::hypot(Pos.X(), Pos.Y()) <= 4.712) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
     } else {
@@ -118,7 +119,8 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
     int ID = static_cast<int>(std::floor((Pos.Y() + 7.4/2.0) / (7.4/64.0)));
 
-    if (ID >= 0 && ID < 64) {
+    // Check for strip ID and if the position is within the allowed strip length or on the guard ring
+    if (ID >= 0 && ID < 64 && std::abs(Pos.X()) <= 7.4/2.0 && std::hypot(Pos.X(), Pos.Y()) <= 4.712) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
     } else {

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -99,9 +99,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     MVector Pos = SH.m_SimulatedPositionInDetector;
 
     // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
+    // TODO: Confirm the correct strip pitch based on SMEX detector models
     int ID = static_cast<int>(std::floor((Pos.X() + 7.4/2.0) / (7.4/64.0)));
 
     // Check for strip ID and if the position is within the allowed strip length or on the guard ring
+    // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
     if (ID >= 0 && ID < 64 && std::abs(Pos.Y()) <= 7.4/2.0 && std::hypot(Pos.X(), Pos.Y()) <= 4.712) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;
@@ -117,9 +119,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     MVector Pos = SH.m_SimulatedPositionInDetector;
 
     // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
+    // TODO: Confirm the correct strip pitch based on SMEX detector models
     int ID = static_cast<int>(std::floor((Pos.Y() + 7.4/2.0) / (7.4/64.0)));
 
     // Check for strip ID and if the position is within the allowed strip length or on the guard ring
+    // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
     if (ID >= 0 && ID < 64 && std::abs(Pos.X()) <= 7.4/2.0 && std::hypot(Pos.X(), Pos.Y()) <= 4.712) {
       SH.m_ROE.SetStripID(ID);
       SH.m_IsGuardRing = false;


### PR DESCRIPTION
In the DEE, the way the strip ID is determined is ignoring the shape of the GR.

Current implementation:
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/a54e3bde-d894-4fb0-8d2d-bcb7cdb7450d" />

After this PR:
<img width="1200" height="600" alt="image" src="https://github.com/user-attachments/assets/38be0dea-a2ab-4dbf-9088-2dc32a059e94" />

The exact values I put here are still dummy values, which should be cross-checked with the SMEX massmodel in the future.