### PR TITLE
ADD: Support reading the new compact strip map format

### DIFF
--- a/src/MStripMap.cxx
+++ b/src/MStripMap.cxx
@@ -79,6 +79,7 @@ bool MStripMap::Open(MString FileName)
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
     if (Parser.GetTokenizerAt(i)->GetNTokens() == 0) continue;
     if (Parser.GetTokenizerAt(i)->GetTokenAtAsString(0).BeginsWith("#") == true) continue;
+    // Strip map format 1 (with 9 columns)
     if (Parser.GetTokenizerAt(i)->GetNTokens() == 9) {
       MSingleStripMapping SM;
       SM.m_ReadOutID = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(0);
@@ -90,6 +91,23 @@ bool MStripMap::Open(MString FileName)
       SM.m_DetectorID = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(6);
       SM.m_IsLowVoltage = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(7) == 0 ? true : false;
       SM.m_StripNumber = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(8);
+      m_StripMappings.push_back(SM);
+    }
+    // Strip map format 2 (with 4 columns)
+    if (Parser.GetTokenizerAt(i)->GetNTokens() == 4) {
+      MSingleStripMapping SM;
+      SM.m_ReadOutID = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(0);
+      SM.m_DetectorID = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(1);
+      SM.m_IsLowVoltage = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(2) == 0 ? true : false;
+      SM.m_StripNumber = Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(3);
+      
+      // Infer the rest of the information from the ReadOutID
+      SM.m_RTB = (SM.m_ReadOutID >> 8) & 0x01;
+      SM.m_DRM = (SM.m_ReadOutID >> 7) & 0x01;
+      SM.m_IsPrimary = (SM.m_ReadOutID >> 6) & 0x01;
+      SM.m_ASICID = (SM.m_ReadOutID >> 5) & 0x01;
+      SM.m_ChannelID = SM.m_ReadOutID & 0x1F;
+
       m_StripMappings.push_back(SM);
     }
   }


### PR DESCRIPTION
`nuclearizer` currently only supports strip map files that have 9 columns.
Example file: [strip_map_priLV_June2025.map](https://github.com/user-attachments/files/25803654/strip_map_priLV_June2025.csv)
```
# Columns are strip_id, rtb, drm, is_primary, asic, channel, detector, side (0=LV, 1=HV), strip
0 0 0 0 0 0 0 1 32
1 0 0 0 0 1 0 1 33
2 0 0 0 0 2 0 1 34
3 0 0 0 0 3 0 1 35
...
```

Some of these columns are redundant, as the information can be retrieved from the first column `strip_id`.
This allows for defining compact strip maps, excluding the columns with redundant information.
Example file: [strip_map_priLV_Feb2026.map](https://github.com/user-attachments/files/25803670/strip_map_priLV_Feb2026.csv)
```
# Columns are strip_id, detector, side (0=LV, 1=HV), strip
0 0 1 32
1 0 1 33
2 0 1 34
3 0 1 35
...
```

NRL is using the compact strip map format as default, and we should allow for `nuclearizer` to be able to read the new file format too. 

This PR now also allows reading strip map files in the reduced 4-column format.

I tested that this code is doing the correct thing by reading the same HDF5 file using both strip maps and validating that the output ROA files are identical.



