### PR TITLE
ADD: Support for loading version 2 of the HDF hit info

### DIFF
--- a/include/MModuleLoaderMeasurementsHDF.h
+++ b/include/MModuleLoaderMeasurementsHDF.h
@@ -257,6 +257,9 @@ class MModuleLoaderMeasurementsHDF : public MModuleLoaderMeasurements
   //! The file name of the strip map
   MString m_FileNameStripMap;
 
+  //! The map which ASICs are HV/LV for HDFv2
+  vector<map<bool, vector<bool>>> m_ASICPolarities;
+
   //! The strip map
   MStripMap m_StripMap;
   

--- a/include/MModuleLoaderMeasurementsHDF.h
+++ b/include/MModuleLoaderMeasurementsHDF.h
@@ -112,7 +112,8 @@ struct MHDFStripHit_V2 {
 struct MHDFEvent_V2_0 {
   uint16_t m_EventID;
   uint64_t m_TimeCode;
-  double   m_GSETimeCode;
+  // Nanoseconds since epoch
+  uint64_t m_GSETimeCode;
   uint8_t  m_Hits;
   uint16_t m_Bytes;
   uint8_t  m_EventType;
@@ -123,8 +124,10 @@ struct MHDFEvent_V2_0 {
 struct MHDFEvent_V2_2 {
   uint16_t m_EventID;
   uint64_t m_TimeCode;
-  double   m_GSETimeCode;
-  double   m_SPWTimeCode;
+  // Nanoseconds since epoch
+  uint64_t m_GSETimeCode;
+  // Nanoseconds since start of acquisition
+  uint64_t m_SPWTimeCode;
   uint8_t  m_Hits;
   uint16_t m_Bytes;
   uint8_t  m_EventType;
@@ -278,7 +281,6 @@ class MModuleLoaderMeasurementsHDF : public MModuleLoaderMeasurements
 
   //! Current hit number in the file
   hsize_t m_CurrentHit;
-  unsigned int m_CurrentEvent;
 
   //! Number of event ID roll-overs:
   unsigned int m_NumberOfEventIDRollOvers;

--- a/include/MModuleLoaderMeasurementsHDF.h
+++ b/include/MModuleLoaderMeasurementsHDF.h
@@ -1,7 +1,7 @@
 /*
  * MModuleLoaderMeasurementsHDF.h
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Andreas Zoglauer, Felix Hagemann.
  * All rights reserved.
  *
  * Please see the source-file for the copyright-notice.

--- a/include/MModuleLoaderMeasurementsHDF.h
+++ b/include/MModuleLoaderMeasurementsHDF.h
@@ -39,13 +39,14 @@ using namespace H5;
 
 
 //! The versions of the strip hits stored in the HDF file
-enum class MHDFStripHitVersion { V1_0, V1_2 };
+enum class MHDFStripHitVersion { V1_0, V1_2, V2_2 };
 
 //! And a streamer for it
 inline ostream& operator<<(ostream& os, MHDFStripHitVersion Version) {
   switch (Version) {
     case MHDFStripHitVersion::V1_0: return os<<"1.0";
     case MHDFStripHitVersion::V1_2: return os<<"1.2";
+    case MHDFStripHitVersion::V2_2: return os<<"2.2";
     default: return os<<"Unknown";
   }
 }
@@ -90,6 +91,28 @@ struct MHDFStripHit_V1_2 {
   uint16_t m_EnergyDataHighGain;
   uint16_t m_TimingData;
   uint8_t  m_Pad;
+  uint8_t  m_Hits;
+  uint16_t m_Bytes;
+  uint8_t  m_EventType;
+  uint8_t  m_CRC;
+};
+
+//! Version 2.2 of the HDF5 hit info
+struct MHDFStripHit_V2_2 {
+  uint32_t m_EventIndex;
+  uint8_t  m_HitType;
+  uint8_t  m_TimingType;
+  uint16_t m_StripID;
+  uint16_t m_EnergyData;
+  uint16_t m_TimingData;
+};
+
+//! Version 2.2 of the HDF5 event info
+struct MHDFEvent_V2_2 {
+  uint16_t m_EventID;
+  uint64_t m_TimeCode;
+  double   m_GSETimeCode;
+  double   m_SPWTimeCode;
   uint8_t  m_Hits;
   uint16_t m_Bytes;
   uint8_t  m_EventType;
@@ -191,9 +214,11 @@ class MModuleLoaderMeasurementsHDF : public MModuleLoaderMeasurements
   
   //! The HDF5 data set
   DataSet m_HDFDataSet;
+  DataSet m_EventDataSet;
 
   //! The HDF5 compond data type
   CompType m_HDFCompoundDataType;
+  CompType m_EventCompoundDataType;
 
   //! The version of the strip hit structure
   MHDFStripHitVersion m_HDFStripHitVersion;
@@ -212,12 +237,16 @@ class MModuleLoaderMeasurementsHDF : public MModuleLoaderMeasurements
   vector<MHDFStripHit_V1_0> m_Buffer_1_0;
   //! The MHDFStripHit_V1_2 batch:
   vector<MHDFStripHit_V1_2> m_Buffer_1_2;
+  //! The MHDFStripHit_V2_2 batch:
+  vector<MHDFStripHit_V2_2> m_Buffer_2_2;
+  vector<MHDFEvent_V2_2> m_EventData_2_2;
 
   //! Total number of hits in a file
   hsize_t m_TotalHits;
 
   //! Current hit number in the file
   hsize_t m_CurrentHit;
+  unsigned int m_CurrentEvent;
 
   //! Number of event ID roll-overs:
   unsigned int m_NumberOfEventIDRollOvers;

--- a/include/MModuleLoaderMeasurementsHDF.h
+++ b/include/MModuleLoaderMeasurementsHDF.h
@@ -39,13 +39,14 @@ using namespace H5;
 
 
 //! The versions of the strip hits stored in the HDF file
-enum class MHDFStripHitVersion { V1_0, V1_2, V2_2 };
+enum class MHDFStripHitVersion { V1_0, V1_2, V2_0, V2_2 };
 
 //! And a streamer for it
 inline ostream& operator<<(ostream& os, MHDFStripHitVersion Version) {
   switch (Version) {
     case MHDFStripHitVersion::V1_0: return os<<"1.0";
     case MHDFStripHitVersion::V1_2: return os<<"1.2";
+    case MHDFStripHitVersion::V2_0: return os<<"2.0";
     case MHDFStripHitVersion::V2_2: return os<<"2.2";
     default: return os<<"Unknown";
   }
@@ -97,8 +98,8 @@ struct MHDFStripHit_V1_2 {
   uint8_t  m_CRC;
 };
 
-//! Version 2.2 of the HDF5 hit info
-struct MHDFStripHit_V2_2 {
+//! Version 2 of the HDF5 hit info
+struct MHDFStripHit_V2 {
   uint32_t m_EventIndex;
   uint8_t  m_HitType;
   uint8_t  m_TimingType;
@@ -107,7 +108,18 @@ struct MHDFStripHit_V2_2 {
   uint16_t m_TimingData;
 };
 
-//! Version 2.2 of the HDF5 event info
+//! Version 2.0 of the HDF5 event info
+struct MHDFEvent_V2_0 {
+  uint16_t m_EventID;
+  uint64_t m_TimeCode;
+  double   m_GSETimeCode;
+  uint8_t  m_Hits;
+  uint16_t m_Bytes;
+  uint8_t  m_EventType;
+  uint8_t  m_CRC;
+};
+
+//! Version 2.2 of the HDF5 event info (adding SPWTimeCode)
 struct MHDFEvent_V2_2 {
   uint16_t m_EventID;
   uint64_t m_TimeCode;
@@ -117,6 +129,17 @@ struct MHDFEvent_V2_2 {
   uint16_t m_Bytes;
   uint8_t  m_EventType;
   uint8_t  m_CRC;
+};
+
+//! HDF5 EventIndices (for HDF5v2 data)
+struct MHDFEventIndices_V2 {
+  uint32_t m_FEEHits[2];
+  uint32_t m_ACSHits[2];
+  uint32_t m_HS[2];
+  uint32_t m_SinglesCounts[2];
+  uint32_t m_DIBCoincidence[2];
+  uint32_t m_DetectorHits[2];
+  uint32_t m_DetectorLiveTime[2];
 };
 
 //! The version string
@@ -215,10 +238,16 @@ class MModuleLoaderMeasurementsHDF : public MModuleLoaderMeasurements
   //! The HDF5 data set
   DataSet m_HDFDataSet;
   DataSet m_EventDataSet;
+  DataSet m_EventIndicesDataSet;
 
-  //! The HDF5 compond data type
+  //! The HDF5 compound data type (v1)
   CompType m_HDFCompoundDataType;
+
+  //! The HDF5 compound data types (v2)
   CompType m_EventCompoundDataType;
+  CompType m_EventIndicesCompoundDataType;
+  CompType m_HDFFEECompoundDataType;
+
 
   //! The version of the strip hit structure
   MHDFStripHitVersion m_HDFStripHitVersion;
@@ -231,14 +260,17 @@ class MModuleLoaderMeasurementsHDF : public MModuleLoaderMeasurements
 
   //! The current index in the batch
   unsigned int m_CurrentBatchIndex;
+  unsigned int m_MinHitIndex;
 
   // The various batches:
   //! The MHDFStripHit_V1_0 batch:
   vector<MHDFStripHit_V1_0> m_Buffer_1_0;
   //! The MHDFStripHit_V1_2 batch:
   vector<MHDFStripHit_V1_2> m_Buffer_1_2;
-  //! The MHDFStripHit_V2_2 batch:
-  vector<MHDFStripHit_V2_2> m_Buffer_2_2;
+  //! The MHDFStripHit_V2 batch:
+  vector<MHDFStripHit_V2> m_Buffer_2;
+  vector<MHDFEventIndices_V2> m_EventIndices_2;
+  vector<MHDFEvent_V2_0> m_EventData_2_0;
   vector<MHDFEvent_V2_2> m_EventData_2_2;
 
   //! Total number of hits in a file

--- a/include/MStripMap.h
+++ b/include/MStripMap.h
@@ -1,7 +1,7 @@
 /*
  * MStripMap.h
  *
- * Copyright (C) by Andreas Zoglauer
+ * Copyright (C) by Andreas Zoglauer, Felix Hagemann.
  * All rights reserved.
  *
  * Please see the source-file for the copyright-notice.

--- a/include/MStripMap.h
+++ b/include/MStripMap.h
@@ -45,6 +45,9 @@ class MStripMap
   //! Load a strip map - return false on error
   bool Open(MString FileName);
 
+  //! Update which ASICs are LV/HV depending on their polarities
+  bool UpdateASICPolarities(vector<map<bool, vector<bool>>> ASICPolarities);
+
   //! Check if we have a certain read-out ID
   bool HasReadOutID(unsigned int ROI) const;
 

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -580,6 +580,9 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
 
   Event->SetAnalysisProgress(MAssembly::c_EventLoader | MAssembly::c_EventLoaderMeasurement);
 
+  m_NEventsInFile++;
+  m_NGoodEventsInFile++;
+
   return true;
 }
 

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -171,11 +171,30 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<string(VS.string_col)<<endl<<"Please update this module."<<endl;
         return false;
       }
+    // Check for existence of HDFVersion in /Events/HDFVersion (HDF v2)
+    } else if (H5Lexists(m_HDFFile.getId(), "Events", H5P_DEFAULT) > 0) {
+      m_EventDataSet = m_HDFFile.openDataSet("/Events");
+      Attribute VersionAttribute = m_EventDataSet.openAttribute("HDFVersion");
+
+      // Read HDF5 version from Events/HDF5Version to a string
+      string VersionString;
+      VersionAttribute.read(VersionAttribute.getStrType(), VersionString);
+
+      if (VersionString == "2.2" || VersionString == "2.3") {
+        m_HDFStripHitVersion = MHDFStripHitVersion::V2_2;
+      } else {
+        if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<VersionString<<endl<<"Please update this module."<<endl;
+        return false;
+      }
     }
     cout<<m_XmlTag<<": HDF5 hit version found: "<<m_HDFStripHitVersion<<endl;
 
     // Get the data set
-    m_HDFDataSet = m_HDFFile.openDataSet("/Hits");
+    if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
+      m_HDFDataSet = m_HDFFile.openDataSet("/FEEHits");
+    } else {
+      m_HDFDataSet = m_HDFFile.openDataSet("/Hits");
+    }
 
     // Get the data space
     DataSpace DS = m_HDFDataSet.getSpace();
@@ -240,6 +259,36 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
       m_HDFCompoundDataType.insertMember("BYTES",                 HOFFSET(MHDFStripHit_V1_2, m_Bytes),                  PredType::STD_U16LE);
       m_HDFCompoundDataType.insertMember("EVENT_TYPE",            HOFFSET(MHDFStripHit_V1_2, m_EventType),            PredType::STD_U8LE);
       m_HDFCompoundDataType.insertMember("CRC",                   HOFFSET(MHDFStripHit_V1_2, m_CRC),                   PredType::STD_U8LE);
+    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
+
+      // Create compound data type for reading detector hit information from /FEEHits
+      m_HDFCompoundDataType = CompType(sizeof(MHDFStripHit_V2_2));
+      m_HDFCompoundDataType.insertMember("event_index",           HOFFSET(MHDFStripHit_V2_2, m_EventIndex),        PredType::STD_U32LE);
+      m_HDFCompoundDataType.insertMember("hit_type",              HOFFSET(MHDFStripHit_V2_2, m_HitType),           PredType::STD_U8LE);
+      m_HDFCompoundDataType.insertMember("timing_type",           HOFFSET(MHDFStripHit_V2_2, m_TimingType),        PredType::STD_U8LE);
+      m_HDFCompoundDataType.insertMember("strip_id",              HOFFSET(MHDFStripHit_V2_2, m_StripID),           PredType::STD_U16LE);
+      m_HDFCompoundDataType.insertMember("energy",                HOFFSET(MHDFStripHit_V2_2, m_EnergyData),        PredType::STD_U16LE);
+      m_HDFCompoundDataType.insertMember("timing",                HOFFSET(MHDFStripHit_V2_2, m_TimingData),        PredType::STD_U16LE);
+
+      // Create compound data type for reading event information from /Events
+      m_EventCompoundDataType = CompType(sizeof(MHDFEvent_V2_2));
+      m_EventCompoundDataType.insertMember("event_id",            HOFFSET(MHDFEvent_V2_2, m_EventID),              PredType::STD_U16LE);
+      m_EventCompoundDataType.insertMember("timecode",            HOFFSET(MHDFEvent_V2_2, m_TimeCode),             PredType::STD_U64LE);
+      m_EventCompoundDataType.insertMember("gse_timecode",        HOFFSET(MHDFEvent_V2_2, m_GSETimeCode),          PredType::IEEE_F64LE);
+      m_EventCompoundDataType.insertMember("spw_timecode",        HOFFSET(MHDFEvent_V2_2, m_SPWTimeCode),          PredType::IEEE_F64LE);
+      m_EventCompoundDataType.insertMember("hits",                HOFFSET(MHDFEvent_V2_2, m_Hits),                 PredType::STD_U8LE);
+      m_EventCompoundDataType.insertMember("bytes",               HOFFSET(MHDFEvent_V2_2, m_Bytes),                PredType::STD_U16LE);
+      m_EventCompoundDataType.insertMember("event_type",          HOFFSET(MHDFEvent_V2_2, m_EventType),            PredType::STD_U8LE);
+      m_EventCompoundDataType.insertMember("crc",                 HOFFSET(MHDFEvent_V2_2, m_CRC),                  PredType::STD_U8LE);
+
+      // Read the event information from /Events
+      DataSpace EventDataSpace = m_EventDataSet.getSpace();
+      hsize_t dims[1];
+      EventDataSpace.getSimpleExtentDims(dims);
+      size_t n = dims[0];
+      m_EventData_2_2.resize(n);
+      m_EventDataSet.read(m_EventData_2_2.data(), m_EventCompoundDataType);
+
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
       return false;
@@ -254,7 +303,7 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
     }
 
   } catch (const H5::Exception& E) {
-    if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": HDF5 initializion error: "<<E.getDetailMsg()<<endl;
+    if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": HDF5 initialization error: "<<E.getDetailMsg()<<endl;
     return false;
   }
 
@@ -278,6 +327,7 @@ bool MModuleLoaderMeasurementsHDF::ReadBatchHits()
     if (m_CurrentBatchSize == 0) {
       m_Buffer_1_0.resize(0);
       m_Buffer_1_2.resize(0);
+      m_Buffer_2_2.resize(0);
       m_CurrentBatchIndex = 0;
       return false;
     }
@@ -300,11 +350,17 @@ bool MModuleLoaderMeasurementsHDF::ReadBatchHits()
         m_Buffer_1_2.resize(m_CurrentBatchSize);
       }
       m_HDFDataSet.read(m_Buffer_1_2.data(), m_HDFCompoundDataType, MS, DS);
+    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
+      if (m_Buffer_2_2.size() != m_CurrentBatchSize) {
+        m_Buffer_2_2.resize(m_CurrentBatchSize);
+      }
+      m_HDFDataSet.read(m_Buffer_2_2.data(), m_HDFCompoundDataType, MS, DS);
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
       m_CurrentBatchSize = 0;
       m_Buffer_1_0.resize(0);
       m_Buffer_1_2.resize(0);
+      m_Buffer_2_2.resize(0);
       m_CurrentBatchIndex = 0;
       return false;
     }
@@ -316,6 +372,7 @@ bool MModuleLoaderMeasurementsHDF::ReadBatchHits()
     m_CurrentBatchSize = 0;
     m_Buffer_1_0.resize(0);
     m_Buffer_1_2.resize(0);
+    m_Buffer_2_2.resize(0);
     m_CurrentBatchIndex = 0;
     return false;
   }
@@ -411,6 +468,25 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       HitType = Hit.m_HitType;
       TimingType = Hit.m_TimingType;
     
+    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
+      MHDFStripHit_V2_2& Hit = m_Buffer_2_2[m_CurrentBatchIndex];
+      ++m_CurrentBatchIndex;
+      ++m_CurrentHit;
+
+      StripID = Hit.m_StripID;
+      ADCs = Hit.m_EnergyData;
+      TACs = Hit.m_TimingData;
+      HitType = Hit.m_HitType;
+      TimingType = Hit.m_TimingType;
+
+      // Read the information about the event based on the EventIndex of the Hit
+      uint32_t EventIndex = Hit.m_EventIndex;
+      MHDFEvent_V2_2& HitEvent = m_EventData_2_2[EventIndex];
+      EventID = HitEvent.m_EventID;
+      TimeCode = HitEvent.m_GSETimeCode;
+      NumberOfHits = HitEvent.m_Hits;
+      // SPWTimeCode = HitEvent.m_SPWTimeCode;
+      
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
       return false;
@@ -425,8 +501,8 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       cout<<"  EnergyData: "<<ADCs<<endl;
       cout<<"  TimingData: "<<TACs<<endl;
       cout<<"  Hits: "<<(int) NumberOfHits<<endl;
-      cout<<" HitType: "<<HitType<<endl;
-      cout<<" TimingType: "<<TimingType<<endl;
+      cout<<"  HitType: "<<(int) HitType<<endl;
+      cout<<"  TimingType: "<<(int) TimingType<<endl;
     }
 
     // Catch a bug in the HDF5 data
@@ -456,6 +532,9 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     Event->SetID(LongEventID);
     if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
       Event->SetCL(TimeCode);
+    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2)  {
+      Event->SetTI(TimeCode);
+      // Event->SetCL(SPWTimeCode);
     } else {
       Event->SetTI(TimeCode);
     }

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -135,6 +135,11 @@ bool MModuleLoaderMeasurementsHDF::Initialize()
     return false;
   }
 
+  if (m_StripMap.UpdateASICPolarities(m_ASICPolarities) == false) {
+    if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unable to update ASIC polarities based on the config JSON."<<endl;
+    return false;
+  }
+
   m_NEventsInFile = 0;
   m_NGoodEventsInFile = 0;
     
@@ -189,13 +194,12 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         return false;
       }
 
-      // Determine ASIC IsLowVoltage
+
       Attribute Config = m_EventDataSet.openAttribute("Config");
       string ConfigJSON;
       Config.read(Config.getStrType(), ConfigJSON);
 
-      vector<map<string, vector<bool>>> IsLowVoltage;
-      string ASIC = "";
+      bool ASICIsPrimary;
 
       // Regex to match either "primary"/"secondary", or the polarity stored in "SP"
       regex pattern(R"(\"(primary|secondary)\"|\"SP\"\s*:\s*(\d+))");
@@ -206,29 +210,29 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         // Check Group 1: Marker (primary/secondary)
         if (match[1].matched) {
 
-          ASIC = match[1].str();
+          ASICIsPrimary = match[1].str() == "primary";
 
-          if (IsLowVoltage.empty() || IsLowVoltage.back().find(ASIC) != IsLowVoltage.back().end()) {
+          if (m_ASICPolarities.empty() || m_ASICPolarities.back().find(ASICIsPrimary) != m_ASICPolarities.back().end()) {
 
             // Check that the previous entry has both primary or secondary before creating a new one
-            if (!IsLowVoltage.empty() && (
-                 IsLowVoltage.back().find("primary") == IsLowVoltage.back().end() || 
-                 IsLowVoltage.back().find("secondary") == IsLowVoltage.back().end())
+            if (!m_ASICPolarities.empty() && (
+                 m_ASICPolarities.back().find(true) == m_ASICPolarities.back().end() || 
+                 m_ASICPolarities.back().find(false) == m_ASICPolarities.back().end())
             ) {
-              if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Parsing ASIC polarities for detector "<<IsLowVoltage.size()-1<<" unsuccessful"<<endl;
+              if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Parsing ASIC polarities for detector "<<m_ASICPolarities.size()-1<<" unsuccessful"<<endl;
                 return false;
             }
 
-            IsLowVoltage.push_back(map<string, vector<bool>>());
+            m_ASICPolarities.push_back(map<bool, vector<bool>>());
           }
 
           // Initialize the vector for this ASIC key if it doesn't exist
-          IsLowVoltage.back()[ASIC] = vector<bool>();
+          m_ASICPolarities.back()[ASICIsPrimary] = vector<bool>();
         }
         
         // Check Group 2: SP value
         else if (match[2].matched) {
-          if (ASIC.empty() || IsLowVoltage.empty()) {
+          if (m_ASICPolarities.empty()) {
             if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": SP found without active ASIC section"<<endl;
             return false;
           }
@@ -240,17 +244,17 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
           }
 
           // val == 1 <=> LV; val == 0 <=> HV
-          IsLowVoltage.back()[ASIC].push_back(val == "1");
+          m_ASICPolarities.back()[ASICIsPrimary].push_back(val == "1");
         }
       }
 
       // Output results for verification
       if (g_Verbosity >= c_Info) {
-        for (size_t i = 0; i < IsLowVoltage.size(); ++i) {
+        for (size_t i = 0; i < m_ASICPolarities.size(); ++i) {
           cout << "Detector ID " << i << ":" << endl;
-          for (auto const& [key, val] : IsLowVoltage[i]) {
-            cout << "  " << key << ": ";
-            for (const auto& s : val) cout << (s ? "LV" : "HV") << " ";
+          for (bool key : {true, false} ) {
+            cout << "  " << (key ? "Primary" : "Secondary") << ": ";
+            for (bool s : m_ASICPolarities[i][key]) cout << (s ? "LV" : "HV") << " ";
             cout << endl;
           }
         }

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -2,7 +2,7 @@
  * MModuleLoaderMeasurementsHDF.cxx
  *
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Andreas Zoglauer, Felix Hagemann.
  * All rights reserved.
  *
  *

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -179,21 +179,23 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
       }
 
     // Check for existence of HDFVersion in /Events/HDFVersion (HDF v2)
-    } else if (H5Lexists(m_HDFFile.getId(), "Events", H5P_DEFAULT) > 0) {
+    } else if (H5Lexists(m_HDFFile.getId(), "Events", H5P_DEFAULT) > 0 && H5Lexists(m_HDFFile.getId(), "EventIndices", H5P_DEFAULT) > 0) {
       m_EventDataSet = m_HDFFile.openDataSet("/Events");
+      m_EventIndicesDataSet = m_HDFFile.openDataSet("/EventIndices");
 
       // Read HDF5 version from Events/HDF5Version to a string
       Attribute VersionAttribute = m_EventDataSet.openAttribute("HDFVersion");
       string VersionString;
       VersionAttribute.read(VersionAttribute.getStrType(), VersionString);
 
-      if (VersionString == "2.2" || VersionString == "2.3") {
+      if (VersionString == "2.0" || VersionString == "2.1") {
+        m_HDFStripHitVersion = MHDFStripHitVersion::V2_0;
+      } else if (VersionString.length() >= 2 && VersionString.compare(0, 2, "2.") == 0) {
         m_HDFStripHitVersion = MHDFStripHitVersion::V2_2;
       } else {
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<VersionString<<endl<<"Please update this module."<<endl;
         return false;
       }
-
 
       Attribute Config = m_EventDataSet.openAttribute("Config");
       string ConfigJSON;
@@ -263,10 +265,10 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
     cout<<m_XmlTag<<": HDF5 hit version found: "<<m_HDFStripHitVersion<<endl;
 
     // Get the data set
-    if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
-      m_HDFDataSet = m_HDFFile.openDataSet("/FEEHits");
-    } else {
+    if (m_HDFStripHitVersion <= MHDFStripHitVersion::V1_2) {
       m_HDFDataSet = m_HDFFile.openDataSet("/Hits");
+    } else {
+      m_HDFDataSet = m_HDFFile.openDataSet("/FEEHits");
     }
 
     // Get the data space
@@ -332,42 +334,64 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
       m_HDFCompoundDataType.insertMember("BYTES",                 HOFFSET(MHDFStripHit_V1_2, m_Bytes),                  PredType::STD_U16LE);
       m_HDFCompoundDataType.insertMember("EVENT_TYPE",            HOFFSET(MHDFStripHit_V1_2, m_EventType),            PredType::STD_U8LE);
       m_HDFCompoundDataType.insertMember("CRC",                   HOFFSET(MHDFStripHit_V1_2, m_CRC),                   PredType::STD_U8LE);
-    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
+    } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
 
       // Create compound data type for reading detector hit information from /FEEHits
-      m_HDFCompoundDataType = CompType(sizeof(MHDFStripHit_V2_2));
-      m_HDFCompoundDataType.insertMember("event_index",           HOFFSET(MHDFStripHit_V2_2, m_EventIndex),        PredType::STD_U32LE);
-      m_HDFCompoundDataType.insertMember("hit_type",              HOFFSET(MHDFStripHit_V2_2, m_HitType),           PredType::STD_U8LE);
-      m_HDFCompoundDataType.insertMember("timing_type",           HOFFSET(MHDFStripHit_V2_2, m_TimingType),        PredType::STD_U8LE);
-      m_HDFCompoundDataType.insertMember("strip_id",              HOFFSET(MHDFStripHit_V2_2, m_StripID),           PredType::STD_U16LE);
-      m_HDFCompoundDataType.insertMember("energy",                HOFFSET(MHDFStripHit_V2_2, m_EnergyData),        PredType::STD_U16LE);
-      m_HDFCompoundDataType.insertMember("timing",                HOFFSET(MHDFStripHit_V2_2, m_TimingData),        PredType::STD_U16LE);
+      m_HDFFEECompoundDataType = CompType(sizeof(MHDFStripHit_V2));
+      m_HDFFEECompoundDataType.insertMember("event_index",           HOFFSET(MHDFStripHit_V2, m_EventIndex),        PredType::STD_U32LE);
+      m_HDFFEECompoundDataType.insertMember("hit_type",              HOFFSET(MHDFStripHit_V2, m_HitType),           PredType::STD_U8LE);
+      m_HDFFEECompoundDataType.insertMember("timing_type",           HOFFSET(MHDFStripHit_V2, m_TimingType),        PredType::STD_U8LE);
+      m_HDFFEECompoundDataType.insertMember("strip_id",              HOFFSET(MHDFStripHit_V2, m_StripID),           PredType::STD_U16LE);
+      m_HDFFEECompoundDataType.insertMember("energy",                HOFFSET(MHDFStripHit_V2, m_EnergyData),        PredType::STD_U16LE);
+      m_HDFFEECompoundDataType.insertMember("timing",                HOFFSET(MHDFStripHit_V2, m_TimingData),        PredType::STD_U16LE);
 
       // Create compound data type for reading event information from /Events
-      m_EventCompoundDataType = CompType(sizeof(MHDFEvent_V2_2));
-      m_EventCompoundDataType.insertMember("event_id",            HOFFSET(MHDFEvent_V2_2, m_EventID),              PredType::STD_U16LE);
-      m_EventCompoundDataType.insertMember("timecode",            HOFFSET(MHDFEvent_V2_2, m_TimeCode),             PredType::STD_U64LE);
-      m_EventCompoundDataType.insertMember("gse_timecode",        HOFFSET(MHDFEvent_V2_2, m_GSETimeCode),          PredType::IEEE_F64LE);
-      m_EventCompoundDataType.insertMember("spw_timecode",        HOFFSET(MHDFEvent_V2_2, m_SPWTimeCode),          PredType::IEEE_F64LE);
-      m_EventCompoundDataType.insertMember("hits",                HOFFSET(MHDFEvent_V2_2, m_Hits),                 PredType::STD_U8LE);
-      m_EventCompoundDataType.insertMember("bytes",               HOFFSET(MHDFEvent_V2_2, m_Bytes),                PredType::STD_U16LE);
-      m_EventCompoundDataType.insertMember("event_type",          HOFFSET(MHDFEvent_V2_2, m_EventType),            PredType::STD_U8LE);
-      m_EventCompoundDataType.insertMember("crc",                 HOFFSET(MHDFEvent_V2_2, m_CRC),                  PredType::STD_U8LE);
+      if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_0) {
+        m_EventCompoundDataType = CompType(sizeof(MHDFEvent_V2_0));
+        m_EventCompoundDataType.insertMember("event_id",            HOFFSET(MHDFEvent_V2_0, m_EventID),            PredType::STD_U16LE);
+        m_EventCompoundDataType.insertMember("timecode",            HOFFSET(MHDFEvent_V2_0, m_TimeCode),           PredType::STD_U64LE);
+        m_EventCompoundDataType.insertMember("gse_timecode",        HOFFSET(MHDFEvent_V2_0, m_GSETimeCode),        PredType::IEEE_F64LE);
+        m_EventCompoundDataType.insertMember("hits",                HOFFSET(MHDFEvent_V2_0, m_Hits),               PredType::STD_U8LE);
+        m_EventCompoundDataType.insertMember("bytes",               HOFFSET(MHDFEvent_V2_0, m_Bytes),              PredType::STD_U16LE);
+        m_EventCompoundDataType.insertMember("event_type",          HOFFSET(MHDFEvent_V2_0, m_EventType),          PredType::STD_U8LE);
+        m_EventCompoundDataType.insertMember("crc",                 HOFFSET(MHDFEvent_V2_0, m_CRC),                PredType::STD_U8LE);
+      } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
+        m_EventCompoundDataType = CompType(sizeof(MHDFEvent_V2_2));
+        m_EventCompoundDataType.insertMember("event_id",            HOFFSET(MHDFEvent_V2_2, m_EventID),            PredType::STD_U16LE);
+        m_EventCompoundDataType.insertMember("timecode",            HOFFSET(MHDFEvent_V2_2, m_TimeCode),           PredType::STD_U64LE);
+        m_EventCompoundDataType.insertMember("gse_timecode",        HOFFSET(MHDFEvent_V2_2, m_GSETimeCode),        PredType::IEEE_F64LE);
+        m_EventCompoundDataType.insertMember("spw_timecode",        HOFFSET(MHDFEvent_V2_2, m_SPWTimeCode),        PredType::IEEE_F64LE);
+        m_EventCompoundDataType.insertMember("hits",                HOFFSET(MHDFEvent_V2_2, m_Hits),               PredType::STD_U8LE);
+        m_EventCompoundDataType.insertMember("bytes",               HOFFSET(MHDFEvent_V2_2, m_Bytes),              PredType::STD_U16LE);
+        m_EventCompoundDataType.insertMember("event_type",          HOFFSET(MHDFEvent_V2_2, m_EventType),          PredType::STD_U8LE);
+        m_EventCompoundDataType.insertMember("crc",                 HOFFSET(MHDFEvent_V2_2, m_CRC),                PredType::STD_U8LE);
+      } else {
+        if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
+        return false;
+      }
+    
 
-      // Read the event information from /Events
+      // Create compound data type for reading event indices information from /EventIndices
+      hsize_t array_dims[1] = {2};
+      ArrayType uint32_pair(PredType::STD_U32LE, 1, array_dims);
+      m_EventIndicesCompoundDataType = CompType(sizeof(MHDFEventIndices_V2));
+      m_EventIndicesCompoundDataType.insertMember("fee_hits",            HOFFSET(MHDFEventIndices_V2, m_FEEHits),            uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("acs_hits",            HOFFSET(MHDFEventIndices_V2, m_ACSHits),            uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("hs",                  HOFFSET(MHDFEventIndices_V2, m_HS),                 uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("singles_counts",      HOFFSET(MHDFEventIndices_V2, m_SinglesCounts),      uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("dib_coindicidence",   HOFFSET(MHDFEventIndices_V2, m_DIBCoincidence),     uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("detector_hits",       HOFFSET(MHDFEventIndices_V2, m_DetectorHits),       uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("detector_live_time",  HOFFSET(MHDFEventIndices_V2, m_DetectorLiveTime),   uint32_pair);
+
       DataSpace EventDataSpace = m_EventDataSet.getSpace();
-      hsize_t dims[1];
-      EventDataSpace.getSimpleExtentDims(dims);
-      size_t n = dims[0];
-      m_EventData_2_2.resize(n);
-      m_EventDataSet.read(m_EventData_2_2.data(), m_EventCompoundDataType);
+      EventDataSpace.getSimpleExtentDims(&m_TotalHits, nullptr);
 
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
       return false;
     }
 
-    DS.getSimpleExtentDims(&m_TotalHits, nullptr);
+    if (m_HDFStripHitVersion <= MHDFStripHitVersion::V1_2) DS.getSimpleExtentDims(&m_TotalHits, nullptr);
     m_CurrentHit = 0;
 
     if (ReadBatchHits() == false) {
@@ -400,7 +424,7 @@ bool MModuleLoaderMeasurementsHDF::ReadBatchHits()
     if (m_CurrentBatchSize == 0) {
       m_Buffer_1_0.resize(0);
       m_Buffer_1_2.resize(0);
-      m_Buffer_2_2.resize(0);
+      m_Buffer_2.resize(0);
       m_CurrentBatchIndex = 0;
       return false;
     }
@@ -408,32 +432,71 @@ bool MModuleLoaderMeasurementsHDF::ReadBatchHits()
     hsize_t Offset[1] = { m_CurrentHit };
     hsize_t Count[1] = { m_CurrentBatchSize };
 
-    DataSpace DS = m_HDFDataSet.getSpace();
-    DS.selectHyperslab(H5S_SELECT_SET, Count, Offset);
+    if (m_HDFStripHitVersion <= MHDFStripHitVersion::V1_2) {
+      DataSpace DS = m_HDFDataSet.getSpace();
+      DS.selectHyperslab(H5S_SELECT_SET, Count, Offset);
+      DataSpace MS(1, Count);
 
-    DataSpace MS(1, Count);
+      if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
+        if (m_Buffer_1_0.size() != m_CurrentBatchSize) {
+          m_Buffer_1_0.resize(m_CurrentBatchSize);
+        }
+        m_HDFDataSet.read(m_Buffer_1_0.data(), m_HDFCompoundDataType, MS, DS);
+      } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_2) {
+        if (m_Buffer_1_2.size() != m_CurrentBatchSize) {
+          m_Buffer_1_2.resize(m_CurrentBatchSize);
+        }
+        m_HDFDataSet.read(m_Buffer_1_2.data(), m_HDFCompoundDataType, MS, DS);
+      }
+    } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
 
-    if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
-      if (m_Buffer_1_0.size() != m_CurrentBatchSize) {
-        m_Buffer_1_0.resize(m_CurrentBatchSize);
+      // Read /Events
+      DataSpace ES = m_EventDataSet.getSpace();
+      ES.selectHyperslab(H5S_SELECT_SET, Count, Offset);
+      DataSpace MES(1, Count);
+
+      if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_0) {
+        if (m_EventData_2_0.size() != Count[0]) {
+          m_EventData_2_0.resize(Count[0]);
+        }
+        m_EventDataSet.read(m_EventData_2_0.data(), m_EventCompoundDataType, MES, ES);
+      } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
+        if (m_EventData_2_2.size() != Count[0]) {
+          m_EventData_2_2.resize(Count[0]);
+        }
+        m_EventDataSet.read(m_EventData_2_2.data(), m_EventCompoundDataType, MES, ES);
       }
-      m_HDFDataSet.read(m_Buffer_1_0.data(), m_HDFCompoundDataType, MS, DS);
-    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_2) {
-      if (m_Buffer_1_2.size() != m_CurrentBatchSize) {
-        m_Buffer_1_2.resize(m_CurrentBatchSize);
+
+      // Read /EventIndices
+      DataSpace EIS = m_EventIndicesDataSet.getSpace();
+      EIS.selectHyperslab(H5S_SELECT_SET, Count, Offset);
+      DataSpace MEIS(1, Count);
+      if (m_EventIndices_2.size() != Count[0]) {
+        m_EventIndices_2.resize(Count[0]);
       }
-      m_HDFDataSet.read(m_Buffer_1_2.data(), m_HDFCompoundDataType, MS, DS);
-    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
-      if (m_Buffer_2_2.size() != m_CurrentBatchSize) {
-        m_Buffer_2_2.resize(m_CurrentBatchSize);
+      m_EventIndicesDataSet.read(m_EventIndices_2.data(), m_EventIndicesCompoundDataType, MEIS, EIS);
+
+      // Read /FEEHits (only the part that is accessed by the current Events batch)
+      uint32_t MinHitIndex = m_EventIndices_2.front().m_FEEHits[0];
+      uint32_t MaxHitIndex = m_EventIndices_2.back().m_FEEHits[1];
+      hsize_t HitOffset[1] = { MinHitIndex };
+      hsize_t HitCount[1] = { MaxHitIndex - MinHitIndex };
+
+      DataSpace DS = m_HDFDataSet.getSpace();
+      DS.selectHyperslab(H5S_SELECT_SET, HitCount, HitOffset);
+      DataSpace MS(1, HitCount);
+      if (m_Buffer_2.size() != HitCount[0]) {
+        m_Buffer_2.resize(HitCount[0]);
       }
-      m_HDFDataSet.read(m_Buffer_2_2.data(), m_HDFCompoundDataType, MS, DS);
+      m_HDFDataSet.read(m_Buffer_2.data(), m_HDFFEECompoundDataType, MS, DS);
+      m_MinHitIndex = MinHitIndex;
+
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
       m_CurrentBatchSize = 0;
       m_Buffer_1_0.resize(0);
       m_Buffer_1_2.resize(0);
-      m_Buffer_2_2.resize(0);
+      m_Buffer_2.resize(0);
       m_CurrentBatchIndex = 0;
       return false;
     }
@@ -445,7 +508,7 @@ bool MModuleLoaderMeasurementsHDF::ReadBatchHits()
     m_CurrentBatchSize = 0;
     m_Buffer_1_0.resize(0);
     m_Buffer_1_2.resize(0);
-    m_Buffer_2_2.resize(0);
+    m_Buffer_2.resize(0);
     m_CurrentBatchIndex = 0;
     return false;
   }
@@ -506,93 +569,184 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     // Extract the data we need
     uint16_t EventID;
     uint64_t TimeCode;
-    uint16_t StripID;
-    uint16_t ADCs;
-    uint16_t TACs;
+    uint64_t SPWTimeCode = 0;
     uint8_t NumberOfHits;
-    uint8_t HitType;
-    uint8_t TimingType;
 
-    if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
-      MHDFStripHit_V1_0& Hit = m_Buffer_1_0[m_CurrentBatchIndex];
-      ++m_CurrentBatchIndex;
-      ++m_CurrentHit;
+    if (m_HDFStripHitVersion <= MHDFStripHitVersion::V1_2) {
 
-      EventID = Hit.m_EventID;
-      TimeCode = Hit.m_TimeCode;
-      StripID = Hit.m_StripID;
-      ADCs = Hit.m_EnergyData;
-      TACs = Hit.m_TimingData;
-      NumberOfHits = Hit.m_Hits;
-      HitType = Hit.m_HitType;
-      TimingType = Hit.m_TimingType;
-    
-    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_2) {
-      MHDFStripHit_V1_2& Hit = m_Buffer_1_2[m_CurrentBatchIndex];
-      ++m_CurrentBatchIndex;
-      ++m_CurrentHit;
+      uint16_t StripID;
+      uint16_t ADCs;
+      uint16_t TACs;
+      uint8_t HitType;
+      uint8_t TimingType;
 
-      EventID = Hit.m_EventID;
-      TimeCode = Hit.m_TimeCode;
-      StripID = Hit.m_StripID;
-      ADCs = Hit.m_EnergyData;
-      TACs = Hit.m_TimingData;
-      NumberOfHits = Hit.m_Hits;
-      HitType = Hit.m_HitType;
-      TimingType = Hit.m_TimingType;
-    
-    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
-      MHDFStripHit_V2_2& Hit = m_Buffer_2_2[m_CurrentBatchIndex];
-      ++m_CurrentBatchIndex;
-      ++m_CurrentHit;
+      if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
+        MHDFStripHit_V1_0& Hit = m_Buffer_1_0[m_CurrentBatchIndex];
+        ++m_CurrentBatchIndex;
+        ++m_CurrentHit;
 
-      StripID = Hit.m_StripID;
-      ADCs = Hit.m_EnergyData;
-      TACs = Hit.m_TimingData;
-      HitType = Hit.m_HitType;
-      TimingType = Hit.m_TimingType;
+        EventID = Hit.m_EventID;
+        TimeCode = Hit.m_TimeCode;
+        StripID = Hit.m_StripID;
+        ADCs = Hit.m_EnergyData;
+        TACs = Hit.m_TimingData;
+        NumberOfHits = Hit.m_Hits;
+        HitType = Hit.m_HitType;
+        TimingType = Hit.m_TimingType;
 
-      // Read the information about the event based on the EventIndex of the Hit
-      uint32_t EventIndex = Hit.m_EventIndex;
-      MHDFEvent_V2_2& HitEvent = m_EventData_2_2[EventIndex];
-      EventID = HitEvent.m_EventID;
-      TimeCode = HitEvent.m_GSETimeCode;
-      NumberOfHits = HitEvent.m_Hits;
-      // SPWTimeCode = HitEvent.m_SPWTimeCode;
+      } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_2) {
+        MHDFStripHit_V1_2& Hit = m_Buffer_1_2[m_CurrentBatchIndex];
+        ++m_CurrentBatchIndex;
+        ++m_CurrentHit;
+
+        EventID = Hit.m_EventID;
+        TimeCode = Hit.m_TimeCode;
+        StripID = Hit.m_StripID;
+        ADCs = Hit.m_EnergyData;
+        TACs = Hit.m_TimingData;
+        NumberOfHits = Hit.m_Hits;
+        HitType = Hit.m_HitType;
+        TimingType = Hit.m_TimingType;
+      } else {
+        if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
+        return false;
+      }
+
+      if (g_Verbosity >= c_Info) {
+        cout<<endl;
+        cout<<"Hit "<<m_CurrentHit<<endl;
+        cout<<"  EventID: "<<EventID<<endl;
+        cout<<"  TimeCode: "<<TimeCode<<endl;
+        cout<<"  StripID: "<<StripID<<endl;
+        cout<<"  EnergyData: "<<ADCs<<endl;
+        cout<<"  TimingData: "<<TACs<<endl;
+        cout<<"  Hits: "<<(int) NumberOfHits<<endl;
+        cout<<"  HitType: "<<(int) HitType<<endl;
+        cout<<"  TimingType: "<<(int) TimingType<<endl;
+      }
+
+      // Catch a bug in the HDF5 data (v1)
+      if (EventID == 0 && StripID == 0 && ADCs == 0) {
+        IsZeroDataBug = true;
+        if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": ZERO-DATA-BUG: Found empty data set. Ignoring event."<<endl;
+        continue;
+      } else {
+        if (IsZeroDataBug == true) { // We are now out of the bug and need to recover
+          // Clear the strip hits - everything else gets overwritten later
+          while (Event->GetNStripHits() > 0) {
+            MStripHit* H = Event->GetStripHit(0);
+            delete H;
+            Event->RemoveStripHit(0);
+          }
+        }
+        IsZeroDataBug = false;
+      }
+
+      if (m_StripMap.HasReadOutID(StripID) == true) {
+        MStripHit* H = new MStripHit();
+        H->SetDetectorID(m_StripMap.GetDetectorID(StripID));
+        H->SetStripID(m_StripMap.GetStripNumber(StripID));
+        H->IsLowVoltageStrip(m_StripMap.IsLowVoltage(StripID));
+        H->SetADCUnits(ADCs);
+        H->SetTAC(TACs);
+
+        // Set boolean flags based on HitType and TimingType
+        H->IsGuardRing(HitType == 2);
+        if (H->IsGuardRing() == true) {
+          Event->SetGuardRingVeto(true);
+        }
+        
+        H->IsNearestNeighbor(HitType == 1);
+        H->HasFastTiming(TimingType == 1);
+        
+        // If the user does not want to include Nearest Neighbors in the data, then this is where we remove them
+        // NOTE: at some point we will want to remove this code and always include nearest neighbor data
+        if (m_IncludeNearestNeighbor == false && HitType == 1) {
+          delete H; // Clean up the memory we just allocated
+          // Increase counters
+          NStripHits = static_cast<unsigned int>(NumberOfHits);
+          StripHitIndex++;
+          continue;
+        }
+          
+        Event->AddStripHit(H);
+      } else {
+        if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<StripID<<" not found in strip map"<<endl;
+        return false;
+      }
       
+    } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
+
+      if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_0) {
+        MHDFEvent_V2_0& HitEvent = m_EventData_2_0[m_CurrentBatchIndex];
+        EventID = HitEvent.m_EventID;
+        TimeCode = HitEvent.m_GSETimeCode;
+        NumberOfHits = HitEvent.m_Hits;
+      } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
+        MHDFEvent_V2_2& HitEvent = m_EventData_2_2[m_CurrentBatchIndex];
+        EventID = HitEvent.m_EventID;
+        TimeCode = HitEvent.m_GSETimeCode;
+        NumberOfHits = HitEvent.m_Hits;
+      } else {
+        if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
+        return false;
+      }
+
+      MHDFEventIndices_V2& EventIndices = m_EventIndices_2[m_CurrentBatchIndex];
+      ++m_CurrentBatchIndex;
+      ++m_CurrentHit;
+
+      if (m_Buffer_2.data() == nullptr || m_Buffer_2.size() == 0) {
+        if (g_Verbosity >= c_Error) cout << "Buffer is empty or null!" << endl;
+        return false;
+      }
+
+      // Create objects for all hits that belong to that event
+      for (uint32_t i = EventIndices.m_FEEHits[0]; i < EventIndices.m_FEEHits[1]; i++) {
+
+        uint32_t IndexInBatch = i - m_MinHitIndex;
+        if (i < m_MinHitIndex || i >= (m_MinHitIndex + m_Buffer_2.size())) {
+          if (g_Verbosity >= c_Error) cout << m_XmlTag << ": Entry " << i << " is NOT in the current FEEHits buffer!" << endl;
+          return false;
+        } 
+        
+        MHDFStripHit_V2& Hit = m_Buffer_2[IndexInBatch];
+        if (m_StripMap.HasReadOutID(Hit.m_StripID) == true) {
+          MStripHit* H = new MStripHit();
+          H->SetDetectorID(m_StripMap.GetDetectorID(Hit.m_StripID));
+          H->SetStripID(m_StripMap.GetStripNumber(Hit.m_StripID));
+          H->IsLowVoltageStrip(m_StripMap.IsLowVoltage(Hit.m_StripID));
+          H->SetADCUnits(Hit.m_EnergyData);
+          H->SetTAC(Hit.m_TimingData);
+
+          // Set boolean flags based on HitType and TimingType
+          H->IsGuardRing(Hit.m_HitType == 2);
+          if (H->IsGuardRing() == true) {
+            Event->SetGuardRingVeto(true);
+          }
+          
+          H->IsNearestNeighbor(Hit.m_HitType == 1);
+          H->HasFastTiming(Hit.m_TimingType == 1);
+          
+          // If the user does not want to include Nearest Neighbors in the data, then this is where we remove them
+          // NOTE: at some point we will want to remove this code and always include nearest neighbor data
+          if (m_IncludeNearestNeighbor == false && Hit.m_HitType == 1) {
+            delete H; // Clean up the memory we just allocated
+            // Increase counters
+            NStripHits = static_cast<unsigned int>(NumberOfHits);
+            StripHitIndex++;
+            continue;
+          }
+            
+          Event->AddStripHit(H);
+        } else {
+          if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<Hit.m_StripID<<" not found in strip map"<<endl;
+          return false;
+        }
+      }
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
       return false;
-    }
-
-    if (g_Verbosity >= c_Info) {
-      cout<<endl;
-      cout<<"Hit "<<m_CurrentHit<<endl;
-      cout<<"  EventID: "<<EventID<<endl;
-      cout<<"  TimeCode: "<<TimeCode<<endl;
-      cout<<"  StripID: "<<StripID<<endl;
-      cout<<"  EnergyData: "<<ADCs<<endl;
-      cout<<"  TimingData: "<<TACs<<endl;
-      cout<<"  Hits: "<<(int) NumberOfHits<<endl;
-      cout<<"  HitType: "<<(int) HitType<<endl;
-      cout<<"  TimingType: "<<(int) TimingType<<endl;
-    }
-
-    // Catch a bug in the HDF5 data
-    if (EventID == 0 && StripID == 0 && ADCs == 0) {
-      IsZeroDataBug = true;
-      if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": ZERO-DATA-BUG: Found empty data set. Ignoring event."<<endl;
-      continue;
-    } else {
-      if (IsZeroDataBug == true) { // We are now out of the bug and need to recover
-        // Clear the strip hits - everything else gets overwritten later
-        while (Event->GetNStripHits() > 0) {
-          MStripHit* H = Event->GetStripHit(0);
-          delete H;
-          Event->RemoveStripHit(0);
-        }
-      }
-      IsZeroDataBug = false;
     }
 
     if (EventID < m_LastEventID) {
@@ -605,48 +759,14 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     Event->SetID(LongEventID);
     if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
       Event->SetCL(TimeCode);
-    } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2)  {
+    } else if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_0)  {
       Event->SetTI(TimeCode);
-      // Event->SetCL(SPWTimeCode);
+      if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_2) {
+        Event->SetCL(SPWTimeCode);
+      }
     } else {
       Event->SetTI(TimeCode);
     }
-
-    if (m_StripMap.HasReadOutID(StripID) == true) {
-      MStripHit* H = new MStripHit();
-      H->SetDetectorID(m_StripMap.GetDetectorID(StripID));
-      H->SetStripID(m_StripMap.GetStripNumber(StripID));
-      H->IsLowVoltageStrip(m_StripMap.IsLowVoltage(StripID));
-      H->SetADCUnits(ADCs);
-      H->SetTAC(TACs);
-
-
-      // Set boolean flags based on HitType and TimingType
-      H->IsGuardRing(HitType == 2);
-      if (H->IsGuardRing() == true) {
-        Event->SetGuardRingVeto(true);
-      }
-      
-      H->IsNearestNeighbor(HitType == 1);
-      H->HasFastTiming(TimingType == 1);
-      
-      // If the user does not want to include Nearest Neighbors in the data, then this is where we remove them
-      // NOTE: at some point we will want to remove this code and always include nearest neighbor data
-      if (m_IncludeNearestNeighbor == false && HitType == 1) {
-        delete H; // Clean up the memory we just allocated
-        // Increase counters
-        NStripHits = static_cast<unsigned int>(NumberOfHits);
-        StripHitIndex++;
-        continue;
-      }
-        
-      Event->AddStripHit(H);
-       
-    } else {
-      if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<StripID<<" not found in strip map"<<endl;
-      return false;
-    }
-
     NStripHits = static_cast<unsigned int>(NumberOfHits);
     StripHitIndex++;
   }
@@ -670,7 +790,7 @@ void MModuleLoaderMeasurementsHDF::Finalize()
   MModule::Finalize();
   
   cout<<"MModuleLoaderMeasurementsHDF: "<<endl;
-  cout<<"  * all events on file: "<<m_NEventsInFile<<endl;
+  cout<<"  * all events on file:  "<<m_NEventsInFile<<endl;
   cout<<"  * good events on file: "<<m_NGoodEventsInFile<<endl;
 
   m_HDFFile.close();

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -114,6 +114,20 @@ bool MModuleLoaderMeasurementsHDF::Initialize()
   m_NumberOfEventIDRollOvers = 0;
   m_LastEventID = 0;
 
+  // Clear all data buffers and related variables
+  m_Buffer_1_0.clear();
+  m_Buffer_1_2.clear();
+  m_Buffer_2.clear();
+  m_EventIndices_2.clear();
+  m_EventData_2_0.clear();
+  m_EventData_2_2.clear();
+  m_CurrentBatchSize = 0;
+  m_CurrentBatchIndex = 0;
+  m_MinHitIndex = 0;
+
+  // Clear ASIC polarities (relevant in HDFv2)
+  m_ASICPolarities.clear();
+
   if (MFile::Exists(m_FileName) == false) {
     if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": The file "<<m_FileName<<" does not exist."<<endl;
     return false;

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -379,7 +379,7 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
       m_EventIndicesCompoundDataType.insertMember("acs_hits",            HOFFSET(MHDFEventIndices_V2, m_ACSHits),            uint32_pair);
       m_EventIndicesCompoundDataType.insertMember("hs",                  HOFFSET(MHDFEventIndices_V2, m_HS),                 uint32_pair);
       m_EventIndicesCompoundDataType.insertMember("singles_counts",      HOFFSET(MHDFEventIndices_V2, m_SinglesCounts),      uint32_pair);
-      m_EventIndicesCompoundDataType.insertMember("dib_coindicidence",   HOFFSET(MHDFEventIndices_V2, m_DIBCoincidence),     uint32_pair);
+      m_EventIndicesCompoundDataType.insertMember("dib_coincidence",     HOFFSET(MHDFEventIndices_V2, m_DIBCoincidence),     uint32_pair);
       m_EventIndicesCompoundDataType.insertMember("detector_hits",       HOFFSET(MHDFEventIndices_V2, m_DetectorHits),       uint32_pair);
       m_EventIndicesCompoundDataType.insertMember("detector_live_time",  HOFFSET(MHDFEventIndices_V2, m_DetectorLiveTime),   uint32_pair);
 
@@ -569,8 +569,11 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     // Extract the data we need
     uint16_t EventID;
     uint64_t TimeCode;
-    uint64_t SPWTimeCode = 0;
     uint8_t NumberOfHits;
+
+    // Setting SPWTimeCode default to 0, as it is defined only iin HDF version >= 2.2
+    uint64_t SPWTimeCode = 0;
+
 
     if (m_HDFStripHitVersion <= MHDFStripHitVersion::V1_2) {
 
@@ -696,7 +699,7 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       ++m_CurrentBatchIndex;
       ++m_CurrentHit;
 
-      if (m_Buffer_2.data() == nullptr || m_Buffer_2.size() == 0) {
+      if (m_Buffer_2.empty()) {
         if (g_Verbosity >= c_Error) cout << "Buffer is empty or null!" << endl;
         return false;
       }

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -28,6 +28,7 @@
 
 // Standard libs:
 #include <algorithm>
+#include <regex>
 using namespace std;
 
 // ROOT libs:
@@ -171,12 +172,13 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<string(VS.string_col)<<endl<<"Please update this module."<<endl;
         return false;
       }
+
     // Check for existence of HDFVersion in /Events/HDFVersion (HDF v2)
     } else if (H5Lexists(m_HDFFile.getId(), "Events", H5P_DEFAULT) > 0) {
       m_EventDataSet = m_HDFFile.openDataSet("/Events");
-      Attribute VersionAttribute = m_EventDataSet.openAttribute("HDFVersion");
 
       // Read HDF5 version from Events/HDF5Version to a string
+      Attribute VersionAttribute = m_EventDataSet.openAttribute("HDFVersion");
       string VersionString;
       VersionAttribute.read(VersionAttribute.getStrType(), VersionString);
 
@@ -185,6 +187,72 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
       } else {
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<VersionString<<endl<<"Please update this module."<<endl;
         return false;
+      }
+
+      // Determine ASIC polarities
+      Attribute Config = m_EventDataSet.openAttribute("Config");
+      string ConfigJSON;
+      Config.read(Config.getStrType(), ConfigJSON);
+
+      vector<map<string, vector<string>>> polarities;
+      string ASIC = "";
+
+      // Regex to match either "primary"/"secondary", or the polarity stored in "SP"
+      regex pattern(R"(\"(primary|secondary)\"|\"SP\"\s*:\s*(\d+))");
+      for (sregex_iterator i = sregex_iterator(ConfigJSON.begin(), ConfigJSON.end(), pattern); i != sregex_iterator(); ++i) {
+        
+        smatch match = *i;
+
+        // Check Group 1: Marker (primary/secondary)
+        if (match[1].matched) {
+
+          ASIC = match[1].str();
+
+          if (polarities.empty() || polarities.back().find(ASIC) != polarities.back().end()) {
+
+            // Check that the previous entry has both primary or secondary before creating a new one
+            if (!polarities.empty() && (
+                 polarities.back().find("primary") == polarities.back().end() || 
+                 polarities.back().find("secondary") == polarities.back().end())
+            ) {
+              if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Parsing ASIC polarities for detector "<<polarities.size()-1<<" unsuccessful"<<endl;
+                return false;
+            }
+
+            polarities.push_back(map<string, vector<string>>());
+          }
+
+          // Initialize the vector for this ASIC key if it doesn't exist
+          polarities.back()[ASIC] = vector<string>();
+        }
+        
+        // Check Group 2: SP value
+        else if (match[2].matched) {
+          if (ASIC.empty() || polarities.empty()) {
+            if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": SP found without active ASIC section"<<endl;
+            return false;
+          }
+          
+          string val = match[2].str();
+          if (val != "0" && val != "1") {
+            if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Cannot interpret polarity \""<<val<<"\" (allowed are \"0\" and \"1\")"<< endl;
+            return false;
+          }
+
+          polarities.back()[ASIC].push_back(val == "0" ? "HV" : "LV");
+        }
+      }
+
+      // Output results for verification
+      if (g_Verbosity >= c_Info) {
+        for (size_t i = 0; i < polarities.size(); ++i) {
+          cout << "Detector ID " << i << ":" << endl;
+          for (auto const& [key, val] : polarities[i]) {
+            cout << "  " << key << ": ";
+            for (const auto& s : val) cout << s << " ";
+            cout << endl;
+          }
+        }
       }
     }
     cout<<m_XmlTag<<": HDF5 hit version found: "<<m_HDFStripHitVersion<<endl;

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -189,12 +189,12 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         return false;
       }
 
-      // Determine ASIC polarities
+      // Determine ASIC IsLowVoltage
       Attribute Config = m_EventDataSet.openAttribute("Config");
       string ConfigJSON;
       Config.read(Config.getStrType(), ConfigJSON);
 
-      vector<map<string, vector<string>>> polarities;
+      vector<map<string, vector<bool>>> IsLowVoltage;
       string ASIC = "";
 
       // Regex to match either "primary"/"secondary", or the polarity stored in "SP"
@@ -208,27 +208,27 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
 
           ASIC = match[1].str();
 
-          if (polarities.empty() || polarities.back().find(ASIC) != polarities.back().end()) {
+          if (IsLowVoltage.empty() || IsLowVoltage.back().find(ASIC) != IsLowVoltage.back().end()) {
 
             // Check that the previous entry has both primary or secondary before creating a new one
-            if (!polarities.empty() && (
-                 polarities.back().find("primary") == polarities.back().end() || 
-                 polarities.back().find("secondary") == polarities.back().end())
+            if (!IsLowVoltage.empty() && (
+                 IsLowVoltage.back().find("primary") == IsLowVoltage.back().end() || 
+                 IsLowVoltage.back().find("secondary") == IsLowVoltage.back().end())
             ) {
-              if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Parsing ASIC polarities for detector "<<polarities.size()-1<<" unsuccessful"<<endl;
+              if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Parsing ASIC polarities for detector "<<IsLowVoltage.size()-1<<" unsuccessful"<<endl;
                 return false;
             }
 
-            polarities.push_back(map<string, vector<string>>());
+            IsLowVoltage.push_back(map<string, vector<bool>>());
           }
 
           // Initialize the vector for this ASIC key if it doesn't exist
-          polarities.back()[ASIC] = vector<string>();
+          IsLowVoltage.back()[ASIC] = vector<bool>();
         }
         
         // Check Group 2: SP value
         else if (match[2].matched) {
-          if (ASIC.empty() || polarities.empty()) {
+          if (ASIC.empty() || IsLowVoltage.empty()) {
             if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": SP found without active ASIC section"<<endl;
             return false;
           }
@@ -239,17 +239,18 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
             return false;
           }
 
-          polarities.back()[ASIC].push_back(val == "0" ? "HV" : "LV");
+          // val == 1 <=> LV; val == 0 <=> HV
+          IsLowVoltage.back()[ASIC].push_back(val == "1");
         }
       }
 
       // Output results for verification
       if (g_Verbosity >= c_Info) {
-        for (size_t i = 0; i < polarities.size(); ++i) {
+        for (size_t i = 0; i < IsLowVoltage.size(); ++i) {
           cout << "Detector ID " << i << ":" << endl;
-          for (auto const& [key, val] : polarities[i]) {
+          for (auto const& [key, val] : IsLowVoltage[i]) {
             cout << "  " << key << ": ";
-            for (const auto& s : val) cout << s << " ";
+            for (const auto& s : val) cout << (s ? "LV" : "HV") << " ";
             cout << endl;
           }
         }

--- a/src/MStripMap.cxx
+++ b/src/MStripMap.cxx
@@ -104,8 +104,10 @@ bool MStripMap::Open(MString FileName)
 ////////////////////////////////////////////////////////////////////////////////
 
 bool MStripMap::UpdateASICPolarities(vector<map<bool, vector<bool>>> ASICPolarities) {
-  for (MSingleStripMapping s : m_StripMappings) {
-    s.m_IsLowVoltage = ASICPolarities[s.m_DetectorID][s.m_IsPrimary][s.m_ASICID];
+  if (!m_StripMappings.empty()) {
+    for (MSingleStripMapping &s : m_StripMappings) {
+      s.m_IsLowVoltage = ASICPolarities[s.m_DetectorID][s.m_IsPrimary][s.m_ASICID];
+    }
   }
   return true;
 }

--- a/src/MStripMap.cxx
+++ b/src/MStripMap.cxx
@@ -105,8 +105,8 @@ bool MStripMap::Open(MString FileName)
 
 bool MStripMap::UpdateASICPolarities(vector<map<bool, vector<bool>>> ASICPolarities) {
   if (!m_StripMappings.empty()) {
-    for (MSingleStripMapping &s : m_StripMappings) {
-      s.m_IsLowVoltage = ASICPolarities[s.m_DetectorID][s.m_IsPrimary][s.m_ASICID];
+    for (MSingleStripMapping& S : m_StripMappings) {
+      S.m_IsLowVoltage = ASICPolarities[S.m_DetectorID][S.m_IsPrimary][S.m_ASICID];
     }
   }
   return true;

--- a/src/MStripMap.cxx
+++ b/src/MStripMap.cxx
@@ -2,7 +2,7 @@
  * MStripMap.cxx
  *
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Andreas Zoglauer, Felix Hagemann.
  * All rights reserved.
  *
  *

--- a/src/MStripMap.cxx
+++ b/src/MStripMap.cxx
@@ -103,6 +103,16 @@ bool MStripMap::Open(MString FileName)
 
 ////////////////////////////////////////////////////////////////////////////////
 
+bool MStripMap::UpdateASICPolarities(vector<map<bool, vector<bool>>> ASICPolarities) {
+  for (MSingleStripMapping s : m_StripMappings) {
+    s.m_IsLowVoltage = ASICPolarities[s.m_DetectorID][s.m_IsPrimary][s.m_ASICID];
+  }
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
 
 //! Return true if the given read-out ID is on file
 bool MStripMap::HasReadOutID(unsigned int ROI) const


### PR DESCRIPTION
This is my attempt to implement a HDF loader for the newest version 2 of the HDF hit into.
I'm not claiming that this is perfect, but it seems to give something reasonable at least..
It also fixes #57.

I developed this based on a file that was taken with `HDF v2.3` and `GSE v7.2.2` on the FM assembly at SSL.

The changes between versions 1 and 2 addressed in this PR are:
- **where the HDFVersion is saved in the file**
  | Version 1 | Version 2 |
  |----------|----------|
  | `HDFVersion` is its own dataset within the file. | `HDFVersion` is an attribute of the `Events` dataset. |
  |  <pre>🗂️ HDF5.File (version 1)<br>  ├─ 🏷️ CLASS<br>  ├─ 🏷️ FILTERS<br>  ├─ 🏷️ PYTABLES_FORMAT_VERSION<br>  ├─ 🏷️ TITLE<br>  ├─ 🏷️ VERSION<br>  ├─ 🔢 Buffers<br>  ├─ 🔢 Config<br>  ├─ 🔢 GSEVersion<br>  ├─ 🔢 HDFVersion<br>  │  ├─ 🏷️ CLASS<br>  │  ├─ 🏷️ FIELD_0_FILL<br>  │  ├─ 🏷️ FIELD_0_NAME<br>  │  ├─ 🏷️ NROWS<br>  │  ├─ 🏷️ TITLE<br>  │  └─ 🏷️ VERSION<br>  ├─ 🔢 Headers<br>  └─ 🔢 Hits</pre> | <pre>  🗂️ HDF5.File (version 2)<br>  ├─ 🔢 ACSHits<br>  ├─ 🔢 Buffers<br>  ├─ 🔢 DIBCoincidence<br>  ├─ 🔢 DetectorHits<br>  ├─ 🔢 DetectorLiveTime<br>  ├─ 🔢 EventIndices<br>  ├─ 🔢 Events<br>  │  ├─ 🏷️ BackendVersion<br>  │  ├─ 🏷️ Config<br>  │  ├─ 🏷️ Firmware<br>  │  ├─ 🏷️ GSEVersion<br>  │  └─ 🏷️ HDFVersion<br>  ├─ 🔢 FEEHits<br>  ├─ 🔢 H&S<br>  ├─ 🔢 Headers<br>  ├─ 🔢 RTBHousekeeping<br>  ├─ 🔢 SCBHousekeeping<br>  └─ 🔢 SinglesCounts</pre> |

  --> If no dataset `HDFVersion` exists, check for the existence of `Events` and attribute `HDFVersion` therein.
 
- **Hit and event information are now stored in different datasets**
  | Version 1 | Version 2 |
  |----------|----------|
  | Both, hit and event information was stored in the dataset `Hits`. | The hit information is saved in the dataset `FEEHits` and the event information is saved in the dataset `Events`. Hit entries in `FEEHits` have a field `event_index` which denotes which "row" in the `Events` dataset correspond to the given hit. |

  For clarification:
  - Hit information = strip ID, energy data, timing data, hit type, timing type
  - Event information = event ID, timecode, GSE timecode, SPW timecode, number of hits, ...
  
  --> use the same buffer logic for **hit information**, but read in the **event information** as a whole.


Right now, the handling of `SPWTimeCode` (spacewire time code) is commented out to avoid undeclared variable warnings.

I would be very grateful for feedback! :)