### PR TITLE
Add MGUIExpoPlotSpectrum for plotting energy spectrums

### DIFF
--- a/include/MGUIExpoPlotSpectrum.h
+++ b/include/MGUIExpoPlotSpectrum.h
@@ -65,6 +65,9 @@ public:
 
   //! Update the frame
   virtual void Update();
+  
+  //! Set the plotting mode (200=None, 201=NoBuffer, 202=WithBuffer)
+  void SetPlotMode(int Mode) { m_PlotSpectrumMode = Mode; }
 
 
 protected:
@@ -111,7 +114,7 @@ private:
   std::vector<double> m_DataBufferNearestNeighborLVFinal;
   std::vector<double> m_DataBufferNearestNeighborHVFinal;
   
-  bool m_PlotSpectrum;
+  int m_PlotSpectrumMode;
 
 #ifdef ___CLING___
 public:

--- a/include/MGUIOptionsEnergyCalibrationUniversal.h
+++ b/include/MGUIOptionsEnergyCalibrationUniversal.h
@@ -97,7 +97,11 @@ class MGUIOptionsEnergyCalibrationUniversal : public MGUIOptions
   TGRadioButton* m_SlowThresholdCutNearestNeighborRBFixed;
   //! The threshold cut entry box for Nearest Neighbors
   MGUIEEntry* m_SlowThresholdCutNearestNeighborFixedValue;
-
+  
+  //! Radio button for plotting the spectrum with/without the buffer
+  TGRadioButton* m_PlotSpectrumNoneRB;
+  TGRadioButton* m_PlotSpectrumNoBufferRB;
+  TGRadioButton* m_PlotSpectrumWithBufferRB;
 
   //! IDs of radio buttons
   //! The numbers should be identical to MSlowThresholdCutModes
@@ -105,7 +109,10 @@ class MGUIOptionsEnergyCalibrationUniversal : public MGUIOptions
     c_SlowThresholdFixed,
     c_SlowThresholdFile,
     c_SlowThresholdNearestNeighborIgnore = 100,
-    c_SlowThresholdNearestNeighborFixed};
+    c_SlowThresholdNearestNeighborFixed,
+    c_PlotSpectrumNone = 200,
+    c_PlotSpectrumNoBuffer,
+    c_PlotSpectrumWithBuffer};
 
 
 #ifdef ___CLING___

--- a/include/MGUIOptionsTACcut.h
+++ b/include/MGUIOptionsTACcut.h
@@ -42,6 +42,14 @@ class MGUIEEntry;
 
 ////////////////////////////////////////////////////////////////////////////////
 
+enum {
+  // ... your other UI IDs ...
+  c_PlotSpectrumNone = 200,
+  c_PlotSpectrumNoBuffer = 201,
+  c_PlotSpectrumWithBuffer = 202
+};
+
+////////////////////////////////////////////////////////////////////////////////
 
 class MGUIOptionsTACcut : public MGUIOptions
 {
@@ -79,6 +87,12 @@ class MGUIOptionsTACcut : public MGUIOptions
 	
   // private members:
  private:
+  //! Radio buttons for the spectrum plots 
+  TGRadioButton* m_PlotSpectrumNoneRB;
+  TGRadioButton* m_PlotSpectrumNoBufferRB;
+  TGRadioButton* m_PlotSpectrumWithBufferRB;
+
+  void ToggleRadioButtons(int WidgetID);
 
 
 #ifdef ___CLING___

--- a/include/MGUIOptionsTACcut.h
+++ b/include/MGUIOptionsTACcut.h
@@ -71,6 +71,9 @@ class MGUIOptionsTACcut : public MGUIOptions
 
   //! Actions after the Apply or OK button has been pressed
   virtual bool OnApply();
+  
+  //! Toggle the radio buttons
+  void ToggleRadioButtons(int WidgetID);
 
 
   // protected members:
@@ -92,7 +95,12 @@ class MGUIOptionsTACcut : public MGUIOptions
   TGRadioButton* m_PlotSpectrumNoBufferRB;
   TGRadioButton* m_PlotSpectrumWithBufferRB;
 
-  void ToggleRadioButtons(int WidgetID);
+  //! IDs of radio buttons
+  //! The numbers should be identical to Plot spectrum module
+  enum RBButtonIDs {
+    c_PlotSpectrumNone = 200,
+    c_PlotSpectrumNoBuffer,
+    c_PlotSpectrumWithBuffer};
 
 
 #ifdef ___CLING___

--- a/include/MModuleEnergyCalibrationUniversal.h
+++ b/include/MModuleEnergyCalibrationUniversal.h
@@ -54,6 +54,14 @@ enum class MNearestNeighborCutModes : int
   e_Fixed = 101
 };
 
+//! Definition of the plot spectrum modes
+enum MPlotSpectrumModes : int
+{
+  e_PlotNone = 200,
+  e_PlotNoBuffer = 201,
+  e_PlotWithBuffer = 202
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -101,6 +109,12 @@ class MModuleEnergyCalibrationUniversal : public MModule
   void SetNearestNeighborThreshold(double Threshold) { m_NearestNeighborThreshold = Threshold; }
   //! Get the threshold value for Nearest Neighbors
   double GetNearestNeighborThreshold() const { return m_NearestNeighborThreshold; }
+  
+  // Spectrum plotting options
+  //! Set the plot spectrum mode
+  void SetPlotSpectrumMode(const MPlotSpectrumModes& Mode) { m_PlotSpectrumMode = Mode; }
+  //! Get the plot spectrum mode
+  MPlotSpectrumModes GetPlotSpectrumMode() const { return m_PlotSpectrumMode; }
  
  
   //! Create the expos
@@ -159,8 +173,12 @@ class MModuleEnergyCalibrationUniversal : public MModule
   MNearestNeighborCutModes m_NearestNeighborCutMode;
     
   //! The Nearest Neighbor threshold value
-  double m_NearestNeighborThreshold; 
-
+  double m_NearestNeighborThreshold;
+  
+  //! The spectrum plotting mode
+  MPlotSpectrumModes m_PlotSpectrumMode;
+  
+  
 
   // private members:
  private:

--- a/include/MModuleEnergyCalibrationUniversal.h
+++ b/include/MModuleEnergyCalibrationUniversal.h
@@ -55,6 +55,7 @@ enum class MNearestNeighborCutModes : int
 };
 
 //! Definition of the plot spectrum modes
+// Attention: The ints are also used in the Plot Spectrum Model! Thus don't change the numbers
 enum MPlotSpectrumModes : int
 {
   e_PlotNone = 200,

--- a/include/MModuleEnergyCalibrationUniversal.h
+++ b/include/MModuleEnergyCalibrationUniversal.h
@@ -56,7 +56,7 @@ enum class MNearestNeighborCutModes : int
 
 //! Definition of the plot spectrum modes
 // Attention: The ints are also used in the Plot Spectrum Model! Thus don't change the numbers
-enum MPlotSpectrumModes : int
+enum MEnergyCalibrationPlotSpectrumModes : int
 {
   e_PlotNone = 200,
   e_PlotNoBuffer = 201,
@@ -113,10 +113,11 @@ class MModuleEnergyCalibrationUniversal : public MModule
   
   // Spectrum plotting options
   //! Set the plot spectrum mode
-  void SetPlotSpectrumMode(const MPlotSpectrumModes& Mode) { m_PlotSpectrumMode = Mode; }
+  void SetPlotSpectrumMode(MEnergyCalibrationPlotSpectrumModes Mode) { m_PlotSpectrumMode = Mode; }
   //! Get the plot spectrum mode
-  MPlotSpectrumModes GetPlotSpectrumMode() const { return m_PlotSpectrumMode; }
- 
+  MEnergyCalibrationPlotSpectrumModes GetPlotSpectrumMode() const { return m_PlotSpectrumMode; }
+   
+  
  
   //! Create the expos
   virtual void CreateExpos();
@@ -177,7 +178,7 @@ class MModuleEnergyCalibrationUniversal : public MModule
   double m_NearestNeighborThreshold;
   
   //! The spectrum plotting mode
-  MPlotSpectrumModes m_PlotSpectrumMode;
+  MEnergyCalibrationPlotSpectrumModes m_PlotSpectrumMode;
   
   
 

--- a/include/MModuleTACcut.h
+++ b/include/MModuleTACcut.h
@@ -32,6 +32,14 @@
 
 // Forward declarations:
 
+////////////////////////////////////////////////////////////////////////////////
+
+enum class MTACPlotSpectrumModes {
+  e_PlotNone = 200,
+  e_PlotNoBuffer = 201,
+  e_PlotWithBuffer = 202
+};
+
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -86,6 +94,10 @@ class MModuleTACcut : public MModule
 
   //! Load the TAC cut file
   bool LoadTACCutFile(MString FName);
+  
+  //!  Mode for which to plot the spectrum (200 = not plot, 201 = plot no buffer, 202 = plot with buffer) 
+  void SetPlotSpectrumMode(MTACPlotSpectrumModes Mode) { m_PlotSpectrumMode = Mode; }
+  MTACPlotSpectrumModes GetPlotSpectrumMode() const { return m_PlotSpectrumMode; }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
  
@@ -121,7 +133,8 @@ vector<unsigned int> m_DetectorIDs;
 
 MGUIExpoTACcut* m_ExpoTACcut;
 
-  MGUIExpoPlotSpectrum* m_ExpoEnergySpectrum;
+MGUIExpoPlotSpectrum* m_ExpoEnergySpectrum;
+MTACPlotSpectrumModes m_PlotSpectrumMode;
 
 
 #ifdef ___CLING___

--- a/src/MGUIExpoPlotSpectrum.cxx
+++ b/src/MGUIExpoPlotSpectrum.cxx
@@ -58,7 +58,7 @@ MGUIExpoPlotSpectrum::MGUIExpoPlotSpectrum(MModule* Module) : MGUIExpo(Module)
 
   // standard constructor
   
-  m_PlotSpectrum = true;
+  m_PlotSpectrumMode = 200; // Default is to not make a plot (which also means not to buffer the data)
 
   // Set the new title of the tab here:
   if (Module != nullptr) {
@@ -241,9 +241,9 @@ void MGUIExpoPlotSpectrum::SetEnergyHistogramParameters(int NBins, double Min, d
 {
   //! Set the energy histogram parameters
 
-  // SAFETY FIX: Never allow 0 or negative bins. Default to 100 if something goes wrong.
+  // SAFETY FIX: Never allow 0 or negative bins. Default to 1 if something goes wrong.
   if (NBins <= 0) {
-    NBins = 100;
+    NBins = 1;
   }
   // SAFETY FIX: Ensure Max is actually greater than Min
   if (Max <= Min) {
@@ -291,9 +291,8 @@ void MGUIExpoPlotSpectrum::AddEnergyInitial(double Energy, bool IsNearestNeighbo
 {
   //! Add data to the energy histogram Initial
   
-  
   // First check if we want to plot the spectrum 
-  if (m_PlotSpectrum == false) {
+  if (m_PlotSpectrumMode == 200) {
     return;
   }
   
@@ -304,24 +303,32 @@ void MGUIExpoPlotSpectrum::AddEnergyInitial(double Energy, bool IsNearestNeighbo
       if (m_EnergyHistogramNearestNeighborLVInitial != nullptr) {
         m_EnergyHistogramNearestNeighborLVInitial->Fill(Energy);
       }
-      m_DataBufferNearestNeighborLVInitial.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferNearestNeighborLVInitial.push_back(Energy);
+      }
     } else {
       if (m_EnergyHistogramNearestNeighborHVInitial != nullptr) {
         m_EnergyHistogramNearestNeighborHVInitial->Fill(Energy);
       }
-      m_DataBufferNearestNeighborHVInitial.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferNearestNeighborHVInitial.push_back(Energy);
+      }
     }
   } else {
     if (IsLV == true) {
       if (m_EnergyHistogramLVInitial != nullptr) {
         m_EnergyHistogramLVInitial->Fill(Energy);
       }
-      m_DataBufferLVInitial.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferLVInitial.push_back(Energy);
+      }
     } else {
       if (m_EnergyHistogramHVInitial != nullptr) {
         m_EnergyHistogramHVInitial->Fill(Energy);
       }
-      m_DataBufferHVInitial.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferHVInitial.push_back(Energy);
+      }
     }
   }
     
@@ -336,8 +343,8 @@ void MGUIExpoPlotSpectrum::AddEnergyFinal(double Energy, bool IsNearestNeighbor,
 {
   //! Add data to the energy histogram Final
   
-  // First check if we want to plot the spectrum
-  if (m_PlotSpectrum == false) {
+  // First check if we want to plot the spectrum at all (200 = e_PlotNone)
+  if (m_PlotSpectrumMode == 200) {
     return;
   }
   
@@ -348,24 +355,32 @@ void MGUIExpoPlotSpectrum::AddEnergyFinal(double Energy, bool IsNearestNeighbor,
       if (m_EnergyHistogramNearestNeighborLVFinal != nullptr) {
         m_EnergyHistogramNearestNeighborLVFinal->Fill(Energy);
       }
-      m_DataBufferNearestNeighborLVFinal.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferNearestNeighborLVFinal.push_back(Energy);
+      }
     } else {
       if (m_EnergyHistogramNearestNeighborHVFinal != nullptr) {
         m_EnergyHistogramNearestNeighborHVFinal->Fill(Energy);
       }
-      m_DataBufferNearestNeighborHVFinal.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferNearestNeighborHVFinal.push_back(Energy);
+      }
     }
   } else {
     if (IsLV == true) {
       if (m_EnergyHistogramLVFinal != nullptr) {
         m_EnergyHistogramLVFinal->Fill(Energy);
       }
-      m_DataBufferLVFinal.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferLVFinal.push_back(Energy);
+      }
     } else {
       if (m_EnergyHistogramHVFinal != nullptr) {
         m_EnergyHistogramHVFinal->Fill(Energy);
       }
-      m_DataBufferHVFinal.push_back(Energy);
+      if (m_PlotSpectrumMode == 202) {
+        m_DataBufferHVFinal.push_back(Energy);
+      }
     }
   }
     
@@ -559,6 +574,13 @@ void MGUIExpoPlotSpectrum::OnUpdateRange()
 {
   //! Update the histogram range and binning
 
+  //! Update the histogram range and binning
+
+  // Safety fix: If we did not buffer the data (202), we cannot rebin/redraw!
+  //if (m_PlotSpectrumMode != 202) {
+  //  return;
+  //}
+  
   double Min = m_RangeMinEntry->GetAsDouble();
   double Max = m_RangeMaxEntry->GetAsDouble();
   double Width = m_BinWidthEntry->GetAsDouble();

--- a/src/MGUIExpoPlotSpectrum.cxx
+++ b/src/MGUIExpoPlotSpectrum.cxx
@@ -29,6 +29,7 @@
 #include <TCanvas.h>
 #include <TGButton.h>
 #include <THStack.h>
+#include <TLegend.h>
 
 // MEGAlib libs:
 #include "MStreams.h"
@@ -241,11 +242,11 @@ void MGUIExpoPlotSpectrum::SetEnergyHistogramParameters(int NBins, double Min, d
 {
   //! Set the energy histogram parameters
 
-  // SAFETY FIX: Never allow 0 or negative bins. Default to 1 if something goes wrong.
+  // Never allow 0 or negative bins. Default to 1 if something goes wrong.
   if (NBins <= 0) {
     NBins = 1;
   }
-  // SAFETY FIX: Ensure Max is actually greater than Min
+  // Make sure the max is actually greater than the min
   if (Max <= Min) {
     Max = Min + 100.0;
   }
@@ -291,7 +292,7 @@ void MGUIExpoPlotSpectrum::AddEnergyInitial(double Energy, bool IsNearestNeighbo
 {
   //! Add data to the energy histogram Initial
   
-  // First check if we want to plot the spectrum 
+  // First check if we want to plot the spectrum at all (200 = e_PlotNone)
   if (m_PlotSpectrumMode == 200) {
     return;
   }
@@ -343,7 +344,7 @@ void MGUIExpoPlotSpectrum::AddEnergyFinal(double Energy, bool IsNearestNeighbor,
 {
   //! Add data to the energy histogram Final
   
-  // First check if we want to plot the spectrum at all (200 = e_PlotNone)
+  // First check if we want to plot the spectrum
   if (m_PlotSpectrumMode == 200) {
     return;
   }
@@ -411,7 +412,9 @@ void MGUIExpoPlotSpectrum::Create()
   //! Add the GUI options here
 
   // Do not create it twice!
-  if (m_IsCreated == true) return;
+  if (m_IsCreated == true) {
+    return;
+  }
 
   m_Mutex.Lock();
   
@@ -467,8 +470,6 @@ void MGUIExpoPlotSpectrum::Create()
   
   // LV side
   m_EnergyCanvas->GetCanvas()->cd(1);
-  // Final
-  m_EnergyCanvas->GetCanvas()->cd(1);
   if (m_EnergyHistogramLVFinal != nullptr) {
     m_EnergyHistogramLVFinal->Draw("HIST");
   }
@@ -485,8 +486,6 @@ void MGUIExpoPlotSpectrum::Create()
 
   // HV side
   m_EnergyCanvas->GetCanvas()->cd(2);
-  // Final
-  m_EnergyCanvas->GetCanvas()->cd(2);
   if (m_EnergyHistogramHVFinal != nullptr) {
     m_EnergyHistogramHVFinal->Draw("HIST");
   }
@@ -500,6 +499,7 @@ void MGUIExpoPlotSpectrum::Create()
   if (m_EnergyHistogramNearestNeighborHVInitial != nullptr) {
     m_EnergyHistogramNearestNeighborHVInitial->Draw("HIST SAME");
   }
+
   
   m_EnergyCanvas->GetCanvas()->Update();
   
@@ -556,7 +556,54 @@ void MGUIExpoPlotSpectrum::Update()
   
   if (m_EnergyCanvas != nullptr && m_EnergyCanvas->GetCanvas() != nullptr) {
     TCanvas* C = m_EnergyCanvas->GetCanvas();
+    
+    C->cd(1);
+    TList* primsLV = gPad->GetListOfPrimitives();
+    TObject* objLV;
+    while ((objLV = primsLV->FindObject("TPave"))){
+      primsLV->Remove(objLV);
+      delete objLV;
+    }
+    
+    TLegend* legendLV = new TLegend(0.55, 0.65, 0.88, 0.88);
+    if (m_EnergyHistogramLVInitial != nullptr && m_EnergyHistogramLVInitial->GetEntries() > 0) {
+      legendLV->AddEntry(m_EnergyHistogramLVInitial, "Strips Initial", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborLVInitial != nullptr && m_EnergyHistogramNearestNeighborLVInitial->GetEntries() > 0) {
+      legendLV->AddEntry(m_EnergyHistogramNearestNeighborLVInitial, "Nearest Neighbor Initial", "f");
+    }
+    if (m_EnergyHistogramLVFinal != nullptr && m_EnergyHistogramLVFinal->GetEntries() > 0) {
+      legendLV->AddEntry(m_EnergyHistogramLVFinal, "Strips Final", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborLVFinal != nullptr && m_EnergyHistogramNearestNeighborLVFinal->GetEntries() > 0) {
+      legendLV->AddEntry(m_EnergyHistogramNearestNeighborLVFinal, "Nearest Neighbor Final", "f");
+    }
     if (C->GetPad(1)) C->GetPad(1)->Modified();
+    
+    C->cd(2);
+    TList* primsHV = gPad->GetListOfPrimitives();
+    TObject* objHV;
+    while((objHV = primsHV->FindObject("TPave"))) {
+      primsHV->Remove(objHV); delete objHV;
+    }
+    
+    TLegend* legendHV = new TLegend(0.55, 0.65, 0.88, 0.88);
+    if (m_EnergyHistogramHVInitial != nullptr && m_EnergyHistogramHVInitial->GetEntries() > 0) {
+      legendHV->AddEntry(m_EnergyHistogramHVInitial, "Strips Initial", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborHVInitial != nullptr && m_EnergyHistogramNearestNeighborHVInitial->GetEntries() > 0) {
+      legendHV->AddEntry(m_EnergyHistogramNearestNeighborHVInitial, "Nearest Neighbor Initial", "f");
+    }
+    if (m_EnergyHistogramHVFinal != nullptr && m_EnergyHistogramHVFinal->GetEntries() > 0) {
+      legendHV->AddEntry(m_EnergyHistogramHVFinal, "Strips Final", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborHVFinal != nullptr && m_EnergyHistogramNearestNeighborHVFinal->GetEntries() > 0) {
+      legendHV->AddEntry(m_EnergyHistogramNearestNeighborHVFinal, "Nearest Neighbor Final", "f");
+    }
+    legendHV->SetBorderSize(0);
+    if (legendHV->GetNRows() > 0) {
+      legendHV->Draw();
+    }
     if (C->GetPad(2)) C->GetPad(2)->Modified();
     
     C->Modified();
@@ -573,14 +620,8 @@ void MGUIExpoPlotSpectrum::Update()
 void MGUIExpoPlotSpectrum::OnUpdateRange()
 {
   //! Update the histogram range and binning
+  // This is the buffer part of the code
 
-  //! Update the histogram range and binning
-
-  // Safety fix: If we did not buffer the data (202), we cannot rebin/redraw!
-  //if (m_PlotSpectrumMode != 202) {
-  //  return;
-  //}
-  
   double Min = m_RangeMinEntry->GetAsDouble();
   double Max = m_RangeMaxEntry->GetAsDouble();
   double Width = m_BinWidthEntry->GetAsDouble();
@@ -589,7 +630,7 @@ void MGUIExpoPlotSpectrum::OnUpdateRange()
   if (Max <= Min) return;
   if (Width <= 0.0) return;
 
-  // If Log X is requested, Min cannot be <= 0. Bump it to a small positive number.
+  // If log x then min > 0 (has to be!) 
   if (m_LogXButton->IsOn() && Min <= 0.0) {
     Min = 0.1;
   }
@@ -597,14 +638,12 @@ void MGUIExpoPlotSpectrum::OnUpdateRange()
   // Calculate bins
   int NBins = (int)((Max - Min) / Width);
    
-  // SAFETY FIX: Ensure we have at least one bin
+  // Make sure we have at least one bin
   if (NBins < 1) NBins = 1;
 
   m_Mutex.Lock();
    
   // Rebin and refill all histograms
-
-  // Helper to refill histograms
   auto RefillHist = [&](TH1D* Hist, const std::vector<double>& Buffer) {
     if (Hist != nullptr) {
       Hist->SetBins(NBins, Min, Max);
@@ -637,8 +676,8 @@ void MGUIExpoPlotSpectrum::OnUpdateRange()
     
     // LV Side
     C->cd(1);
-    gPad->SetLogx(logX); // Apply Log X
-    gPad->SetLogy(logY); // Apply Log Y
+    gPad->SetLogx(logX);
+    gPad->SetLogy(logY);
     C->GetPad(1)->Clear();
     
     THStack* LVStack = new THStack("lvStack", "LV Energy Spectrum");
@@ -655,10 +694,52 @@ void MGUIExpoPlotSpectrum::OnUpdateRange()
       LVStack->Add(m_EnergyHistogramNearestNeighborLVFinal);
     }
 
-    // Scaling to the plot with the most data :)
+    // Scaling to the plot with the most data
+    // Calculate the max Y value based ONLY on the main strip data
+    // Otherwise it scales to the nearest neighbor peak which isn't useful if we want to look at peaks
+    // TODO: @RobinAnthonyPetersen when you rebin the data the y-axis scales to the nearest neighbors not the strips, this needs to be fixed
+    double maxLV = 0.0;
+    if (m_EnergyHistogramLVInitial != nullptr) {
+      double currentMax = m_EnergyHistogramLVInitial->GetMaximum();
+      if (currentMax > maxLV) {
+        maxLV = currentMax;
+      }
+    }
+    if (m_EnergyHistogramLVFinal != nullptr) {
+      double currentMax = m_EnergyHistogramLVFinal->GetMaximum();
+      if (currentMax > maxLV) {
+        maxLV = currentMax;
+      }
+    }
+    // Force the stack to use this max, adding headroom based on log scale
+    if (maxLV > 0) {
+      if (logY) {
+        LVStack->SetMaximum(maxLV * 10.0); // 1 decade of headroom for Log
+        LVStack->SetMinimum(0.1);          // No log (0)
+      } else {
+        LVStack->SetMaximum(maxLV * 1.10); // 10% headroom for linear scale
+      }
+    }
+
     LVStack->Draw("nostack hist");
     LVStack->GetXaxis()->SetTitle("Energy [keV]");
     LVStack->GetYaxis()->SetTitle("Counts");
+    
+    TLegend* updateLegendLV = new TLegend(0.55, 0.65, 0.88, 0.88);
+    if (m_EnergyHistogramLVInitial != nullptr) {
+      updateLegendLV->AddEntry(m_EnergyHistogramLVInitial, "Strips Initial", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborLVInitial != nullptr) {
+      updateLegendLV->AddEntry(m_EnergyHistogramNearestNeighborLVInitial, "Nearest Neighbor Initial", "f");
+    }
+    if (m_EnergyHistogramLVFinal != nullptr) {
+      updateLegendLV->AddEntry(m_EnergyHistogramLVFinal, "Strips Final", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborLVFinal != nullptr) {
+      updateLegendLV->AddEntry(m_EnergyHistogramNearestNeighborLVFinal, "Nearest Neighbor Final", "f");
+    }
+    updateLegendLV->SetBorderSize(0);
+    updateLegendLV->Draw();
 
     // HV
     C->cd(2);
@@ -681,10 +762,50 @@ void MGUIExpoPlotSpectrum::OnUpdateRange()
       HVStack->Add(m_EnergyHistogramNearestNeighborHVFinal);
     }
 
-    // Scaling to the plot with the most data :)
+    // Scaling to the plot with the most data, just like for the LV side
+    // TODO: @RobinAnthonyPetersen when you rebin the data the y-axis scales to the nearest neighbors not the strips, this needs to be fixed 
+    double maxHV = 0.0;
+    if (m_EnergyHistogramHVInitial != nullptr) {
+      double currentMax = m_EnergyHistogramHVInitial->GetMaximum();
+      if (currentMax > maxHV) {
+        maxHV = currentMax;
+      }
+    }
+    if (m_EnergyHistogramHVFinal != nullptr) {
+      double currentMax = m_EnergyHistogramHVFinal->GetMaximum();
+      if (currentMax > maxHV) {
+        maxHV = currentMax;
+      }
+    }
+    // Force the stack to use this max, adding headroom based on log scale
+    if (maxHV > 0) {
+      if (logY) {
+        HVStack->SetMaximum(maxHV * 10.0); // 1 decade of headroom for Log
+        HVStack->SetMinimum(0.1);          // make sure not log(0)
+      } else {
+        HVStack->SetMaximum(maxHV * 1.10); // 10% headroom for Linear
+      }
+    }
+
     HVStack->Draw("nostack hist");
     HVStack->GetXaxis()->SetTitle("Energy [keV]");
     HVStack->GetYaxis()->SetTitle("Counts");
+    
+    TLegend* updateLegendHV = new TLegend(0.55, 0.65, 0.88, 0.88);
+    if (m_EnergyHistogramHVInitial != nullptr) {
+      updateLegendHV->AddEntry(m_EnergyHistogramHVInitial, "Strips Initial", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborHVInitial != nullptr) {
+      updateLegendHV->AddEntry(m_EnergyHistogramNearestNeighborHVInitial, "Nearest Neighbor Initial", "f");
+    }
+    if (m_EnergyHistogramHVFinal != nullptr) {
+      updateLegendHV->AddEntry(m_EnergyHistogramHVFinal, "Strips Final", "f");
+    }
+    if (m_EnergyHistogramNearestNeighborHVFinal != nullptr) {
+      updateLegendHV->AddEntry(m_EnergyHistogramNearestNeighborHVFinal, "Nearest Neighbor Final", "f");
+    }
+    updateLegendHV->SetBorderSize(0);
+    updateLegendHV->Draw();
     
     C->Modified();
     C->Update();

--- a/src/MGUIOptionsEnergyCalibrationUniversal.cxx
+++ b/src/MGUIOptionsEnergyCalibrationUniversal.cxx
@@ -131,7 +131,7 @@ void MGUIOptionsEnergyCalibrationUniversal::Create()
   ToggleRadioButtons(static_cast<int>(NearestNeighborCutMode));
   
   
-  // Plot spectrum
+  // Plot spectrum options 
   TGLabel* PlotSpectrumLabel = new TGLabel(m_OptionsFrame, "Please choose a spectrum plotting and memory option:");
   m_OptionsFrame->AddFrame(PlotSpectrumLabel, LabelLayout);
     
@@ -282,12 +282,12 @@ bool MGUIOptionsEnergyCalibrationUniversal::OnApply()
   
   // Plot spectrum
   if (m_PlotSpectrumNoneRB->GetState() == kButtonDown) {
-    dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MPlotSpectrumModes::e_PlotNone);
-  } else if (m_PlotSpectrumNoBufferRB->GetState() == kButtonDown) {
-    dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MPlotSpectrumModes::e_PlotNoBuffer);
-  } else if (m_PlotSpectrumWithBufferRB->GetState() == kButtonDown) {
-    dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MPlotSpectrumModes::e_PlotWithBuffer);
-  }
+      dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MEnergyCalibrationPlotSpectrumModes::e_PlotNone);
+    } else if (m_PlotSpectrumNoBufferRB->GetState() == kButtonDown) {
+      dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MEnergyCalibrationPlotSpectrumModes::e_PlotNoBuffer);
+    } else if (m_PlotSpectrumWithBufferRB->GetState() == kButtonDown) {
+      dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MEnergyCalibrationPlotSpectrumModes::e_PlotWithBuffer);
+    }
 
   return true;
 }

--- a/src/MGUIOptionsEnergyCalibrationUniversal.cxx
+++ b/src/MGUIOptionsEnergyCalibrationUniversal.cxx
@@ -129,7 +129,30 @@ void MGUIOptionsEnergyCalibrationUniversal::Create()
   
   MNearestNeighborCutModes NearestNeighborCutMode = dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->GetNearestNeighborCutMode();
   ToggleRadioButtons(static_cast<int>(NearestNeighborCutMode));
+  
+  
+  // Plot spectrum
+  TGLabel* PlotSpectrumLabel = new TGLabel(m_OptionsFrame, "Please choose a spectrum plotting and memory option:");
+  m_OptionsFrame->AddFrame(PlotSpectrumLabel, LabelLayout);
     
+  // Don't plot
+  m_PlotSpectrumNoneRB = new TGRadioButton(m_OptionsFrame, "Do not plot spectrum", c_PlotSpectrumNone);
+  m_PlotSpectrumNoneRB->Associate(this);
+  m_OptionsFrame->AddFrame(m_PlotSpectrumNoneRB, RBLayout);
+
+  // Plot without the buffer
+  m_PlotSpectrumNoBufferRB = new TGRadioButton(m_OptionsFrame, "Plot spectrum without buffering data (uses less memory)", c_PlotSpectrumNoBuffer);
+  m_PlotSpectrumNoBufferRB->Associate(this);
+  m_OptionsFrame->AddFrame(m_PlotSpectrumNoBufferRB, RBLayout);
+    
+  // Plot with the buffer
+  m_PlotSpectrumWithBufferRB = new TGRadioButton(m_OptionsFrame, "Plot spectrum with buffered data (warning: uses x2 memory!)", c_PlotSpectrumWithBuffer);
+  m_PlotSpectrumWithBufferRB->Associate(this);
+  m_OptionsFrame->AddFrame(m_PlotSpectrumWithBufferRB, RBLayout);
+
+  int PlotMode = dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->GetPlotSpectrumMode();
+  ToggleRadioButtons(PlotMode);
+  
 
   PostCreate();
 }
@@ -241,6 +264,15 @@ bool MGUIOptionsEnergyCalibrationUniversal::OnApply()
   }
 
   dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetNearestNeighborThreshold(m_SlowThresholdCutNearestNeighborFixedValue->GetAsDouble());
+  
+  // Plot spectrum
+  if (m_PlotSpectrumNoneRB->GetState() == kButtonDown) {
+    dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MPlotSpectrumModes::e_PlotNone);
+  } else if (m_PlotSpectrumNoBufferRB->GetState() == kButtonDown) {
+    dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MPlotSpectrumModes::e_PlotNoBuffer);
+  } else if (m_PlotSpectrumWithBufferRB->GetState() == kButtonDown) {
+    dynamic_cast<MModuleEnergyCalibrationUniversal*>(m_Module)->SetPlotSpectrumMode(MPlotSpectrumModes::e_PlotWithBuffer);
+  }
 
   return true;
 }

--- a/src/MGUIOptionsEnergyCalibrationUniversal.cxx
+++ b/src/MGUIOptionsEnergyCalibrationUniversal.cxx
@@ -233,6 +233,21 @@ void MGUIOptionsEnergyCalibrationUniversal::ToggleRadioButtons(int WidgetID)
       m_SlowThresholdCutNearestNeighborFixedValue->SetEnabled(true);
     }
   }
+  
+  // Plot spectrum
+  if (WidgetID == c_PlotSpectrumNone) {
+    m_PlotSpectrumNoneRB->SetState(kButtonDown);
+    m_PlotSpectrumNoBufferRB->SetState(kButtonUp);
+    m_PlotSpectrumWithBufferRB->SetState(kButtonUp);
+  } else if (WidgetID == c_PlotSpectrumNoBuffer) {
+    m_PlotSpectrumNoneRB->SetState(kButtonUp);
+    m_PlotSpectrumNoBufferRB->SetState(kButtonDown);
+    m_PlotSpectrumWithBufferRB->SetState(kButtonUp);
+  } else if (WidgetID == c_PlotSpectrumWithBuffer) {
+    m_PlotSpectrumNoneRB->SetState(kButtonUp);
+    m_PlotSpectrumNoBufferRB->SetState(kButtonUp);
+    m_PlotSpectrumWithBufferRB->SetState(kButtonDown);
+  }
 }
 
 

--- a/src/MGUIOptionsTACcut.cxx
+++ b/src/MGUIOptionsTACcut.cxx
@@ -85,6 +85,27 @@ void MGUIOptionsTACcut::Create()
   TGLayoutHints* TACCutLayout = new TGLayoutHints(kLHintsTop | kLHintsCenterX | kLHintsExpandX, 10, 10, 10, 10);
   m_OptionsFrame->AddFrame(m_TACCutFileSelector, TACCutLayout);
   
+  TGLayoutHints* LabelLayout = new TGLayoutHints(kLHintsTop | kLHintsLeft, 10, 10, 10, 10);
+  TGLayoutHints* RBLayout = new TGLayoutHints(kLHintsLeft | kLHintsTop, 40, 10, 2, 0);
+
+  TGLabel* PlotSpectrumLabel = new TGLabel(m_OptionsFrame, "Please choose a spectrum plotting and memory option:");
+  m_OptionsFrame->AddFrame(PlotSpectrumLabel, LabelLayout);
+      
+  m_PlotSpectrumNoneRB = new TGRadioButton(m_OptionsFrame, "Do not plot spectrum", c_PlotSpectrumNone);
+  m_PlotSpectrumNoneRB->Associate(this);
+  m_OptionsFrame->AddFrame(m_PlotSpectrumNoneRB, RBLayout);
+
+  m_PlotSpectrumNoBufferRB = new TGRadioButton(m_OptionsFrame, "Plot spectrum without buffering data", c_PlotSpectrumNoBuffer);
+  m_PlotSpectrumNoBufferRB->Associate(this);
+  m_OptionsFrame->AddFrame(m_PlotSpectrumNoBufferRB, RBLayout);
+      
+  m_PlotSpectrumWithBufferRB = new TGRadioButton(m_OptionsFrame, "Plot spectrum with buffered data", c_PlotSpectrumWithBuffer);
+  m_PlotSpectrumWithBufferRB->Associate(this);
+  m_OptionsFrame->AddFrame(m_PlotSpectrumWithBufferRB, RBLayout);
+
+  int PlotMode = static_cast<int>(dynamic_cast<MModuleTACcut*>(m_Module)->GetPlotSpectrumMode());
+  ToggleRadioButtons(PlotMode);
+  
   PostCreate();
 }
 
@@ -94,14 +115,15 @@ void MGUIOptionsTACcut::Create()
 
 bool MGUIOptionsTACcut::ProcessMessage(long Message, long Parameter1, long Parameter2)
 {
-  // Modify here if you have more buttons
-
   bool Status = true;
   
   switch (GET_MSG(Message)) {
   case kC_COMMAND:
     switch (GET_SUBMSG(Message)) {
     case kCM_BUTTON:
+      break;
+    case kCM_RADIOBUTTON:
+      ToggleRadioButtons(Parameter1);
       break;
     default:
       break;
@@ -115,7 +137,6 @@ bool MGUIOptionsTACcut::ProcessMessage(long Message, long Parameter1, long Param
     return false;
   }
 
-  // Call also base class
   return MGUIOptions::ProcessMessage(Message, Parameter1, Parameter2);
 }
 
@@ -128,8 +149,35 @@ bool MGUIOptionsTACcut::OnApply()
   // Store the data in the module
   dynamic_cast<MModuleTACcut*>(m_Module)->SetTACCalFileName(m_TACCalFileSelector->GetFileName());
   dynamic_cast<MModuleTACcut*>(m_Module)->SetTACCutFileName(m_TACCutFileSelector->GetFileName());
+  
+  if (m_PlotSpectrumNoneRB->GetState() == kButtonDown) {
+    dynamic_cast<MModuleTACcut*>(m_Module)->SetPlotSpectrumMode(MTACPlotSpectrumModes::e_PlotNone);
+  } else if (m_PlotSpectrumNoBufferRB->GetState() == kButtonDown) {
+    dynamic_cast<MModuleTACcut*>(m_Module)->SetPlotSpectrumMode(MTACPlotSpectrumModes::e_PlotNoBuffer);
+  } else if (m_PlotSpectrumWithBufferRB->GetState() == kButtonDown) {
+    dynamic_cast<MModuleTACcut*>(m_Module)->SetPlotSpectrumMode(MTACPlotSpectrumModes::e_PlotWithBuffer);
+  }
 
   return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+void MGUIOptionsTACcut::ToggleRadioButtons(int WidgetID)
+{
+  if (WidgetID == c_PlotSpectrumNone) {
+    m_PlotSpectrumNoneRB->SetState(kButtonDown);
+    m_PlotSpectrumNoBufferRB->SetState(kButtonUp);
+    m_PlotSpectrumWithBufferRB->SetState(kButtonUp);
+  } else if (WidgetID == c_PlotSpectrumNoBuffer) {
+    m_PlotSpectrumNoneRB->SetState(kButtonUp);
+    m_PlotSpectrumNoBufferRB->SetState(kButtonDown);
+    m_PlotSpectrumWithBufferRB->SetState(kButtonUp);
+  } else if (WidgetID == c_PlotSpectrumWithBuffer) {
+    m_PlotSpectrumNoneRB->SetState(kButtonUp);
+    m_PlotSpectrumNoBufferRB->SetState(kButtonUp);
+    m_PlotSpectrumWithBufferRB->SetState(kButtonDown);
+  }
 }
 
 

--- a/src/MGUIOptionsTACcut.cxx
+++ b/src/MGUIOptionsTACcut.cxx
@@ -165,6 +165,7 @@ bool MGUIOptionsTACcut::OnApply()
 
 void MGUIOptionsTACcut::ToggleRadioButtons(int WidgetID)
 {
+  // Plot spectrum
   if (WidgetID == c_PlotSpectrumNone) {
     m_PlotSpectrumNoneRB->SetState(kButtonDown);
     m_PlotSpectrumNoBufferRB->SetState(kButtonUp);

--- a/src/MModuleEnergyCalibrationUniversal.cxx
+++ b/src/MModuleEnergyCalibrationUniversal.cxx
@@ -118,21 +118,25 @@ MModuleEnergyCalibrationUniversal::~MModuleEnergyCalibrationUniversal()
 
 void MModuleEnergyCalibrationUniversal::CreateExpos()
 {
-  // If they are already created, return
+  // 1. If the window ALREADY exists from a previous run, just update the setting and return.
+  // (If they switched to "No Plot", the window will stay open but go to sleep).
   if (m_Expos.size() != 0) {
+    if (m_ExpoSpectrum != nullptr) {
+      m_ExpoSpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
+    }
     return;
   }
 
-  // Set the histogram display
-  //m_ExpoEnergyCalibration = new MGUIExpoEnergyCalibration(this);
-  //m_ExpoEnergyCalibration->SetEnergyHistogramParameters(200, 0, 2000);
-  //m_Expos.push_back(m_ExpoEnergyCalibration);
-  
-  // Updated: Set the histogram display
+  // 2. If it DOES NOT exist yet, and they selected "No Plot", skip creation entirely!
+  if (m_PlotSpectrumMode == MPlotSpectrumModes::e_PlotNone) {
+    return;
+  }
+
+  // 3. Otherwise, create it for the very first time!
   m_ExpoSpectrum = new MGUIExpoPlotSpectrum(this);
+  m_ExpoSpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
   m_ExpoSpectrum->SetEnergyHistogramParameters(200, 0, 2000);
   m_Expos.push_back(m_ExpoSpectrum);
-  
 }
 
 

--- a/src/MModuleEnergyCalibrationUniversal.cxx
+++ b/src/MModuleEnergyCalibrationUniversal.cxx
@@ -98,6 +98,9 @@ MModuleEnergyCalibrationUniversal::MModuleEnergyCalibrationUniversal() : MModule
   // Nearest Neighbor threshold (-1000 because we don't want to default to cut neg values) 
   m_NearestNeighborCutMode = MNearestNeighborCutModes::e_Ignore;
   m_NearestNeighborThreshold = -1000.0;
+  
+  // Plot spectrum
+  m_PlotSpectrumMode = MPlotSpectrumModes::e_PlotNone;
 
 }
 
@@ -573,6 +576,10 @@ bool MModuleEnergyCalibrationUniversal::ReadXmlConfiguration(MXmlNode* Node)
   if (NearestNeighborThresholdNode != nullptr) {
     m_NearestNeighborThreshold = NearestNeighborThresholdNode->GetValueAsDouble();
   }
+  MXmlNode* PlotSpectrumModeNode = Node->GetNode("PlotSpectrumMode");
+  if (PlotSpectrumModeNode != nullptr) {
+    m_PlotSpectrumMode = static_cast<MPlotSpectrumModes>(PlotSpectrumModeNode->GetValueAsInt());
+  }
 
   return true;
 }
@@ -592,6 +599,7 @@ MXmlNode* MModuleEnergyCalibrationUniversal::CreateXmlConfiguration()
   new MXmlNode(Node, "SlowThresholdCutThresholdFileName", m_SlowThresholdCutFileName);
   new MXmlNode(Node, "NearestNeighborCutMode", static_cast<int>(m_NearestNeighborCutMode));
   new MXmlNode(Node, "NearestNeighborThreshold", m_NearestNeighborThreshold);
+  new MXmlNode(Node, "PlotSpectrumMode", static_cast<int>(m_PlotSpectrumMode));
 
   return Node;
 }

--- a/src/MModuleEnergyCalibrationUniversal.cxx
+++ b/src/MModuleEnergyCalibrationUniversal.cxx
@@ -100,7 +100,7 @@ MModuleEnergyCalibrationUniversal::MModuleEnergyCalibrationUniversal() : MModule
   m_NearestNeighborThreshold = -1000.0;
   
   // Plot spectrum
-  m_PlotSpectrumMode = MPlotSpectrumModes::e_PlotNone;
+  m_PlotSpectrumMode = MEnergyCalibrationPlotSpectrumModes::e_PlotNone;
 
 }
 
@@ -118,8 +118,8 @@ MModuleEnergyCalibrationUniversal::~MModuleEnergyCalibrationUniversal()
 
 void MModuleEnergyCalibrationUniversal::CreateExpos()
 {
-  // 1. If the window ALREADY exists from a previous run, just update the setting and return.
-  // (If they switched to "No Plot", the window will stay open but go to sleep).
+  // If the window already exists from a previous run, just update the setting and return
+  // If they switched to "No Plot", the window will stay open but go to sleep
   if (m_Expos.size() != 0) {
     if (m_ExpoSpectrum != nullptr) {
       m_ExpoSpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
@@ -127,12 +127,12 @@ void MModuleEnergyCalibrationUniversal::CreateExpos()
     return;
   }
 
-  // 2. If it DOES NOT exist yet, and they selected "No Plot", skip creation entirely!
-  if (m_PlotSpectrumMode == MPlotSpectrumModes::e_PlotNone) {
+  // If it the window does not exist yet, and they selected "No Plot", skip creating the plot entirely
+  if (m_PlotSpectrumMode == MEnergyCalibrationPlotSpectrumModes::e_PlotNone) {
     return;
   }
 
-  // 3. Otherwise, create it for the very first time!
+  // If window doesn't exist, create it for the very first time
   m_ExpoSpectrum = new MGUIExpoPlotSpectrum(this);
   m_ExpoSpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
   m_ExpoSpectrum->SetEnergyHistogramParameters(200, 0, 2000);
@@ -582,7 +582,7 @@ bool MModuleEnergyCalibrationUniversal::ReadXmlConfiguration(MXmlNode* Node)
   }
   MXmlNode* PlotSpectrumModeNode = Node->GetNode("PlotSpectrumMode");
   if (PlotSpectrumModeNode != nullptr) {
-    m_PlotSpectrumMode = static_cast<MPlotSpectrumModes>(PlotSpectrumModeNode->GetValueAsInt());
+    m_PlotSpectrumMode = static_cast<MEnergyCalibrationPlotSpectrumModes>(PlotSpectrumModeNode->GetValueAsInt());
   }
 
   return true;

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -88,6 +88,7 @@ MModuleTACcut::MModuleTACcut() : MModule()
   
   // For plotting the spectrum, default it to don't plot
   m_PlotSpectrumMode = MTACPlotSpectrumModes::e_PlotNone;
+  m_ExpoEnergySpectrum = nullptr;
 }
 
 
@@ -136,10 +137,17 @@ bool MModuleTACcut::Initialize()
 
 void MModuleTACcut::CreateExpos()
 {
-  // If windows already exist, update the settings and exit
-  if (HasExpos() == true) {
+  // If the window already exists from a previous run, just update the setting and return
+  // If they switched to "No Plot", the window will stay open but go to sleep
+  if (m_Expos.size() != 0) {
     if (m_ExpoEnergySpectrum != nullptr) {
       m_ExpoEnergySpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
+    }
+    else if (m_PlotSpectrumMode != MTACPlotSpectrumModes::e_PlotNone) {
+      m_ExpoEnergySpectrum = new MGUIExpoPlotSpectrum(this);
+      m_ExpoEnergySpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
+      m_ExpoEnergySpectrum->SetEnergyHistogramParameters(200, 0, 1000);
+      m_Expos.push_back(m_ExpoEnergySpectrum);
     }
     return;
   }
@@ -157,7 +165,7 @@ void MModuleTACcut::CreateExpos()
   if (m_PlotSpectrumMode != MTACPlotSpectrumModes::e_PlotNone) {
     m_ExpoEnergySpectrum = new MGUIExpoPlotSpectrum(this);
     m_ExpoEnergySpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
-    m_ExpoEnergySpectrum->SetEnergyHistogramParameters(200, 0, 1000); // Adjust bounds as needed
+    m_ExpoEnergySpectrum->SetEnergyHistogramParameters(200, 0, 1000);
     m_Expos.push_back(m_ExpoEnergySpectrum);
   }
 }
@@ -176,7 +184,7 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
     char Side = SH->IsLowVoltageStrip() ? 'l' : 'h';
     
     // This captures every single hit before we delete any of them.
-    if (HasExpos()) {
+    if (HasExpos() && m_ExpoEnergySpectrum != nullptr) {
       m_ExpoEnergySpectrum->AddEnergyInitial(SH->GetEnergy(), SH->IsNearestNeighbor(), SH->IsLowVoltageStrip());
     }
 
@@ -265,9 +273,13 @@ bool MModuleTACcut::AnalyzeEvent(MReadOutAssembly* Event)
         // }
         if ((SHTiming < TotalOffset) || (SHTiming < MaxTAC - HardCoincidenceWindow)) { //Eliminating the upper boundary condition and just using one cut based on the coincidence window
           Passed = false;
+        
         } else if (HasExpos()==true) {
           m_ExpoTACcut->AddTAC(DetID, SHTiming);
-          m_ExpoEnergySpectrum->AddEnergyFinal(SH->GetEnergy(), SH->IsNearestNeighbor(), SH->IsLowVoltageStrip());
+          // Only plot the spectrum if the energy spectrum window was actually created
+          if (m_ExpoEnergySpectrum != nullptr) {
+            m_ExpoEnergySpectrum->AddEnergyFinal(SH->GetEnergy(), SH->IsNearestNeighbor(), SH->IsLowVoltageStrip());
+          }
         }
       }
     }
@@ -324,14 +336,11 @@ bool MModuleTACcut::ReadXmlConfiguration(MXmlNode* Node)
     SetTACCutFileName(TACCutFileNameNode->GetValue());
   }
   
-  // In ReadXmlConfiguration():
-  if (Node->GetName() == "PlotSpectrumMode") {
-    m_PlotSpectrumMode = static_cast<MTACPlotSpectrumModes>(Node->GetValueAsInt());
+  MXmlNode* PlotSpectrumModeNode = Node->GetNode("PlotSpectrumMode");
+  if (PlotSpectrumModeNode != nullptr) {
+    m_PlotSpectrumMode = static_cast<MTACPlotSpectrumModes>(PlotSpectrumModeNode->GetValueAsInt());
   }
-
-  // In CreateXmlConfiguration():
-  new MXmlNode(Node, "PlotSpectrumMode", static_cast<int>(m_PlotSpectrumMode));
-
+  
   return true;
 }
 
@@ -347,6 +356,7 @@ MXmlNode* MModuleTACcut::CreateXmlConfiguration()
   
   new MXmlNode(Node, "TACCalFileName", m_TACCalFile);
   new MXmlNode(Node, "TACCutFileName", m_TACCutFile);
+  new MXmlNode(Node, "PlotSpectrumMode", static_cast<int>(m_PlotSpectrumMode));
 
   return Node;
 }

--- a/src/MModuleTACcut.cxx
+++ b/src/MModuleTACcut.cxx
@@ -85,6 +85,9 @@ MModuleTACcut::MModuleTACcut() : MModule()
   m_AllowMultipleInstances = true;
 
   m_SideToIndex = {{'l', 0}, {'h', 1}, {'0', 0}, {'1', 1}, {'p', 0}, {'n', 1}};
+  
+  // For plotting the spectrum, default it to don't plot
+  m_PlotSpectrumMode = MTACPlotSpectrumModes::e_PlotNone;
 }
 
 
@@ -133,11 +136,15 @@ bool MModuleTACcut::Initialize()
 
 void MModuleTACcut::CreateExpos()
 {
-  // Create all expos
+  // If windows already exist, update the settings and exit
+  if (HasExpos() == true) {
+    if (m_ExpoEnergySpectrum != nullptr) {
+      m_ExpoEnergySpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
+    }
+    return;
+  }
 
-  if (HasExpos() == true) return;
-
-  // Set the histogram display
+  // TAC cut window
   m_ExpoTACcut = new MGUIExpoTACcut(this);
   m_ExpoTACcut->SetTACHistogramArrangement(m_DetectorIDs);
   for (unsigned int i = 0; i < m_DetectorIDs.size(); ++i) {
@@ -146,9 +153,13 @@ void MModuleTACcut::CreateExpos()
   }
   m_Expos.push_back(m_ExpoTACcut);
   
-  // Set the energy histogram display
-  m_ExpoEnergySpectrum = new MGUIExpoPlotSpectrum(this);
-  m_Expos.push_back(m_ExpoEnergySpectrum);
+  // spectrum plot
+  if (m_PlotSpectrumMode != MTACPlotSpectrumModes::e_PlotNone) {
+    m_ExpoEnergySpectrum = new MGUIExpoPlotSpectrum(this);
+    m_ExpoEnergySpectrum->SetPlotMode(static_cast<int>(m_PlotSpectrumMode));
+    m_ExpoEnergySpectrum->SetEnergyHistogramParameters(200, 0, 1000); // Adjust bounds as needed
+    m_Expos.push_back(m_ExpoEnergySpectrum);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -312,6 +323,14 @@ bool MModuleTACcut::ReadXmlConfiguration(MXmlNode* Node)
   if (TACCutFileNameNode != nullptr) {
     SetTACCutFileName(TACCutFileNameNode->GetValue());
   }
+  
+  // In ReadXmlConfiguration():
+  if (Node->GetName() == "PlotSpectrumMode") {
+    m_PlotSpectrumMode = static_cast<MTACPlotSpectrumModes>(Node->GetValueAsInt());
+  }
+
+  // In CreateXmlConfiguration():
+  new MXmlNode(Node, "PlotSpectrumMode", static_cast<int>(m_PlotSpectrumMode));
 
   return true;
 }


### PR DESCRIPTION
This update adds a new plotting tool, MGUIExpoPlotSpectrum, to plot the spectrum as it moves through the pipeline. The function to plot the spectrum using MGUIExpoPlotSpectrum can be called in any module. This is what the new plotting looks like (comparing before and after the TAC cut in this example): 

<img width="896" height="605" alt="Screenshot 2026-03-04 at 9 11 07 PM" src="https://github.com/user-attachments/assets/247ce0e6-db6d-436d-97f9-99231e3a4e53" />

Key Features:
* Can compares 'Initial' and 'Final' energy distributions side-by-side to verify that cuts are working as expected.
* Separates LV and HV hits
* Plots Strips and Nearest Neighbor data separately 
* Once added to a module, the user can choose whether or not to plot the data. There are three options:   
    - 'No Plot', the data is not plotted. This is best for running from the command line. 
    - 'No Buffer' for a live look at the spectrum during a run. 
    - 'With Buffer' if you have the buffer all the data is saved as a copy so if you changed something like the bin size, all the data is reloaded from the buffer and plotted. This means you can look at the data after the run finishes. But it also means that x2 the memory is used. 

This is what the plotting options look like (added to the TAC cut GUI option): 

<img width="724" height="386" alt="Screenshot 2026-03-04 at 9 04 06 PM" src="https://github.com/user-attachments/assets/992709d5-ef71-418e-b125-c432f666f1fd" />


The tool is integrated into the Energy Calibration Universal and TAC Calibration modules, with all plotting preferences and modes saved directly to the XML configuration files.