### PR TITLE
[DEE] Update `AnalyzeEvent` in `MSubModuleChargeTransport`

### DIFF
--- a/include/MSubModuleChargeTransport.h
+++ b/include/MSubModuleChargeTransport.h
@@ -75,7 +75,7 @@ class MSubModuleChargeTransport : public MSubModule
  protected:
 
   //! Calculate charge fraction on a strip in local strip coordinates based on self-repulsion (η) and diffusion (σ)
-  double CalculateChargeFraction(double x, double Eta, double Sigma);
+  void RunChargeTransportForHit(MDEEStripHit& SH, bool isLV);
 
   // private methods:
  private:
@@ -98,6 +98,8 @@ class MSubModuleChargeTransport : public MSubModule
   unordered_map<int, double> m_Radii;
   unordered_map<int, MDDetector*> m_Detectors;
   vector<unsigned int> m_DetectorIDs;
+
+  list<MDEEStripHit> m_ChargeTransportHits;
 
 
   // private members:

--- a/include/MSubModuleChargeTransport.h
+++ b/include/MSubModuleChargeTransport.h
@@ -74,6 +74,9 @@ class MSubModuleChargeTransport : public MSubModule
   // protected methods:
  protected:
 
+  //! Calculate charge fraction on a strip in local strip coordinates based on self-repulsion (η) and diffusion (σ)
+  double CalculateChargeFraction(double x, double Eta, double Sigma);
+
   // private methods:
  private:
 

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -27,8 +27,10 @@
 #include "MSubModuleChargeTransport.h"
 
 // Standard libs:
+#include <cmath>
 
 // ROOT libs:
+#include "TMath.h"
 
 // MEGAlib libs:
 #include "MSubModule.h"
@@ -156,9 +158,23 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level 
 
-  // Dummy code:
+  // Define physical constants
+  constexpr double kB = TMath::K(); // unit: J/K
+  constexpr double ElementaryCharge = TMath::Qe(); // unit: C
+  constexpr double IonizationEnergy = 0.00295; // unit: keV
+  constexpr double Epsilon0 = 8.85418781762039e-14; // unit: F/cm
+  constexpr double EpsilonR = 16.0; // in germanium, unitless
+
+  // TODO: Read bias voltage and temperature of the detector from a file
+  constexpr double BiasVoltage = 600.0; // unit: V
+  constexpr double Temperature = 87.0; // unit: K
+
+  // TODO: Implement energy-dependent initial charge-cloud sizes
+  constexpr double InitialChargeCloudSize = 0.02; // 200µm in cm
 
   // Create strip hits
+  list<MDEEStripHit> ChargeTransportLVHits;
+
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
   for (MDEEStripHit& SH: LVHits) {
     MVector Pos = SH.m_SimulatedPositionInDetector;
@@ -167,9 +183,13 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     unsigned int DetID = SH.m_ROE.GetDetectorID();
     double XWidth = m_XWidths[DetID];
     double YWidth = m_YWidths[DetID];
+    double Thickness = m_Thicknesses[DetID];
     double XPitch = m_XPitches[DetID];
     double Radius = m_Radii[DetID];
     int NXStrips = m_NXStrips[DetID];
+
+    double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
+    double N = SH.m_SimulatedEnergy / IonizationEnergy;
 
     // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
     int ID = static_cast<int>(std::floor((Pos.X() + XWidth/2.0) / XPitch));
@@ -177,14 +197,86 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     // Check for strip ID and if the position is within the allowed strip length or on the guard ring
     // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
     if (ID >= 0 && ID < NXStrips && std::abs(Pos.Y()) <= YWidth/2.0 && std::hypot(Pos.X(), Pos.Y()) <= Radius) {
-      SH.m_ROE.SetStripID(ID);
-      SH.m_IsGuardRing = false;
+
+      // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= X < XPitch)
+      double XFromGap = std::fmod(Pos.X() + XWidth/2.0, XPitch);
+
+      // calculate σ and µ, assuming t = z / v = z / (µ * E)
+      double SigmaX = std::sqrt(2.0 * kB * Temperature * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
+      double EtaX   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Pos.Z() + Thickness / 2.0) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
+      cout << "X: " << Pos.X() << ", Y: " << Pos.Y() << ", Z: " << Pos.Z() << ", E: " << SH.m_SimulatedEnergy << endl;
+      cout << "Sigma X: " << SigmaX << ", EtaX: " << EtaX << endl;
+
+      auto Lambda = [&](double x) -> double {
+        double a = (x - EtaX) / (TMath::Sqrt2() * SigmaX);
+        double b = (x + EtaX) / (TMath::Sqrt2() * SigmaX);
+        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaX, 3)) * (
+          std::erf(b) * (2.0 * std::pow(EtaX, 3) + x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
+          std::erf(a) * (2.0 * std::pow(EtaX, 3) - x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
+          std::exp(- std::pow(b,2)) * std::sqrt(2.0 / TMath::Pi()) * SigmaX * (EtaX * x + (2.0 * std::pow(EtaX, 2) - 2.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
+          std::exp(- std::pow(a,2)) * std::sqrt(2.0 / TMath::Pi()) * SigmaX * (EtaX * x - (2.0 * std::pow(EtaX, 2) - 2.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) 
+        );
+      };
+
+      double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap);
+      double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap);
+      double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap);
+
+      cout << "Energy: " << SH.m_SimulatedEnergy << ", split into " << NNLeftStripEnergy << ", " << MainStripEnergy << " and " << NNRightStripEnergy << endl;
+
+      // create entry for the main hit
+      MDEEStripHit MainSH = SH;
+      MainSH.m_ROE.SetStripID(ID);
+      MainSH.m_Energy = MainStripEnergy;
+      MainSH.m_IsGuardRing = false;
+      ChargeTransportLVHits.push_back(MainSH);
+
+      // create MDEEStripHit for the left NN
+      if (NNLeftStripEnergy > IonizationEnergy) {
+        MDEEStripHit NNLeftSH = SH;
+        NNLeftSH.m_Energy = NNLeftStripEnergy;
+        if (ID > 0) {
+          NNLeftSH.m_ROE.SetStripID(ID - 1);
+          NNLeftSH.m_IsGuardRing = false;
+          // NNLeftSH.m_IsNearestNeighbor = true;
+        } else {
+          NNLeftSH.m_ROE.SetStripID(NXStrips);
+          NNLeftSH.m_IsGuardRing = true;
+        }
+        ChargeTransportLVHits.push_back(NNLeftSH);
+      }
+      
+      // create MDEEStripHit for the right NN
+      if (NNRightStripEnergy > IonizationEnergy) {
+        MDEEStripHit NNRightSH = SH;
+        NNRightSH.m_Energy = NNRightStripEnergy;
+        if (ID < NXStrips - 1) {
+          NNRightSH.m_ROE.SetStripID(ID + 1);
+          NNRightSH.m_IsGuardRing = false;
+          // NNRightSH.m_IsNearestNeighbor = true;
+        } else {
+          NNRightSH.m_ROE.SetStripID(NXStrips);
+          NNRightSH.m_IsGuardRing = true;
+        }
+        ChargeTransportLVHits.push_back(NNRightSH);
+      }
+
     } else {
+      // TODO: implement charge sharing also for GR events
+      SH.m_Energy = SH.m_SimulatedEnergy;
       SH.m_ROE.SetStripID(NXStrips);
       SH.m_IsGuardRing = true;
+      ChargeTransportLVHits.push_back(SH);
     }
-    SH.m_Energy = SH.m_SimulatedEnergy;
   }
+
+  // replace old list by new list
+  Event->GetDEEStripHitLVListReference().clear();
+  for (MDEEStripHit& SH: ChargeTransportLVHits) {
+    Event->AddDEEStripHitLV(SH);
+  }
+
+  list<MDEEStripHit> ChargeTransportHVHits;
 
   list<MDEEStripHit>& HVHits = Event->GetDEEStripHitHVListReference();
   for (MDEEStripHit& SH: HVHits) {
@@ -194,9 +286,13 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     unsigned int DetID = SH.m_ROE.GetDetectorID();
     double XWidth = m_XWidths[DetID];
     double YWidth = m_YWidths[DetID];
+    double Thickness = m_Thicknesses[DetID];
     double YPitch = m_YPitches[DetID];
     double Radius = m_Radii[DetID];
     int NYStrips = m_NYStrips[DetID];
+
+    double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
+    double N = SH.m_SimulatedEnergy / IonizationEnergy;
 
     // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
     // TODO: Confirm the correct strip pitch based on SMEX detector models
@@ -205,16 +301,83 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     // Check for strip ID and if the position is within the allowed strip length or on the guard ring
     // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
     if (ID >= 0 && ID < NYStrips && std::abs(Pos.X()) <= XWidth/2.0 && std::hypot(Pos.X(), Pos.Y()) <= Radius) {
-      SH.m_ROE.SetStripID(ID);
-      SH.m_IsGuardRing = false;
+
+      // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= Y < YPitch)
+      double YFromGap = std::fmod(Pos.Y() + YWidth/2.0, YPitch);
+
+      // calculate σ and µ, assuming t = z / v = z / (µ * E)
+      double SigmaY = std::sqrt(2.0 * kB * Temperature * (Thickness / 2.0 - Pos.Z()) / (ElementaryCharge * MeanElectricField)); // in cm
+      double EtaY   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Thickness / 2.0 - Pos.Z()) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
+
+      auto Lambda = [&](double y) -> double {
+        double a = (y - EtaY) / (TMath::Sqrt2() * SigmaY);
+        double b = (y + EtaY) / (TMath::Sqrt2() * SigmaY);
+        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaY, 3)) * (
+          std::erf(b) * (2.0 * std::pow(EtaY, 3) + y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
+          std::erf(a) * (2.0 * std::pow(EtaY, 3) - y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
+          std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * SigmaY * (EtaY * y + (2.0 * std::pow(EtaY, 2) - 2.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
+          std::exp(- std::pow(a,2)) * std::sqrt(2 / TMath::Pi()) * SigmaY * (EtaY * y - (2.0 * std::pow(EtaY, 2) - 2.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) 
+        );
+      };
+
+      double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap);
+      double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap);
+      double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap);
+
+      // create entry for the main hit
+      MDEEStripHit MainSH = SH;
+      MainSH.m_ROE.SetStripID(ID);
+      MainSH.m_Energy = MainStripEnergy;
+      MainSH.m_IsGuardRing = false;
+      ChargeTransportHVHits.push_back(MainSH);
+
+      // create MDEEStripHit for the left NN
+      if (NNLeftStripEnergy > IonizationEnergy) {
+        MDEEStripHit NNLeftSH = SH;
+        NNLeftSH.m_Energy = NNLeftStripEnergy;
+        if (ID > 0) {
+          NNLeftSH.m_ROE.SetStripID(ID - 1);
+          NNLeftSH.m_IsGuardRing = false;
+          // NNLeftSH.m_IsNearestNeighbor = true;
+        } else {
+          NNLeftSH.m_ROE.SetStripID(NYStrips);
+          NNLeftSH.m_IsGuardRing = true;
+        }
+        ChargeTransportHVHits.push_back(NNLeftSH);
+      }
+        
+      // create MDEEStripHit for the right NN
+      if (NNRightStripEnergy > IonizationEnergy) {
+        MDEEStripHit NNRightSH = SH;
+        NNRightSH.m_Energy = NNRightStripEnergy;
+        if (ID < NYStrips - 1) {
+          NNRightSH.m_ROE.SetStripID(ID + 1);
+          NNRightSH.m_IsGuardRing = false;
+          // NNRightSH.m_IsNearestNeighbor = true;
+        } else {
+          NNRightSH.m_ROE.SetStripID(NYStrips);
+          NNRightSH.m_IsGuardRing = true;
+        }
+        ChargeTransportHVHits.push_back(NNRightSH);
+      }
+
     } else {
+      // TODO: implement charge sharing also for GR events
+      SH.m_Energy = SH.m_SimulatedEnergy;
       SH.m_ROE.SetStripID(NYStrips);
       SH.m_IsGuardRing = true;
+      ChargeTransportHVHits.push_back(SH);
     }
-    SH.m_Energy = SH.m_SimulatedEnergy;
+  }
+
+  // replace old list by new list
+  Event->GetDEEStripHitHVListReference().clear();
+  for (MDEEStripHit& SH: ChargeTransportHVHits) {
+    Event->AddDEEStripHitHV(SH);
   }
 
   // Merge hits:
+  // TODO: how to deal with flags like "m_IsNearestNeighbor" etc. ?
   for (auto IterLV1 = LVHits.begin(); IterLV1 != LVHits.end(); ++IterLV1) {
     auto IterLV2 = std::next(IterLV1);
     while (IterLV2 != LVHits.end()) {

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -165,7 +165,7 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   constexpr double Epsilon0 = 8.85418781762039e-14; // unit: F/cm
   constexpr double EpsilonR = 16.0; // in germanium, unitless
 
-  // TODO: Read bias voltage and temperature of the detector from a file
+  // TODO: Read bias voltage and temperature of the detector from a database
   constexpr double BiasVoltage = 1050.0; // unit: V
   constexpr double Temperature = 87.0; // unit: K
 
@@ -188,15 +188,8 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     double Radius = m_Radii[DetID];
     int NXStrips = m_NXStrips[DetID];
 
-    // TODO: replace magic numbers for cross-talk by reading parameters from file
     double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
     double N = SH.m_SimulatedEnergy / IonizationEnergy;
-    // constexpr double A = 0.020898810806838582;
-    // constexpr double B1 = 0.2740445312420676;
-    // constexpr double B2 = 0.22725576252704122;
-    // constexpr double Z1 = -6.8702771019427935;
-    // constexpr double Z2 = -6.403253988164561;
-    // double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
 
     // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
     int ID = static_cast<int>(std::floor((Pos.X() + XWidth/2.0) / XPitch));
@@ -208,28 +201,14 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
       // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= X < XPitch)
       double XFromGap = std::fmod(Pos.X() + XWidth/2.0, XPitch);
 
-      // calculate σ and µ, assuming t = z / v = z / (µ * E)
+      // Charge transport based on Eq. (7) in https://doi.org/10.1016/j.nima.2023.168310
+      // calculate σ and η, assuming t = z / v = z / (µ * E)
       double SigmaX = std::sqrt(2.0 * kB * Temperature * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
       double EtaX   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Pos.Z() + Thickness / 2.0) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
-      // cout << "X: " << Pos.X() << ", Y: " << Pos.Y() << ", Z: " << Pos.Z() << ", E: " << SH.m_SimulatedEnergy << endl;
-      // cout << "XPitch" << XPitch << ", SigmaX: " << SigmaX << ", EtaX: " << EtaX << endl;
-
-      auto Lambda = [&](double x) -> double {
-        double a = (x - EtaX) / (TMath::Sqrt2() * SigmaX);
-        double b = (x + EtaX) / (TMath::Sqrt2() * SigmaX);
-        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaX, 3)) * (
-          std::erf(b) * (2.0 * std::pow(EtaX, 3) + x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
-          std::erf(a) * (2.0 * std::pow(EtaX, 3) - x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
-          std::exp(- std::pow(b,2)) * std::sqrt(2.0 / TMath::Pi()) * SigmaX * (EtaX * x + (2.0 * std::pow(EtaX, 2) - 2.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
-          std::exp(- std::pow(a,2)) * std::sqrt(2.0 / TMath::Pi()) * SigmaX * (EtaX * x - (2.0 * std::pow(EtaX, 2) - 2.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) 
-        );
-      };
-
+      auto Lambda = [&](double x) -> double { return SH.m_SimulatedEnergy * CalculateChargeFraction(x, EtaX, SigmaX); };
       double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap);
       double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap);
       double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap);
-
-      // cout << "Energy: " << SH.m_SimulatedEnergy << ", split into " << NNLeftStripEnergy << ", " << MainStripEnergy << " and " << NNRightStripEnergy << endl;
 
       // create entry for the main hit
       MDEEStripHit MainSH = SH;
@@ -298,15 +277,8 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     double Radius = m_Radii[DetID];
     int NYStrips = m_NYStrips[DetID];
 
-    // TODO: replace magic numbers for cross-talk by reading parameters from file
     double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
     double N = SH.m_SimulatedEnergy / IonizationEnergy;
-    // constexpr double A = 0.016119326831437686;
-    // constexpr double B1 = 0.12520563605264975;
-    // constexpr double B2 = 0.17122757421051746;
-    // constexpr double Z1 = 5.812039914491831;
-    // constexpr double Z2 = 6.710904485197925;
-    // double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
 
     // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
     // TODO: Confirm the correct strip pitch based on SMEX detector models
@@ -319,21 +291,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
       // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= Y < YPitch)
       double YFromGap = std::fmod(Pos.Y() + YWidth/2.0, YPitch);
 
-      // calculate σ and µ, assuming t = z / v = z / (µ * E)
+      // Charge transport based on Eq. (7) in https://doi.org/10.1016/j.nima.2023.168310
+      // calculate σ and η, assuming t = z / v = z / (µ * E)
       double SigmaY = std::sqrt(2.0 * kB * Temperature * (Thickness / 2.0 - Pos.Z()) / (ElementaryCharge * MeanElectricField)); // in cm
       double EtaY   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Thickness / 2.0 - Pos.Z()) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
-
-      auto Lambda = [&](double y) -> double {
-        double a = (y - EtaY) / (TMath::Sqrt2() * SigmaY);
-        double b = (y + EtaY) / (TMath::Sqrt2() * SigmaY);
-        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaY, 3)) * (
-          std::erf(b) * (2.0 * std::pow(EtaY, 3) + y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
-          std::erf(a) * (2.0 * std::pow(EtaY, 3) - y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
-          std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * SigmaY * (EtaY * y + (2.0 * std::pow(EtaY, 2) - 2.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
-          std::exp(- std::pow(a,2)) * std::sqrt(2 / TMath::Pi()) * SigmaY * (EtaY * y - (2.0 * std::pow(EtaY, 2) - 2.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) 
-        );
-      };
-
+      auto Lambda = [&](double y) -> double { return SH.m_SimulatedEnergy * CalculateChargeFraction(y, EtaY, SigmaY); };
       double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap);
       double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap);
       double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap);
@@ -416,6 +378,20 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   }
 
   return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+double MSubModuleChargeTransport::CalculateChargeFraction(double x, double Eta, double Sigma) {
+  double a = (x - Eta) / (TMath::Sqrt2() * Sigma);
+  double b = (x + Eta) / (TMath::Sqrt2() * Sigma);
+  return 1.0 / (8.0 * std::pow(Eta, 3)) * (
+    std::erf(b) * (2.0 * std::pow(Eta, 3) + x * (3.0 * std::pow(Eta, 2) - 3.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
+    std::erf(a) * (2.0 * std::pow(Eta, 3) - x * (3.0 * std::pow(Eta, 2) - 3.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
+    std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * Sigma * (Eta * x + (2.0 * std::pow(Eta, 2) - 2.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
+    std::exp(- std::pow(a,2)) * std::sqrt(2 / TMath::Pi()) * Sigma * (Eta * x - (2.0 * std::pow(Eta, 2) - 2.0 * std::pow(Sigma, 2) - std::pow(x, 2))) 
+  );
 }
 
 

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -158,199 +158,35 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level 
 
-  // Define physical constants
-  constexpr double kB = TMath::K(); // unit: J/K
-  constexpr double ElementaryCharge = TMath::Qe(); // unit: C
-  constexpr double IonizationEnergy = 0.00295; // unit: keV
-  constexpr double Epsilon0 = 8.85418781762039e-14; // unit: F/cm
-  constexpr double EpsilonR = 16.0; // in germanium, unitless
-
-  // TODO: Read bias voltage and temperature of the detector from a database
-  constexpr double BiasVoltage = 1050.0; // unit: V
-  constexpr double Temperature = 87.0; // unit: K
-
-  // TODO: Implement energy-dependent initial charge-cloud sizes
-  constexpr double InitialChargeCloudSize = 0.; // zero for now, could be set to the default cut range ?
+  m_ChargeTransportHits.clear();
 
   // Create strip hits
-  list<MDEEStripHit> ChargeTransportLVHits;
-
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
   for (MDEEStripHit& SH: LVHits) {
-    MVector Pos = SH.m_SimulatedPositionInDetector;
-
-    // Determine detector and strip dimensions from the geometry
-    unsigned int DetID = SH.m_ROE.GetDetectorID();
-    double XWidth = m_XWidths[DetID];
-    double YWidth = m_YWidths[DetID];
-    double Thickness = m_Thicknesses[DetID];
-    double XPitch = m_XPitches[DetID];
-    double Radius = m_Radii[DetID];
-    int NXStrips = m_NXStrips[DetID];
-
-    double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
-    double N = SH.m_SimulatedEnergy / IonizationEnergy;
-
-    // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
-    int ID = static_cast<int>(std::floor((Pos.X() + XWidth/2.0) / XPitch));
-
-    // Check for strip ID and if the position is within the allowed strip length or on the guard ring
-    // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
-    if (ID >= 0 && ID < NXStrips && std::abs(Pos.Y()) <= YWidth/2.0 && std::hypot(Pos.X(), Pos.Y()) <= Radius) {
-
-      // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= X < XPitch)
-      double XFromGap = std::fmod(Pos.X() + XWidth/2.0, XPitch);
-
-      // Charge transport based on Eq. (7) in https://doi.org/10.1016/j.nima.2023.168310
-      // calculate σ and η, assuming t = z / v = z / (µ * E)
-      double SigmaX = std::sqrt(2.0 * kB * Temperature * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
-      double EtaX   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Pos.Z() + Thickness / 2.0) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
-      auto Lambda = [&](double x) -> double { return SH.m_SimulatedEnergy * CalculateChargeFraction(x, EtaX, SigmaX); };
-      double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap);
-      double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap);
-      double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap);
-
-      // create entry for the main hit
-      MDEEStripHit MainSH = SH;
-      MainSH.m_ROE.SetStripID(ID);
-      MainSH.m_Energy = MainStripEnergy;
-      MainSH.m_IsGuardRing = false;
-      ChargeTransportLVHits.push_back(MainSH);
-
-      // create MDEEStripHit for the left NN
-      if (NNLeftStripEnergy > IonizationEnergy) {
-        MDEEStripHit NNLeftSH = SH;
-        NNLeftSH.m_Energy = NNLeftStripEnergy;
-        if (ID > 0) {
-          NNLeftSH.m_ROE.SetStripID(ID - 1);
-          NNLeftSH.m_IsGuardRing = false;
-          // NNLeftSH.m_IsNearestNeighbor = true;
-        } else {
-          NNLeftSH.m_ROE.SetStripID(NXStrips);
-          NNLeftSH.m_IsGuardRing = true;
-        }
-        ChargeTransportLVHits.push_back(NNLeftSH);
-      }
-      
-      // create MDEEStripHit for the right NN
-      if (NNRightStripEnergy > IonizationEnergy) {
-        MDEEStripHit NNRightSH = SH;
-        NNRightSH.m_Energy = NNRightStripEnergy;
-        if (ID < NXStrips - 1) {
-          NNRightSH.m_ROE.SetStripID(ID + 1);
-          NNRightSH.m_IsGuardRing = false;
-          // NNRightSH.m_IsNearestNeighbor = true;
-        } else {
-          NNRightSH.m_ROE.SetStripID(NXStrips);
-          NNRightSH.m_IsGuardRing = true;
-        }
-        ChargeTransportLVHits.push_back(NNRightSH);
-      }
-
-    } else {
-      // TODO: implement charge sharing also for GR events
-      SH.m_Energy = SH.m_SimulatedEnergy;
-      SH.m_ROE.SetStripID(NXStrips);
-      SH.m_IsGuardRing = true;
-      ChargeTransportLVHits.push_back(SH);
-    }
+    RunChargeTransportForHit(SH, true);
   }
-
+    
   // replace old list by new list
   Event->GetDEEStripHitLVListReference().clear();
-  for (MDEEStripHit& SH: ChargeTransportLVHits) {
+  for (MDEEStripHit& SH: m_ChargeTransportHits) {
     Event->AddDEEStripHitLV(SH);
   }
 
-  list<MDEEStripHit> ChargeTransportHVHits;
+  // empty list
+  m_ChargeTransportHits.clear();
 
   list<MDEEStripHit>& HVHits = Event->GetDEEStripHitHVListReference();
   for (MDEEStripHit& SH: HVHits) {
-    MVector Pos = SH.m_SimulatedPositionInDetector;
-
-    // Determine detector and strip dimensions from the geometry
-    unsigned int DetID = SH.m_ROE.GetDetectorID();
-    double XWidth = m_XWidths[DetID];
-    double YWidth = m_YWidths[DetID];
-    double Thickness = m_Thicknesses[DetID];
-    double YPitch = m_YPitches[DetID];
-    double Radius = m_Radii[DetID];
-    int NYStrips = m_NYStrips[DetID];
-
-    double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
-    double N = SH.m_SimulatedEnergy / IonizationEnergy;
-
-    // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
-    // TODO: Confirm the correct strip pitch based on SMEX detector models
-    int ID = static_cast<int>(std::floor((Pos.Y() + YWidth/2.0) / YPitch));
-
-    // Check for strip ID and if the position is within the allowed strip length or on the guard ring
-    // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
-    if (ID >= 0 && ID < NYStrips && std::abs(Pos.X()) <= XWidth/2.0 && std::hypot(Pos.X(), Pos.Y()) <= Radius) {
-
-      // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= Y < YPitch)
-      double YFromGap = std::fmod(Pos.Y() + YWidth/2.0, YPitch);
-
-      // Charge transport based on Eq. (7) in https://doi.org/10.1016/j.nima.2023.168310
-      // calculate σ and η, assuming t = z / v = z / (µ * E)
-      double SigmaY = std::sqrt(2.0 * kB * Temperature * (Thickness / 2.0 - Pos.Z()) / (ElementaryCharge * MeanElectricField)); // in cm
-      double EtaY   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Thickness / 2.0 - Pos.Z()) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
-      auto Lambda = [&](double y) -> double { return SH.m_SimulatedEnergy * CalculateChargeFraction(y, EtaY, SigmaY); };
-      double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap);
-      double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap);
-      double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap);
-
-      // create entry for the main hit
-      MDEEStripHit MainSH = SH;
-      MainSH.m_ROE.SetStripID(ID);
-      MainSH.m_Energy = MainStripEnergy;
-      MainSH.m_IsGuardRing = false;
-      ChargeTransportHVHits.push_back(MainSH);
-
-      // create MDEEStripHit for the left NN
-      if (NNLeftStripEnergy > IonizationEnergy) {
-        MDEEStripHit NNLeftSH = SH;
-        NNLeftSH.m_Energy = NNLeftStripEnergy;
-        if (ID > 0) {
-          NNLeftSH.m_ROE.SetStripID(ID - 1);
-          NNLeftSH.m_IsGuardRing = false;
-          // NNLeftSH.m_IsNearestNeighbor = true;
-        } else {
-          NNLeftSH.m_ROE.SetStripID(NYStrips);
-          NNLeftSH.m_IsGuardRing = true;
-        }
-        ChargeTransportHVHits.push_back(NNLeftSH);
-      }
-        
-      // create MDEEStripHit for the right NN
-      if (NNRightStripEnergy > IonizationEnergy) {
-        MDEEStripHit NNRightSH = SH;
-        NNRightSH.m_Energy = NNRightStripEnergy;
-        if (ID < NYStrips - 1) {
-          NNRightSH.m_ROE.SetStripID(ID + 1);
-          NNRightSH.m_IsGuardRing = false;
-          // NNRightSH.m_IsNearestNeighbor = true;
-        } else {
-          NNRightSH.m_ROE.SetStripID(NYStrips);
-          NNRightSH.m_IsGuardRing = true;
-        }
-        ChargeTransportHVHits.push_back(NNRightSH);
-      }
-
-    } else {
-      // TODO: implement charge sharing also for GR events
-      SH.m_Energy = SH.m_SimulatedEnergy;
-      SH.m_ROE.SetStripID(NYStrips);
-      SH.m_IsGuardRing = true;
-      ChargeTransportHVHits.push_back(SH);
-    }
+    RunChargeTransportForHit(SH, false);
   }
 
   // replace old list by new list
   Event->GetDEEStripHitHVListReference().clear();
-  for (MDEEStripHit& SH: ChargeTransportHVHits) {
+  for (MDEEStripHit& SH: m_ChargeTransportHits) {
     Event->AddDEEStripHitHV(SH);
   }
+
+  m_ChargeTransportHits.clear();
 
   // Merge hits:
   // TODO: how to deal with flags like "m_IsNearestNeighbor" etc. ?
@@ -383,17 +219,124 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-double MSubModuleChargeTransport::CalculateChargeFraction(double x, double Eta, double Sigma) {
-  double a = (x - Eta) / (TMath::Sqrt2() * Sigma);
-  double b = (x + Eta) / (TMath::Sqrt2() * Sigma);
-  return 1.0 / (8.0 * std::pow(Eta, 3)) * (
-    std::erf(b) * (2.0 * std::pow(Eta, 3) + x * (3.0 * std::pow(Eta, 2) - 3.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
-    std::erf(a) * (2.0 * std::pow(Eta, 3) - x * (3.0 * std::pow(Eta, 2) - 3.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
-    std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * Sigma * (Eta * x + (2.0 * std::pow(Eta, 2) - 2.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
-    std::exp(- std::pow(a,2)) * std::sqrt(2 / TMath::Pi()) * Sigma * (Eta * x - (2.0 * std::pow(Eta, 2) - 2.0 * std::pow(Sigma, 2) - std::pow(x, 2))) 
-  );
-}
+void MSubModuleChargeTransport::RunChargeTransportForHit(MDEEStripHit& SH, bool isLV) {
 
+  // This function uses strip coordinates (P and Q) instead of X and Y
+  // (P = perpendicular to strip length, Q = along strip length):
+  //   ╔═════════════════════════════════════════════════╗ ↑
+  // P ║                  STRIP CONTACT                  ║ │ Pitch
+  // ↑ ╚═════════════════════════════════════════════════╝ ↓
+  // └→ Q 
+  // On the LV side: P = X, Q = Y
+  // On the HV side: P = Y, Q = X
+
+  // Get detector and strip dimensions
+  unsigned int DetID = SH.m_ROE.GetDetectorID();
+  double Thickness   = m_Thicknesses[DetID];
+  double Radius      = m_Radii[DetID];
+  double PWidth      = isLV ? m_XWidths[DetID] : m_YWidths[DetID];
+  double QWidth      = isLV ? m_YWidths[DetID] : m_XWidths[DetID];
+  double Pitch       = isLV ? m_XPitches[DetID] : m_YPitches[DetID];
+  int NStrips        = isLV ? m_NXStrips[DetID] : m_NYStrips[DetID];
+
+  // Express coordinates of the hit in local strip coordinates
+  MVector Pos = SH.m_SimulatedPositionInDetector;
+  double P    = isLV ? Pos.X() : Pos.Y();
+  double Q    = isLV ? Pos.Y() : Pos.X();
+  double ΔZ   = isLV ? Pos.Z() + Thickness / 2.0 : Thickness / 2.0 - Pos.Z();
+
+  // Calculate strip ID by rounding down intentionally to avoid truncation towards zero
+  int ID = static_cast<int>(std::floor((P + PWidth/2.0) / Pitch));
+
+  // Define physical constants
+  constexpr double kB = TMath::K(); // unit: J/K
+  constexpr double ElementaryCharge = TMath::Qe(); // unit: C
+  constexpr double IonizationEnergy = 0.00295; // unit: keV
+  constexpr double Epsilon0 = 8.85418781762039e-14; // unit: F/cm
+  constexpr double EpsilonR = 16.0; // in germanium, unitless
+
+  // TODO: Read bias voltage and temperature of the detector from a database
+  constexpr double BiasVoltage = 1050.0; // unit: V
+  constexpr double Temperature = 87.0; // unit: K
+
+  double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
+  double N = SH.m_SimulatedEnergy / IonizationEnergy;
+
+  // TODO: Implement energy-dependent initial charge-cloud sizes
+  constexpr double InitialChargeCloudSize = 0.; // zero for now, could be set to the default cut range ?
+
+  // Check for strip ID and if the position is within the allowed strip length or on the guard ring
+  // TODO: Confirm the correct boundary of the guard ring based on SMEX detector models
+  if (ID >= 0 && ID < NStrips && std::abs(P) <= QWidth/2.0 && std::hypot(P, Q) <= Radius) {
+
+    // Apply charge sharing based on relative coordinate to the gap of that strip (0 <= X < XPitch)
+    double FromGap = std::fmod(P + PWidth/2.0, Pitch);
+
+    // Charge transport based on Eq. (7) in https://doi.org/10.1016/j.nima.2023.168310
+    // calculate σ and η, assuming t = z / v = z / (µ * E)
+    double Sigma = std::sqrt(2.0 * kB * Temperature * ΔZ / (ElementaryCharge * MeanElectricField)); // in cm
+    double Eta   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * ΔZ / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
+    auto Lambda = [&](double x) -> double { 
+      double a = (x - Eta) / (TMath::Sqrt2() * Sigma);
+      double b = (x + Eta) / (TMath::Sqrt2() * Sigma);
+      return SH.m_SimulatedEnergy / (8.0 * std::pow(Eta, 3)) * (
+        std::erf(b) * (2.0 * std::pow(Eta, 3) + x * (3.0 * std::pow(Eta, 2) - 3.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
+        std::erf(a) * (2.0 * std::pow(Eta, 3) - x * (3.0 * std::pow(Eta, 2) - 3.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
+        std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * Sigma * (Eta * x + (2.0 * std::pow(Eta, 2) - 2.0 * std::pow(Sigma, 2) - std::pow(x, 2))) + 
+        std::exp(- std::pow(a,2)) * std::sqrt(2 / TMath::Pi()) * Sigma * (Eta * x - (2.0 * std::pow(Eta, 2) - 2.0 * std::pow(Sigma, 2) - std::pow(x, 2))) 
+      );
+    };
+
+    double MainStripEnergy    = Lambda(Pitch - FromGap) - Lambda(-FromGap);
+    double NNLeftStripEnergy  = Lambda(-FromGap) - Lambda(-Pitch - FromGap);
+    double NNRightStripEnergy = Lambda(2.0*Pitch - FromGap) - Lambda(Pitch - FromGap);
+
+    // create entry for the main hit
+    MDEEStripHit MainSH = SH;
+    MainSH.m_ROE.SetStripID(ID);
+    MainSH.m_Energy = MainStripEnergy;
+    MainSH.m_IsGuardRing = false;
+    m_ChargeTransportHits.push_back(MainSH);
+
+    // create MDEEStripHit for the left NN
+    if (NNLeftStripEnergy > IonizationEnergy) {
+      MDEEStripHit NNLeftSH = SH;
+      NNLeftSH.m_Energy = NNLeftStripEnergy;
+      if (ID > 0) {
+        NNLeftSH.m_ROE.SetStripID(ID - 1);
+        NNLeftSH.m_IsGuardRing = false;
+        // NNLeftSH.m_IsNearestNeighbor = true;
+      } else {
+        NNLeftSH.m_ROE.SetStripID(NStrips);
+        NNLeftSH.m_IsGuardRing = true;
+      }
+      m_ChargeTransportHits.push_back(NNLeftSH);
+    }
+    
+    // create MDEEStripHit for the right NN
+    if (NNRightStripEnergy > IonizationEnergy) {
+      MDEEStripHit NNRightSH = SH;
+      NNRightSH.m_Energy = NNRightStripEnergy;
+      if (ID < NStrips - 1) {
+        NNRightSH.m_ROE.SetStripID(ID + 1);
+        NNRightSH.m_IsGuardRing = false;
+        // NNRightSH.m_IsNearestNeighbor = true;
+      } else {
+        NNRightSH.m_ROE.SetStripID(NStrips);
+        NNRightSH.m_IsGuardRing = true;
+      }
+      m_ChargeTransportHits.push_back(NNRightSH);
+    }
+
+  } else {
+    // TODO: implement charge sharing also for GR events
+    SH.m_Energy = SH.m_SimulatedEnergy;
+    SH.m_ROE.SetStripID(NStrips);
+    SH.m_IsGuardRing = true;
+    m_ChargeTransportHits.push_back(SH);
+  }
+}
+  
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -166,7 +166,7 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   constexpr double EpsilonR = 16.0; // in germanium, unitless
 
   // TODO: Read bias voltage and temperature of the detector from a file
-  constexpr double BiasVoltage = 600.0; // unit: V
+  constexpr double BiasVoltage = 1050.0; // unit: V
   constexpr double Temperature = 87.0; // unit: K
 
   // TODO: Implement energy-dependent initial charge-cloud sizes
@@ -188,8 +188,15 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     double Radius = m_Radii[DetID];
     int NXStrips = m_NXStrips[DetID];
 
+    // TODO: replace magic numbers for cross-talk by reading parameters from file
     double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
     double N = SH.m_SimulatedEnergy / IonizationEnergy;
+    constexpr double A = 0.020898810806838582;
+    constexpr double B1 = 0.2740445312420676;
+    constexpr double B2 = 0.22725576252704122;
+    constexpr double Z1 = -6.8702771019427935;
+    constexpr double Z2 = -6.403253988164561;
+    double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
 
     // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
     int ID = static_cast<int>(std::floor((Pos.X() + XWidth/2.0) / XPitch));
@@ -202,15 +209,15 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
       double XFromGap = std::fmod(Pos.X() + XWidth/2.0, XPitch);
 
       // calculate σ and µ, assuming t = z / v = z / (µ * E)
-      double SigmaX = std::sqrt(2.0 * kB * Temperature * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
+      double SigmaX = std::sqrt(2.0 * kB * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
       double EtaX   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Pos.Z() + Thickness / 2.0) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
-      cout << "X: " << Pos.X() << ", Y: " << Pos.Y() << ", Z: " << Pos.Z() << ", E: " << SH.m_SimulatedEnergy << endl;
-      cout << "Sigma X: " << SigmaX << ", EtaX: " << EtaX << endl;
+      // cout << "X: " << Pos.X() << ", Y: " << Pos.Y() << ", Z: " << Pos.Z() << ", E: " << SH.m_SimulatedEnergy << endl;
+      // cout << "SigmaX: " << SigmaX << ", EtaX: " << EtaX << endl;
 
       auto Lambda = [&](double x) -> double {
         double a = (x - EtaX) / (TMath::Sqrt2() * SigmaX);
         double b = (x + EtaX) / (TMath::Sqrt2() * SigmaX);
-        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaX, 3)) * (
+        return SH.m_SimulatedEnergy * (1.0 - CrossTalk) / (8.0 * std::pow(EtaX, 3)) * (
           std::erf(b) * (2.0 * std::pow(EtaX, 3) + x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
           std::erf(a) * (2.0 * std::pow(EtaX, 3) - x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
           std::exp(- std::pow(b,2)) * std::sqrt(2.0 / TMath::Pi()) * SigmaX * (EtaX * x + (2.0 * std::pow(EtaX, 2) - 2.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
@@ -218,11 +225,11 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
         );
       };
 
-      double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap);
-      double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap);
-      double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap);
+      double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap) + SH.m_SimulatedEnergy * CrossTalk;
+      double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap) + SH.m_SimulatedEnergy * CrossTalk;
+      double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap) + SH.m_SimulatedEnergy * CrossTalk;
 
-      cout << "Energy: " << SH.m_SimulatedEnergy << ", split into " << NNLeftStripEnergy << ", " << MainStripEnergy << " and " << NNRightStripEnergy << endl;
+      // cout << "Energy: " << SH.m_SimulatedEnergy << ", split into " << NNLeftStripEnergy << ", " << MainStripEnergy << " and " << NNRightStripEnergy << endl;
 
       // create entry for the main hit
       MDEEStripHit MainSH = SH;
@@ -291,8 +298,15 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     double Radius = m_Radii[DetID];
     int NYStrips = m_NYStrips[DetID];
 
+    // TODO: replace magic numbers for cross-talk by reading parameters from file
     double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
     double N = SH.m_SimulatedEnergy / IonizationEnergy;
+    constexpr double A = 0.016119326831437686;
+    constexpr double B1 = 0.12520563605264975;
+    constexpr double B2 = 0.17122757421051746;
+    constexpr double Z1 = 5.812039914491831;
+    constexpr double Z2 = 6.710904485197925;
+    double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
 
     // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
     // TODO: Confirm the correct strip pitch based on SMEX detector models
@@ -312,7 +326,7 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
       auto Lambda = [&](double y) -> double {
         double a = (y - EtaY) / (TMath::Sqrt2() * SigmaY);
         double b = (y + EtaY) / (TMath::Sqrt2() * SigmaY);
-        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaY, 3)) * (
+        return SH.m_SimulatedEnergy * (1.0 - CrossTalk) / (8.0 * std::pow(EtaY, 3)) * (
           std::erf(b) * (2.0 * std::pow(EtaY, 3) + y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
           std::erf(a) * (2.0 * std::pow(EtaY, 3) - y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
           std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * SigmaY * (EtaY * y + (2.0 * std::pow(EtaY, 2) - 2.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
@@ -320,9 +334,9 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
         );
       };
 
-      double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap);
-      double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap);
-      double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap);
+      double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap) + SH.m_SimulatedEnergy * CrossTalk;
+      double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap) + SH.m_SimulatedEnergy * CrossTalk;
+      double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap) + SH.m_SimulatedEnergy * CrossTalk;
 
       // create entry for the main hit
       MDEEStripHit MainSH = SH;

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -246,6 +246,7 @@ void MSubModuleChargeTransport::RunChargeTransportForHit(MDEEStripHit& SH, bool 
   double ΔZ   = isLV ? Pos.Z() + Thickness / 2.0 : Thickness / 2.0 - Pos.Z();
 
   // Calculate strip ID by rounding down intentionally to avoid truncation towards zero
+  // TODO: Include mask metrology information when calculating the strip ID from the position.
   int ID = static_cast<int>(std::floor((P + PWidth/2.0) / Pitch));
 
   // Define physical constants

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -170,7 +170,7 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
   constexpr double Temperature = 87.0; // unit: K
 
   // TODO: Implement energy-dependent initial charge-cloud sizes
-  constexpr double InitialChargeCloudSize = 0.02; // 200µm in cm
+  constexpr double InitialChargeCloudSize = 0.; // zero for now, could be set to the default cut range ?
 
   // Create strip hits
   list<MDEEStripHit> ChargeTransportLVHits;
@@ -191,12 +191,12 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     // TODO: replace magic numbers for cross-talk by reading parameters from file
     double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
     double N = SH.m_SimulatedEnergy / IonizationEnergy;
-    constexpr double A = 0.020898810806838582;
-    constexpr double B1 = 0.2740445312420676;
-    constexpr double B2 = 0.22725576252704122;
-    constexpr double Z1 = -6.8702771019427935;
-    constexpr double Z2 = -6.403253988164561;
-    double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
+    // constexpr double A = 0.020898810806838582;
+    // constexpr double B1 = 0.2740445312420676;
+    // constexpr double B2 = 0.22725576252704122;
+    // constexpr double Z1 = -6.8702771019427935;
+    // constexpr double Z2 = -6.403253988164561;
+    // double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
 
     // Calculate LV strip ID by rounding down intentionally to avoid truncation towards zero
     int ID = static_cast<int>(std::floor((Pos.X() + XWidth/2.0) / XPitch));
@@ -209,15 +209,15 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
       double XFromGap = std::fmod(Pos.X() + XWidth/2.0, XPitch);
 
       // calculate σ and µ, assuming t = z / v = z / (µ * E)
-      double SigmaX = std::sqrt(2.0 * kB * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
+      double SigmaX = std::sqrt(2.0 * kB * Temperature * (Pos.Z() + Thickness / 2.0) / (ElementaryCharge * MeanElectricField)); // in cm
       double EtaX   = std::cbrt(std::pow(InitialChargeCloudSize, 3) + 3.0 * N * ElementaryCharge * (Pos.Z() + Thickness / 2.0) / (4.0 * TMath::Pi() * Epsilon0 * EpsilonR * MeanElectricField)); // in cm
       // cout << "X: " << Pos.X() << ", Y: " << Pos.Y() << ", Z: " << Pos.Z() << ", E: " << SH.m_SimulatedEnergy << endl;
-      // cout << "SigmaX: " << SigmaX << ", EtaX: " << EtaX << endl;
+      // cout << "XPitch" << XPitch << ", SigmaX: " << SigmaX << ", EtaX: " << EtaX << endl;
 
       auto Lambda = [&](double x) -> double {
         double a = (x - EtaX) / (TMath::Sqrt2() * SigmaX);
         double b = (x + EtaX) / (TMath::Sqrt2() * SigmaX);
-        return SH.m_SimulatedEnergy * (1.0 - CrossTalk) / (8.0 * std::pow(EtaX, 3)) * (
+        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaX, 3)) * (
           std::erf(b) * (2.0 * std::pow(EtaX, 3) + x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
           std::erf(a) * (2.0 * std::pow(EtaX, 3) - x * (3.0 * std::pow(EtaX, 2) - 3.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
           std::exp(- std::pow(b,2)) * std::sqrt(2.0 / TMath::Pi()) * SigmaX * (EtaX * x + (2.0 * std::pow(EtaX, 2) - 2.0 * std::pow(SigmaX, 2) - std::pow(x, 2))) + 
@@ -225,9 +225,9 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
         );
       };
 
-      double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap) + SH.m_SimulatedEnergy * CrossTalk;
-      double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap) + SH.m_SimulatedEnergy * CrossTalk;
-      double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap) + SH.m_SimulatedEnergy * CrossTalk;
+      double MainStripEnergy    = Lambda(XPitch - XFromGap) - Lambda(-XFromGap);
+      double NNLeftStripEnergy  = Lambda(-XFromGap) - Lambda(-XPitch - XFromGap);
+      double NNRightStripEnergy = Lambda(2.0*XPitch - XFromGap) - Lambda(XPitch - XFromGap);
 
       // cout << "Energy: " << SH.m_SimulatedEnergy << ", split into " << NNLeftStripEnergy << ", " << MainStripEnergy << " and " << NNRightStripEnergy << endl;
 
@@ -301,12 +301,12 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
     // TODO: replace magic numbers for cross-talk by reading parameters from file
     double MeanElectricField = BiasVoltage / Thickness; // unit: V/cm
     double N = SH.m_SimulatedEnergy / IonizationEnergy;
-    constexpr double A = 0.016119326831437686;
-    constexpr double B1 = 0.12520563605264975;
-    constexpr double B2 = 0.17122757421051746;
-    constexpr double Z1 = 5.812039914491831;
-    constexpr double Z2 = 6.710904485197925;
-    double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
+    // constexpr double A = 0.016119326831437686;
+    // constexpr double B1 = 0.12520563605264975;
+    // constexpr double B2 = 0.17122757421051746;
+    // constexpr double Z1 = 5.812039914491831;
+    // constexpr double Z2 = 6.710904485197925;
+    // double CrossTalk = A * std::max(1.0 - std::exp(-B1 * (10.0 * Pos.Z() - Z1)), 1.0 - std::exp(B2 * (10.0 * Pos.Z() - Z2)));
 
     // Calculate HV strip ID by rounding down intentionally to avoid truncation towards zero
     // TODO: Confirm the correct strip pitch based on SMEX detector models
@@ -326,7 +326,7 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
       auto Lambda = [&](double y) -> double {
         double a = (y - EtaY) / (TMath::Sqrt2() * SigmaY);
         double b = (y + EtaY) / (TMath::Sqrt2() * SigmaY);
-        return SH.m_SimulatedEnergy * (1.0 - CrossTalk) / (8.0 * std::pow(EtaY, 3)) * (
+        return SH.m_SimulatedEnergy / (8.0 * std::pow(EtaY, 3)) * (
           std::erf(b) * (2.0 * std::pow(EtaY, 3) + y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
           std::erf(a) * (2.0 * std::pow(EtaY, 3) - y * (3.0 * std::pow(EtaY, 2) - 3.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
           std::exp(- std::pow(b,2)) * std::sqrt(2 / TMath::Pi()) * SigmaY * (EtaY * y + (2.0 * std::pow(EtaY, 2) - 2.0 * std::pow(SigmaY, 2) - std::pow(y, 2))) + 
@@ -334,9 +334,9 @@ bool MSubModuleChargeTransport::AnalyzeEvent(MReadOutAssembly* Event)
         );
       };
 
-      double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap) + SH.m_SimulatedEnergy * CrossTalk;
-      double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap) + SH.m_SimulatedEnergy * CrossTalk;
-      double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap) + SH.m_SimulatedEnergy * CrossTalk;
+      double MainStripEnergy    = Lambda(YPitch - YFromGap) - Lambda(-YFromGap);
+      double NNLeftStripEnergy  = Lambda(-YFromGap) - Lambda(-YPitch - YFromGap);
+      double NNRightStripEnergy = Lambda(2.0*YPitch - YFromGap) - Lambda(YPitch - YFromGap);
 
       // create entry for the main hit
       MDEEStripHit MainSH = SH;

--- a/src/MSubModuleStripTrigger.cxx
+++ b/src/MSubModuleStripTrigger.cxx
@@ -311,6 +311,7 @@ bool MSubModuleStripTrigger::ProcessStripHits(MReadOutAssembly* Event)
   m_IsGeDDead = false;
 
   // Get merged strip hits from the event
+  // TODO: check if the strip merging should happen here instead of MSubModuleChargeTransport
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
   list<MDEEStripHit>& HVHits = Event->GetDEEStripHitHVListReference();
 


### PR DESCRIPTION
This is a first PR to replace the dummy code in  `MSubModuleChargeTransport::AnalyzeEvent`.
I will open this as a draft PR, there are still a lot of magic numbers in there (bias voltage, temperature, initial charge cloud size, cross-talk parameters), but this is mainly to collect feedback on my current implementation while moving forward and improving this in comparison with data.

Some mathematical background:
The linear charge density of an event at a given position and depth can be approximated by Eq. (7) in https://doi.org/10.1016/j.nima.2023.168310. To get to the actual charge/energy, we need to integrate the linear charge density from the left edge of the strip to the right edge of the strip:
<img width="509" height="706" alt="image" src="https://github.com/user-attachments/assets/9040d147-c44b-49a6-8df8-31c4a022a3d1" />

The idea is then to calculate the energy for the main strip and it's direct neighbors.
Here is a plot of what is happening in the code:

<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/8ed17643-1f31-44b1-a304-ad3478ae9ffe" />


The implementation of cross-talk is based on the parameterization that we obtained from simulations (for now just for one detector and implemented as magic numbers). This currently seems to underestimate the cross-talk on the HV side and overestimate the cross-talk on the LV side.
<img width="1201" height="577" alt="image" src="https://github.com/user-attachments/assets/d5f71fdc-f9c5-4153-a875-78b9f3a103e7" />
