### PR TITLE
Strip Pairing Flags

### DIFF
--- a/include/MGUIOptionsStripPairingMultiRoundChiSquare.h
+++ b/include/MGUIOptionsStripPairingMultiRoundChiSquare.h
@@ -1,0 +1,88 @@
+/*
+ * MGUIOptionsStripPairingMultiRoundChiSquare.h
+ *
+ * Copyright (C) by Julian Gerber.
+ * All rights reserved.
+ *
+ * Please see the source-file for the copyright-notice.
+ *
+ */
+
+
+#ifndef __MGUIOptionsStripPairingMultiRoundChiSquare__
+#define __MGUIOptionsStripPairingMultiRoundChiSquare__
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+// ROOT libs:
+#include <TROOT.h>
+#include <TVirtualX.h>
+#include <TGWindow.h>
+#include <TObjArray.h>
+#include <TGFrame.h>
+#include <TGButton.h>
+#include <TGButtonGroup.h>
+#include <MString.h>
+#include <TGClient.h>
+#include <TGNumberEntry.h>
+#include <TGTextEntry.h>
+
+// MEGAlib libs:
+#include "MGlobal.h"
+#include "MGUIERBList.h"
+#include "MModule.h"
+#include "MGUIOptions.h"
+
+// Forward declarations:
+class MGUIEFileSelector;
+class MGUIEMinMaxEntry;
+class MGUIEEntry;
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+class MGUIOptionsStripPairingMultiRoundChiSquare : public MGUIOptions
+{
+    // public Session:
+     public:
+      //! Default constructor
+    MGUIOptionsStripPairingMultiRoundChiSquare(MModule* Module);
+      //! Default destructor
+      virtual ~MGUIOptionsStripPairingMultiRoundChiSquare();
+
+      //! Process all button, etc. messages
+      virtual bool ProcessMessage(long Message, long Parameter1, long Parameter2);
+
+      //! The creation part which gets overwritten
+      virtual void Create();
+
+      // protected methods:
+     protected:
+
+      //! Actions after the Apply or OK button has been pressed
+      virtual bool OnApply();
+
+
+      // protected members:
+     protected:
+      //! Maximum number of strip hits
+      MGUIEEntry* m_MaximumStrips;
+
+      // private members:
+     private:
+
+
+
+#ifdef ___CLING___
+ public:
+  ClassDef(MGUIOptionsStripPairingMultiRoundChiSquare, 1) // basic class for dialog windows
+#endif
+
+};
+
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////

--- a/include/MHit.h
+++ b/include/MHit.h
@@ -108,10 +108,18 @@ class MHit
 	//! get m_StripHitMultipleTimesY
 	bool GetStripHitMultipleTimesY() const { return m_StripHitMultipleTimesY; }
 
-	//! set charge sharing flag
-	void SetChargeSharing(bool chargeSharing) {m_ChargeSharing = chargeSharing; }
-	//! get m_ChargeSharing
-	bool GetChargeSharing() const { return m_ChargeSharing; }
+	//! set charge sharing flag for LV side
+	void SetChargeSharingLV(bool chargeSharingLV) {m_ChargeSharingLV = chargeSharingLV; }
+	//! get m_ChargeSharingLV
+	bool GetChargeSharingLV() const { return m_ChargeSharingLV; }
+    //! set charge sharing flag for HV side
+    void SetChargeSharingHV(bool chargeSharingHV) {m_ChargeSharingHV = chargeSharingHV; }
+    //! get m_ChargeSharingHV
+    bool GetChargeSharingHV() const { return m_ChargeSharingHV; }
+    //! Keeping general charge sharing flags because Greedy strip pairing relies on it
+    void SetChargeSharing(bool chargeSharing) {m_ChargeSharing = chargeSharing; }
+    //! get m_ChargeSharing
+    bool GetChargeSharing() const { return m_ChargeSharing; }
 	//! set m_NoDepth
 	void SetNoDepth(bool X = true) { m_NoDepth = X;}
 	//! get m_NoDepth
@@ -184,7 +192,9 @@ class MHit
 	bool m_StripHitMultipleTimesY = false;
 
 	//! true if hit contains charge sharing
-	bool m_ChargeSharing;
+    bool m_ChargeSharing;
+	bool m_ChargeSharingLV;
+    bool m_ChargeSharingHV;
 
 	//! true if depth is invalid, either because the pixel depth was uncalibrated, the hit was mapped too far out of the detector,or there was no timing data
 	bool m_NoDepth;

--- a/include/MHit.h
+++ b/include/MHit.h
@@ -93,6 +93,11 @@ class MHit
 	void SetCrossTalkFlag(bool PossibleCrossTalk) {m_PossibleCrossTalk = PossibleCrossTalk;}
 	//! get cross talk flag value
 	bool GetCrossTalkFlag() const { return m_PossibleCrossTalk; }
+    
+    //! Set guard ring hit flag
+    void SetGuardRingHitFlag(bool GuardRingHit) {m_GuardRingHit = GuardRingHit;}
+    //! Get guard ring hit flag
+    bool GetGuardRingHitFlag() const { return m_GuardRingHit; }
 
 	//! set charge loss flag
 	void SetChargeLossFlag(bool PossibleChargeLoss) {m_PossibleChargeLoss = PossibleChargeLoss;}
@@ -185,6 +190,8 @@ class MHit
 	bool m_PossibleCrossTalk;
 	//! Flag: possible charge loss
 	bool m_PossibleChargeLoss;
+    //! Flag: hit containing guard ring strip
+    bool m_GuardRingHit;
 
 	//! true if hit contains strip that was hit multiple times on X
 	bool m_StripHitMultipleTimesX = false;

--- a/include/MModuleStripPairingMultiRoundChiSquare.h
+++ b/include/MModuleStripPairingMultiRoundChiSquare.h
@@ -72,6 +72,11 @@ class MModuleStripPairingMultiRoundChiSquare : public MModule
   virtual bool ReadXmlConfiguration(MXmlNode* Node);
   //! Create an XML node tree from the configuration
   virtual MXmlNode* CreateXmlConfiguration();
+    
+  //! Set the maximum number of strips
+  void SetMaximumStrips(double MaximumStrips) { m_MaximumStrips = MaximumStrips; }
+  //! Get the maximum number of strips
+  double GetMaximumStrips() const { return m_MaximumStrips; }
 
   // protected methods:
  protected:
@@ -113,7 +118,8 @@ class MModuleStripPairingMultiRoundChiSquare : public MModule
 
   // private members:
  private:
-
+  //! The maximum number of strips to pair
+  unsigned int m_MaximumStrips;
 
 
 

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -238,6 +238,12 @@ class MReadOutAssembly : public MReadOutSequence
   void SetStripHitBelowThreshold_QualityFlag(MString Text = ""){ m_StripHitBelowThreshold_QualityFlag = true; if (Text != "") { m_StripHitBelowThresholdString_QualityFlag.push_back(Text); }}
   //! Get the Strip Hit Below Threshold quality flag
   bool HasStripHitBelowThreshold_QualityFlag() const { return m_StripHitBelowThreshold_QualityFlag; }
+    
+  //! Set the Strip Pairing quality flag
+  void SetStripPairing_QualityFlag(MString Text = ""){ m_StripPairing_QualityFlag = true;
+      if (Text != "") { m_StripPairingString_QualityFlag.push_back(Text); }}
+  //! Get the Strip Pairing quality flag
+  bool HasStripPairing_QualityFlag() const { return m_StripPairing_QualityFlag; }
 
   //! Set the Reduced Chi^2 used in MultiRoundChiSquare module
   void SetStripPairingReducedChiSquare(double StripPairingReducedChiSquare) { m_StripPairingReducedChiSquare = StripPairingReducedChiSquare; }
@@ -417,6 +423,11 @@ class MReadOutAssembly : public MReadOutSequence
   bool m_StripHitBelowThreshold_QualityFlag;
   //! Strip hit below threshold quality string
   vector<MString> m_StripHitBelowThresholdString_QualityFlag;
+    
+  //! Strip pairing quality flag
+  bool m_StripPairing_QualityFlag;
+  //! Strip pairing quality string
+  vector<MString> m_StripPairingString_QualityFlag;
 
   //! Reduced Chi^2 of the Strip Paired Event
   double m_StripPairingReducedChiSquare;

--- a/src/MGUIOptionsStripPairingMultiRoundChiSquare.cxx
+++ b/src/MGUIOptionsStripPairingMultiRoundChiSquare.cxx
@@ -1,0 +1,135 @@
+/*
+ * MGUIOptionsStripPairingMultiRoundChiSquare.cxx
+ *
+ *
+ * Copyright (C) by Julian Gerber
+ * All rights reserved.
+ *
+ *
+ * This code implementation is the intellectual property of
+ * Andreas Zoglauer.
+ *
+ * By copying, distributing or modifying the Program (or any work
+ * based on the Program) you indicate your acceptance of this statement,
+ * and all its terms.
+ *
+ */
+
+
+////////////////////////////////////////////////////////////////////////////////
+//
+// MGUIOptionsStripPairingMultiRoundChiSquare
+//
+////////////////////////////////////////////////////////////////////////////////
+
+
+// Include the header:
+#include "MGUIOptionsStripPairingMultiRoundChiSquare.h"
+
+// Standard libs:
+
+// ROOT libs:
+#include <TSystem.h>
+#include <TGLabel.h>
+#include <TGResourcePool.h>
+#include <TGNumberEntry.h>
+#include <TGTextEntry.h>
+
+// MEGAlib libs:
+#include "MStreams.h"
+#include "MString.h"
+#include "MGUIEFileSelector.h"
+#include "MGUIEMinMaxEntry.h"
+#include "MGUIEEntry.h"
+
+// Nuclearizer libs:
+#include "MModuleStripPairingMultiRoundChiSquare.h"
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+#ifdef ___CLING___
+ClassImp(MGUIOptionsStripPairingMultiRoundChiSquare)
+#endif
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIOptionsStripPairingMultiRoundChiSquare::MGUIOptionsStripPairingMultiRoundChiSquare(MModule* Module)
+  : MGUIOptions(Module)
+{
+  // standard constructor
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MGUIOptionsStripPairingMultiRoundChiSquare::~MGUIOptionsStripPairingMultiRoundChiSquare()
+{
+  // kDeepCleanup is activated
+}
+
+///////////////////////////////////////////////////////////////////////////////////
+
+
+void MGUIOptionsStripPairingMultiRoundChiSquare::Create()
+{
+  PreCreate();
+    
+  TGLayoutHints* FirstLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 10, 10, 30, 2);
+
+  m_MaximumStrips = new MGUIEEntry(m_OptionsFrame,
+                                           "Choose the maximum number of strips on either side:",
+                                           false, dynamic_cast<MModuleStripPairingMultiRoundChiSquare*>(m_Module)->GetMaximumStrips());
+      m_OptionsFrame->AddFrame(m_MaximumStrips, FirstLayout);
+  
+  PostCreate();
+}
+       
+                               
+///////////////////////////////////////////////////////////////////////////////////
+
+
+bool MGUIOptionsStripPairingMultiRoundChiSquare::ProcessMessage(long Message, long Parameter1, long Parameter2)
+{
+ // Modify here if you have more buttons
+
+ bool Status = true;
+ 
+ switch (GET_MSG(Message)) {
+ case kC_COMMAND:
+   switch (GET_SUBMSG(Message)) {
+   case kCM_BUTTON:
+     break;
+   default:
+     break;
+   }
+   break;
+ default:
+   break;
+ }
+ 
+ if (Status == false) {
+   return false;
+ }
+
+ // Call also base class
+ return MGUIOptions::ProcessMessage(Message, Parameter1, Parameter2);
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////
+
+                               
+bool MGUIOptionsStripPairingMultiRoundChiSquare::OnApply()
+{
+  dynamic_cast<MModuleStripPairingMultiRoundChiSquare*>(m_Module)->SetMaximumStrips(m_MaximumStrips->GetAsInt());
+    
+  return true;
+}
+
+
+// MGUIOptionsStripPairingMultiRoundChiSquare.cxx: the end...
+////////////////////////////////////////////////////////////////////////////////

--- a/src/MGUIOptionsStripPairingMultiRoundChiSquare.cxx
+++ b/src/MGUIOptionsStripPairingMultiRoundChiSquare.cxx
@@ -125,7 +125,7 @@ bool MGUIOptionsStripPairingMultiRoundChiSquare::ProcessMessage(long Message, lo
                                
 bool MGUIOptionsStripPairingMultiRoundChiSquare::OnApply()
 {
-  dynamic_cast<MModuleStripPairingMultiRoundChiSquare*>(m_Module)->SetMaximumStrips(m_MaximumStrips->GetAsInt());
+  dynamic_cast<MModuleStripPairingMultiRoundChiSquare*>(m_Module)->SetMaximumStrips(m_MaximumStrips->GetAsDouble());
     
   return true;
 }

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -352,6 +352,10 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
     for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
       
       unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
+        
+      if (abs(long(Combinations[d][0][lv].size()) - long(Combinations[d][1][hv].size())) > 1) {
+        continue;
+      }
 
       bool MorePermutations = true;
       while (MorePermutations == true) {

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -567,6 +567,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
     if (AllAdjacentHV == false && AllAdjacentLV == true) {
       //cout<<"Multiple hits on single LV strip"<<endl;
       bool MultipleHitsOnLV = true;
+      Event->SetStripPairing_QualityFlag("Event contains multiple hits on single LV strip");
 
       // Assign hit energy based on energy measured on HV side
       for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
@@ -588,7 +589,6 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->SetLVEnergy(LVEnergy);
         Hit->SetHVEnergy(HVEnergy);
         Hit->SetStripHitMultipleTimesX(MultipleHitsOnLV);
-        Event->SetStripPairing_QualityFlag("Event contains multiple hits on single LV strip");
         Event->AddHit(Hit);
           
 
@@ -614,6 +614,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
     else if (AllAdjacentLV == false && AllAdjacentHV == true) {
       // cout<<"Multiple hits on single HV strip"<<endl;
       bool MultipleHitsOnHV = true;
+      Event->SetStripPairing_QualityFlag("Event contains multiple hits on single HV strip");
 
       // Assign hit energy based on energy measured on LV side
       for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
@@ -635,7 +636,6 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->SetLVEnergy(LVEnergy);
         Hit->SetHVEnergy(HVEnergy);
         Hit->SetStripHitMultipleTimesY(MultipleHitsOnHV);
-        Event->SetStripPairing_QualityFlag("Event contains multiple hits on single HV strip");
         Event->AddHit(Hit);
 
         HVEnergyTotal += HVEnergy;

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -483,7 +483,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
     }
 
     // If there are no non-adjacent strip groupings, continue pairing as normal
-    if (AllAdjacent) {
+    if (AllAdjacent == true) {
 
       // Add up energy and energy resolution for each grouping of strips
       for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -272,7 +272,9 @@ bool MModuleStripPairingMultiRoundChiSquare::EventSelection(MReadOutAssembly* Ev
   for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
     for (unsigned int side = 0; side <= 1; ++side) { // Side loop
       if (StripHits[d][side].size() > MaxStripHits) {
-        Event->SetStripPairing_QualityFlag("More than 6 hit strips on one side");
+        Event->SetStripPairingError("More than 6 hit strips on one side");
+        Event->SetAnalysisProgress(MAssembly::c_StripPairing);
+        return false;
       }
 
       // Check if one side of the detector has no strip hits

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -793,7 +793,16 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
     if (PopulateHits == false) {
       return false;
     }
-
+      
+    // Check for any hits containing guard ring strips
+    for (unsigned int h = 0; h < Event->GetNHits(); h++) {
+      for (unsigned int sh = 0; sh < Event->GetHit(h)->GetNStripHits(); sh++) {
+        if (Event->GetHit(h)->GetStripHit(sh)->GetStripID() == 64) {
+          Event->GetHit(h)->SetGuardRingHitFlag(true);
+        }
+      }
+    }
+      
   } // End Detector loop
 
   Event->SetAnalysisProgress(MAssembly::c_StripPairing);

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -352,10 +352,6 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
     for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
       
       unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
-        
-      if (abs(long(Combinations[d][0][lv].size()) - long(Combinations[d][1][hv].size())) > 1) {
-        continue;
-      }
 
       bool MorePermutations = true;
       while (MorePermutations == true) {

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -558,6 +558,15 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
       for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
         Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
       }
+      
+      // Check for charge sharing on either side
+      if (BestLVSideCombo[h].size() > 1) {
+        Hit->SetChargeSharingLV(true);
+      }
+      if (BestHVSideCombo[h].size() > 1) {
+        Hit->SetChargeSharingHV(true);
+      }
+      
     }
 
     // If there are non-adjacent strip groupings, then have to separate them out again to form multiple (physical) hits
@@ -603,6 +612,10 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
           Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
         }
+        // Check if there's charge sharing on LV side (currently no way to tell if there's charge sharing on side that doesn't have multiple hits on single strip)
+        if (BestLVSideCombo[h].size() > 1) {
+          Hit->SetChargeSharingLV(true);
+        }
       }
     }
 
@@ -643,6 +656,10 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->AddStripHit(StripHits[d][0][BestLVSideCombo[h][sh]]);
         for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
           Hit->AddStripHit(StripHits[d][1][BestHVSideCombo[h][sh]]);
+        }
+        // Check if there's charge sharing on HV side (currently no way to tell if there's charge sharing on side that doesn't have multiple hits on single strip)
+        if (BestHVSideCombo[h].size() > 1) {
+          Hit->SetChargeSharingHV(true);
         }
       }
     }

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -822,6 +822,7 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
       for (unsigned int sh = 0; sh < Event->GetHit(h)->GetNStripHits(); sh++) {
         if (Event->GetHit(h)->GetStripHit(sh)->GetStripID() == 64) {
           Event->GetHit(h)->SetGuardRingHitFlag(true);
+          Event->SetStripPairing_QualityFlag("GR Hit: Detector ID " + to_string(d) + " and Energy " + to_string(Event->GetHit(h)->GetEnergy()));
         }
       }
     }

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -350,17 +350,8 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
 
   for (unsigned int lv = 0; lv < Combinations[d][0].size(); ++lv) { // Loop over combinations of lv-strips (lv represents a list of sets of strips,  and each set is a proposed Hit)
     for (unsigned int hv = 0; hv < Combinations[d][1].size(); ++hv) {
-      // Skip if lv and hv strip combos differ in size by more than one
-      if (abs(long(Combinations[d][0][lv].size()) - long(Combinations[d][1][hv].size())) > 1) {
-        continue;
-      }
-
+      
       unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
-
-      // Skip pairing if either side has more than 5 sets of strips
-      //if (max(Combinations[d][0][lv].size(), Combinations[d][1][hv].size()) > MaxCombinations) {
-       // continue;
-     // }
 
       bool MorePermutations = true;
       while (MorePermutations == true) {
@@ -788,7 +779,12 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
     
     // Check if size of LV or HV combination exceeds maximum
     if (max(BestLVSideCombo.size(), BestHVSideCombo.size()) > MaxCombinations) {
-      Event->SetStripPairing_QualityFlag("Best strip pairing contains more than 5 strip grouping");
+      Event->SetStripPairing_QualityFlag("Best strip pairing contains more than 5 strip groupings (hits)");
+    }
+    
+    // Flag event if more than one set of strips is left unpaired
+    if (abs(long(BestLVSideCombo.size()) - long(BestHVSideCombo.size())) > 1) {
+      Event->SetStripPairing_QualityFlag("Best strip pairing leaves more than one grouping of strips unpaired");
     }
 
     // Populate hits with best strip paired combination

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -36,6 +36,7 @@
 // MEGAlib libs:
 #include "MModule.h"
 #include "MGUIOptionsStripPairing.h"
+#include "MGUIOptionsStripPairingMultiRoundChiSquare.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -51,7 +52,8 @@ ClassImp(MModuleStripPairingMultiRoundChiSquare)
 //! Define constants to be used in strip pairing
 
 const unsigned int MaxCombinations = 5; // Defines maximum number of strip combinations allowed in pairing
-const unsigned int MaxStripHits = 6; // Define maximum number of strip hits on any one side
+// Now defined by user!
+// const unsigned int MaxStripHits = 6; // Define maximum number of strip hits on any one side
 const unsigned int ChiSquareThreshold = 100; // If strip pairing does not reach this threshold, it will enter round two
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -82,9 +84,11 @@ MModuleStripPairingMultiRoundChiSquare::MModuleStripPairingMultiRoundChiSquare()
 
   // Set if this module has an options GUI
   // Overwrite ShowOptionsGUI() with the call to the GUI!
-  m_HasOptionsGUI = false;
+  m_HasOptionsGUI = true;
   // If true, you have to derive a class from MGUIOptions (use MGUIOptionsTemplate)
   // and implement all your GUI options
+    
+  m_MaximumStrips = 6;
 
   // Can the program be run multi-threaded
   m_AllowMultiThreading = true;
@@ -271,8 +275,8 @@ bool MModuleStripPairingMultiRoundChiSquare::EventSelection(MReadOutAssembly* Ev
   // Limit the number of strip hits on each side
   for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
     for (unsigned int side = 0; side <= 1; ++side) { // Side loop
-      if (StripHits[d][side].size() > MaxStripHits) {
-        Event->SetStripPairingError("More than 6 hit strips on one side");
+      if (StripHits[d][side].size() > m_MaximumStrips) {
+        Event->SetStripPairingError("More than maximum number of strip hits allowed on one side (" + to_string(StripHits[d][side].size()) + ")");
         Event->SetAnalysisProgress(MAssembly::c_StripPairing);
         return false;
       }
@@ -852,7 +856,15 @@ void MModuleStripPairingMultiRoundChiSquare::ShowOptionsGUI()
 {
   //! Show the options GUI --- has to be overwritten!
 
-  MGUIOptionsStripPairing* Options = new MGUIOptionsStripPairing(this);
+  //MGUIOptionsStripPairing* Options = new MGUIOptionsStripPairing(this);
+  //Options->Create();
+  //gClient->WaitForUnmap(Options);
+    
+  // I don't believe the above options GUI (MGUIOptionsStripPairing) is actually being used here?
+    
+  // Show the options GUI for choosing maximum number of strip hits
+
+  MGUIOptionsStripPairingMultiRoundChiSquare* Options = new MGUIOptionsStripPairingMultiRoundChiSquare(this);
   Options->Create();
   gClient->WaitForUnmap(Options);
 }

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -272,9 +272,7 @@ bool MModuleStripPairingMultiRoundChiSquare::EventSelection(MReadOutAssembly* Ev
   for (unsigned int d = 0; d < StripHits.size(); ++d) { // Detector loop
     for (unsigned int side = 0; side <= 1; ++side) { // Side loop
       if (StripHits[d][side].size() > MaxStripHits) {
-        Event->SetStripPairingError("More than 6 hit strips on one side");
-        Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-        return false;
+        Event->SetStripPairing_QualityFlag("More than 6 hit strips on one side");
       }
 
       // Check if one side of the detector has no strip hits
@@ -360,9 +358,9 @@ tuple<vector<vector<unsigned int>>, vector<vector<unsigned int>>, double> MModul
       unsigned int MinSize = min(Combinations[d][0][lv].size(), Combinations[d][1][hv].size());
 
       // Skip pairing if either side has more than 5 sets of strips
-      if (max(Combinations[d][0][lv].size(), Combinations[d][1][hv].size()) > MaxCombinations) {
-        continue;
-      }
+      //if (max(Combinations[d][0][lv].size(), Combinations[d][1][hv].size()) > MaxCombinations) {
+       // continue;
+     // }
 
       bool MorePermutations = true;
       while (MorePermutations == true) {
@@ -590,6 +588,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->SetLVEnergy(LVEnergy);
         Hit->SetHVEnergy(HVEnergy);
         Hit->SetStripHitMultipleTimesX(MultipleHitsOnLV);
+        Event->SetStripPairing_QualityFlag("Event contains multiple hits on single LV strip");
         Event->AddHit(Hit);
           
 
@@ -632,6 +631,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
         Hit->SetLVEnergy(LVEnergy);
         Hit->SetHVEnergy(HVEnergy);
         Hit->SetStripHitMultipleTimesY(MultipleHitsOnHV);
+        Event->SetStripPairing_QualityFlag("Event contains multiple hits on single HV strip");
         Event->AddHit(Hit);
 
         HVEnergyTotal += HVEnergy;
@@ -660,9 +660,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
 
   // One last quality selection based on total event energies
   if ((EnergyTotal > max(LVEnergyTotal, HVEnergyTotal) + 2.5 * max(LVEnergyResTotal, HVEnergyResTotal) || EnergyTotal < min(LVEnergyTotal, HVEnergyTotal) - 2.5 * max(LVEnergyResTotal, HVEnergyResTotal))) {
-    Event->SetStripPairingError("Strips not pairable wihin 2.5 sigma of measured energy");
-    Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-    return false;
+    Event->SetStripPairing_QualityFlag("Strips not pairable wihin 2.5 sigma of measured energy");
   }
   // Plot the good events
   else if ((HasExpos() == true) and Event->IsGood() == true) {
@@ -765,13 +763,16 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
     }
     // Flag events with a reduced chi square > 25
     else if (BestChiSquare > 25) {
-      Event->SetStripPairingError("Best reduced chi square is not below 25");
-      Event->SetAnalysisProgress(MAssembly::c_StripPairing);
-      return false;
+      Event->SetStripPairing_QualityFlag("Best reduced chi square is not below 25");
     }
 
     // Assign the best reduced chi square to the event
     Event->SetStripPairingReducedChiSquare(BestChiSquare);
+    
+    // Check if size of LV or HV combination exceeds maximum
+    if (max(BestLVSideCombo.size(), BestHVSideCombo.size()) > MaxCombinations) {
+      Event->SetStripPairing_QualityFlag("Best strip pairing contains more than 5 strip grouping");
+    }
 
     // Populate hits with best strip paired combination
     bool PopulateHits = CreateHits(d, Event, StripHits, BestLVSideCombo, BestHVSideCombo);

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -785,14 +785,31 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
     
     // Check if size of LV or HV combination exceeds maximum
     if (max(BestLVSideCombo.size(), BestHVSideCombo.size()) > MaxCombinations) {
-      Event->SetStripPairing_QualityFlag("Best strip pairing contains more than 5 strip groupings (hits)");
+      Event->SetStripPairing_QualityFlag("Best strip pairing contains more than 5 strip groupings on one side");
     }
     
     // Flag event if more than one set of strips is left unpaired
-    if (abs(long(BestLVSideCombo.size()) - long(BestHVSideCombo.size())) > 1) {
-      Event->SetStripPairing_QualityFlag("Best strip pairing leaves more than one grouping of strips unpaired");
+    double UnpairedEnergy = 0;
+    if (BestLVSideCombo.size() > BestHVSideCombo.size()) { // LV strips unpaired
+      int index = BestHVSideCombo.size();
+      for (unsigned int h = index; h < BestLVSideCombo.size(); h++) {
+        for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {
+          UnpairedEnergy += StripHits[d][0][BestLVSideCombo[h][sh]]->GetEnergy(); // Add all the energy on the unpaired strips
+        }
+      }
+      Event->SetStripPairing_QualityFlag("Best strip pairing leaves at least one grouping of strips unpaired (unpaired energy: " + to_string(UnpairedEnergy) + ")");
     }
-
+    
+    if (BestHVSideCombo.size() > BestLVSideCombo.size()) { // HV strips unpaired
+      int index = BestLVSideCombo.size();
+      for (unsigned int h = index; h < BestHVSideCombo.size(); h++) {
+        for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
+          UnpairedEnergy += StripHits[d][1][BestHVSideCombo[h][sh]]->GetEnergy(); // Add all the energy on the unpaired strips
+        }
+      }
+      Event->SetStripPairing_QualityFlag("Best strip pairing leaves at least one grouping of strips unpaired (unpaired energy: " + to_string(UnpairedEnergy) + ")");
+    }
+    
     // Populate hits with best strip paired combination
     bool PopulateHits = CreateHits(d, Event, StripHits, BestLVSideCombo, BestHVSideCombo);
 

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -569,7 +569,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
     if (AllAdjacentHV == false && AllAdjacentLV == true) {
       //cout<<"Multiple hits on single LV strip"<<endl;
       bool MultipleHitsOnLV = true;
-      Event->SetStripPairing_QualityFlag("Event contains multiple hits on single LV strip");
+      Event->SetStripPairing_QualityFlag("Event contains multiple hits on a single strip");
 
       // Assign hit energy based on energy measured on HV side
       for (unsigned int sh = 0; sh < BestHVSideCombo[h].size(); ++sh) {
@@ -616,7 +616,7 @@ bool MModuleStripPairingMultiRoundChiSquare::CreateHits(unsigned int d, MReadOut
     else if (AllAdjacentLV == false && AllAdjacentHV == true) {
       // cout<<"Multiple hits on single HV strip"<<endl;
       bool MultipleHitsOnHV = true;
-      Event->SetStripPairing_QualityFlag("Event contains multiple hits on single HV strip");
+      Event->SetStripPairing_QualityFlag("Event contains multiple hits on a single strip");
 
       // Assign hit energy based on energy measured on LV side
       for (unsigned int sh = 0; sh < BestLVSideCombo[h].size(); ++sh) {

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -773,7 +773,7 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
     }
     // Flag events with a reduced chi square > 25
     else if (BestChiSquare > 25) {
-      Event->SetStripPairing_QualityFlag("Best reduced chi square is not below 25");
+      Event->SetStripPairing_QualityFlag("Best reduced chi square is not below 25 (" + to_string(BestChiSquare) + ")");
     }
 
     // Assign the best reduced chi square to the event

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -729,18 +729,6 @@ void MReadOutAssembly::StreamBDFlags(ostream& S)
   if (m_ShieldVeto == true) {
     S<<"BD Shield Veto"<<endl;
   }
-  for (auto H : m_Hits) {
-    if (H->GetStripHitMultipleTimesX()) {
-      S<<"BD Multiple Hits on LV Strip"<<endl;
-      break;
-    }
-  }
-  for (auto H : m_Hits) {
-    if (H->GetStripHitMultipleTimesY()) {
-      S<<"BD Multiple Hits on HV Strip"<<endl;
-      break;
-    }
-  }
 }
 
 

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -189,6 +189,9 @@ void MReadOutAssembly::Clear()
  
   m_StripHitBelowThreshold_QualityFlag = false;
   m_StripHitBelowThresholdString_QualityFlag.clear();
+    
+  m_StripPairing_QualityFlag = false;
+  m_StripPairingString_QualityFlag.clear();
 
   m_FilteredOut = false;
 

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -722,7 +722,18 @@ void MReadOutAssembly::StreamBDFlags(ostream& S)
     }
     S<<endl;
   }
-
+    
+  if (m_StripPairing_QualityFlag == true) {
+    S<<"QA StripPairing";
+    if (m_StripPairingString_QualityFlag.empty() == false) {
+      // iterate through the vectorized error message
+      for (auto i : m_StripPairingString_QualityFlag) {
+        S<<" ("<<i<<")";
+      }
+    }
+    S<<endl;
+  }
+    
   if (m_GuardRingVeto == true) {
     S<<"BD GR Veto"<<endl;
   }


### PR DESCRIPTION
Summary of changes:
- Added strip pairing quality flags for the following things:
  - If the best combination has more than 5 strip groupings (ie. potential hits) on one side
  - If the best strip pairing chi square is > 25
  - If the LV/HV energies are further apart than 2.5 sigma
  - If there are multiple hits on a single strip
  - If the best strip pairing leaves any strips unpaired
    - Read out the total unpaired energy in QA flag
- Split the MHit charge sharing flag into two flags (one for LV and one for HV)
  - Assigned hits charge sharing flag in strip pairing
- Added a guard ring hit flag to MHit
  - At end of strip pairing, check if any paired hit contains a guard ring strip and, if so, assign the guard ring hit flag
  - Read out GR hit info in QA flag (detector ID + energy)
- Implemented options GUI so user can select maximum number of strip hits on one side that can be paired
