### PR TITLE
[DEE] Implement inverse energy calibration

### DIFF
--- a/include/MSubModuleStripReadout.h
+++ b/include/MSubModuleStripReadout.h
@@ -17,9 +17,9 @@
 
 
 // Standard libs:
+#include <map>
 
 // ROOT libs:
-#include <map>
 #include "TF1.h"
 
 // MEGAlib libs:

--- a/include/MSubModuleStripReadout.h
+++ b/include/MSubModuleStripReadout.h
@@ -19,10 +19,13 @@
 // Standard libs:
 
 // ROOT libs:
+#include <map>
+#include "TF1.h"
 
 // MEGAlib libs:
 #include "MGlobal.h"
 #include "MSubModule.h"
+#include "MReadOutElementDoubleStrip.h"
 
 // Forward declarations:
 
@@ -87,6 +90,12 @@ class MSubModuleStripReadout : public MSubModule
  private:
   //! Energy calibration file name
   MString m_EnergyCalibrationFileName;
+  
+  //! Name of the strip map
+  std::map<MReadOutElementDoubleStrip, TF1*> m_Calibration;
+  
+  //! Make value of the ADC units
+  double m_MaxADCRange;
 
 
 

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -185,51 +185,29 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
 
-  // Get low voltage hits
-  list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
-  for (MDEEStripHit& SH: LVHits) {
+  // Get low-voltage and high-voltage hits
+  for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
     
-    // Look up the fit using the ecal
-    TF1* Fit = m_Calibration[SH.m_ROE];
-
-    if (Fit != nullptr) {
-      // Run it in reverse, using ROOT's poly inverter (keV -> ADC)
-      double calculatedADC = Fit->GetX(SH.m_Energy);
-      
-      // Apply hardware limits
-      if (calculatedADC > m_MaxADCRange) calculatedADC = m_MaxADCRange;
-      if (calculatedADC < 0) calculatedADC = 0;
-      
-      SH.m_ADC = static_cast<unsigned int>(calculatedADC);
-      
-    } else {
-      // If no calibration exists in the .ecal file for this strip set it to ADC value of 0
-      if (g_Verbosity >= c_Warning) cout << m_Name << ": No inverse calibration found for LV element " << SH.m_ROE << endl;
-      SH.m_ADC = 0;
-    }
-  }
-
-  // Now do high voltage strips
-  list<MDEEStripHit>& HVHits = Event->GetDEEStripHitHVListReference();
-  for (MDEEStripHit& SH: HVHits) {
+    for (MDEEStripHit& SH : *Hits) {
     
-    // Find the fit
-    TF1* Fit = m_Calibration[SH.m_ROE];
+      // Look up the fit using the ecal
+      TF1* Fit = m_Calibration[SH.m_ROE];
 
-    if (Fit != nullptr) {
-      // keV -> ADC
-      double calculatedADC = Fit->GetX(SH.m_Energy);
-      
-      // Apply hardware limits
-      if (calculatedADC > m_MaxADCRange) calculatedADC = m_MaxADCRange;
-      if (calculatedADC < 0) calculatedADC = 0;
-      
-      SH.m_ADC = static_cast<unsigned int>(calculatedADC);
-      
-    } else {
-      // If no calibration exists in the .ecal file for this strip set it to ADC value of 0
-      if (g_Verbosity >= c_Warning) cout << m_Name << ": No inverse calibration found for HV element " << SH.m_ROE << endl;
-      SH.m_ADC = 0;
+      if (Fit != nullptr) {
+        // Run it in reverse, using ROOT's poly inverter (keV -> ADC), in the allowed ADC range
+        double calculatedADC = Fit->GetX(SH.m_Energy, 0., m_MaxADCRange);
+        
+        // Apply hardware limits
+        if (calculatedADC > m_MaxADCRange) calculatedADC = m_MaxADCRange;
+        if (calculatedADC < 0) calculatedADC = 0;
+        
+        SH.m_ADC = static_cast<unsigned int>(calculatedADC);
+        
+      } else {
+        // If no calibration exists in the .ecal file for this strip set it to ADC value of 0
+        if (g_Verbosity >= c_Warning) cout << m_Name << ": No inverse calibration found for element " << SH.m_ROE << endl;
+        SH.m_ADC = 0;
+      }
     }
   }
 

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -29,9 +29,13 @@
 // Standard libs:
 
 // ROOT libs:
+#include "TF1.h"
+#include <map>
 
 // MEGAlib libs:
 #include "MSubModule.h"
+#include "MParser.h"
+#include "MReadOutElementDoubleStrip.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -52,6 +56,9 @@ MSubModuleStripReadout::MSubModuleStripReadout() : MSubModule()
   m_Name = "DEE strip readout module";
 
   m_EnergyCalibrationFileName = "";
+  
+  // Max value for the ADC range (14-bit ADC maximum)
+  m_MaxADCRange = 16383;
 }
 
 
@@ -71,8 +78,94 @@ bool MSubModuleStripReadout::Initialize()
 {
   // Initialize the module
 
+  // Check if we have a file
+  if (m_EnergyCalibrationFileName == "") {
+    if (g_Verbosity >= c_Error) {
+      cout << m_Name << ": No energy calibration file specified." << endl;
+    }
+    return false;
+  }
+
+  // Opoen ecal file
+  MParser Parser;
+  if (Parser.Open(m_EnergyCalibrationFileName, MFile::c_Read) == false) {
+    if (g_Verbosity >= c_Error) {
+      cout << m_Name << ": Unable to open calibration file " << m_EnergyCalibrationFileName << endl;
+    }
+    return false;
+  }
+
+  // Create the map (smae as the Universal Energy Calibrator)
+  map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine;
+
+  // Add case for double wide strips
+  for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
+    if (Parser.GetTokenizerAt(i)->GetNTokens() < 2) continue;
+
+    if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CM") == true &&
+        Parser.GetTokenizerAt(i)->IsTokenAt(1, "dss") == true) {
+
+      MReadOutElementDoubleStrip R;
+      R.SetDetectorID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(2));
+      R.SetStripID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(3));
+      R.IsLowVoltageStrip((Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "p") ||
+                          (Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "l"));
+      
+      CM_ROEToLine[R] = i;
+    }
+  }
+
+  // Get the parameters and use ROOTs built in TF1 to invert the polynomials
+  for (auto CM : CM_ROEToLine) {
+    unsigned int Pos = 5;
+    MString CalibratorType = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsString(Pos);
+    CalibratorType.ToLower();
+
+    if (CalibratorType == "poly1") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., m_MaxADCRange);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+
+      m_Calibration[CM.first] = melinatorfit;
+    }
+    else if (CalibratorType == "poly2") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., m_MaxADCRange);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+      melinatorfit->FixParameter(2, a2);
+
+      m_Calibration[CM.first] = melinatorfit;
+    }
+    else if (CalibratorType == "poly3") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., m_MaxADCRange);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+      melinatorfit->FixParameter(2, a2);
+      melinatorfit->FixParameter(3, a3);
+
+      m_Calibration[CM.first] = melinatorfit;
+    }
+    //TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
+    // So far only added these ones because these are the ones we use for the ecals
+  }
+
   return MSubModule::Initialize();
 }
+
+
+////////////////////////////////////////////////////////////////////////////////
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -88,25 +181,62 @@ void MSubModuleStripReadout::Clear()
 
 ////////////////////////////////////////////////////////////////////////////////
 
-
 bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
-  // Main data analysis routine, which updates the event to a new level 
+  // Main data analysis routine, which updates the event to a new level
 
-  // Dummy code:
+  // Get low voltage hits
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
   for (MDEEStripHit& SH: LVHits) {
-    SH.m_ADC = 2000 + 4*SH.m_Energy;
-    if (SH.m_ADC > 16383) SH.m_ADC = 16383;
+    
+    // Look up the fit using the ecal
+    TF1* Fit = m_Calibration[SH.m_ROE];
+
+    if (Fit != nullptr) {
+      // Run it in reverse, using ROOT's poly inverter (keV -> ADC)
+      double calculatedADC = Fit->GetX(SH.m_Energy);
+      
+      // Apply hardware limits
+      if (calculatedADC > m_MaxADCRange) calculatedADC = m_MaxADCRange;
+      if (calculatedADC < 0) calculatedADC = 0;
+      
+      SH.m_ADC = static_cast<unsigned int>(calculatedADC);
+      
+    } else {
+      // If no calibration exists in the .ecal file for this strip set it to ADC value of 0
+      if (g_Verbosity >= c_Warning) cout << m_Name << ": No inverse calibration found for LV element " << SH.m_ROE << endl;
+      SH.m_ADC = 0;
+    }
   }
+
+  // Now do high voltage strips
   list<MDEEStripHit>& HVHits = Event->GetDEEStripHitHVListReference();
   for (MDEEStripHit& SH: HVHits) {
-    SH.m_ADC = 2000 + 4*SH.m_Energy;
-    if (SH.m_ADC > 16383) SH.m_ADC = 16383;
+    
+    // Find the fit
+    TF1* Fit = m_Calibration[SH.m_ROE];
+
+    if (Fit != nullptr) {
+      // keV -> ADC
+      double calculatedADC = Fit->GetX(SH.m_Energy);
+      
+      // Apply hardware limits
+      if (calculatedADC > m_MaxADCRange) calculatedADC = m_MaxADCRange;
+      if (calculatedADC < 0) calculatedADC = 0;
+      
+      SH.m_ADC = static_cast<unsigned int>(calculatedADC);
+      
+    } else {
+      // If no calibration exists in the .ecal file for this strip set it to ADC value of 0
+      if (g_Verbosity >= c_Warning) cout << m_Name << ": No inverse calibration found for HV element " << SH.m_ROE << endl;
+      SH.m_ADC = 0;
+    }
   }
 
   return true;
 }
+
+////////////////////////////////////////////////////////////////////////////////
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -114,7 +244,13 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 
 void MSubModuleStripReadout::Finalize()
 {
-  // Finalize the analysis - do all cleanup, i.e., undo Initialize() 
+  // Finalize the analysis - do all cleanup, i.e., undo Initialize()
+
+  // Clean up the memory 
+  for (auto& F : m_Calibration) {
+    delete F.second;
+  }
+  m_Calibration.clear();
 
   MSubModule::Finalize();
 }

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -2,7 +2,7 @@
  * MSubModuleStripReadout.cxx
  *
  *
- * Copyright (C) by Andreas Zoglauer.
+ * Copyright (C) by Andreas Zoglauer, Robin Anthony-Petersen.
  * All rights reserved.
  *
  *
@@ -29,13 +29,9 @@
 // Standard libs:
 
 // ROOT libs:
-#include "TF1.h"
-#include <map>
 
 // MEGAlib libs:
-#include "MSubModule.h"
 #include "MParser.h"
-#include "MReadOutElementDoubleStrip.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -86,7 +82,7 @@ bool MSubModuleStripReadout::Initialize()
     return false;
   }
 
-  // Opoen ecal file
+  // Open ecal file
   MParser Parser;
   if (Parser.Open(m_EnergyCalibrationFileName, MFile::c_Read) == false) {
     if (g_Verbosity >= c_Error) {
@@ -95,10 +91,10 @@ bool MSubModuleStripReadout::Initialize()
     return false;
   }
 
-  // Create the map (smae as the Universal Energy Calibrator)
+  // Create the map (same as the Universal Energy Calibrator)
   map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine;
 
-  // Add case for double wide strips
+  // Add case to handle shorted strips
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
     if (Parser.GetTokenizerAt(i)->GetNTokens() < 2) continue;
 
@@ -115,7 +111,7 @@ bool MSubModuleStripReadout::Initialize()
     }
   }
 
-  // Get the parameters and use ROOTs built in TF1 to invert the polynomials
+  // Get the parameters and store the energy calibration fit function as ROOT's built-in TF1 
   for (auto CM : CM_ROEToLine) {
     unsigned int Pos = 5;
     MString CalibratorType = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsString(Pos);
@@ -130,8 +126,7 @@ bool MSubModuleStripReadout::Initialize()
       melinatorfit->FixParameter(1, a1);
 
       m_Calibration[CM.first] = melinatorfit;
-    }
-    else if (CalibratorType == "poly2") {
+    } else if (CalibratorType == "poly2") {
       double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
@@ -142,8 +137,7 @@ bool MSubModuleStripReadout::Initialize()
       melinatorfit->FixParameter(2, a2);
 
       m_Calibration[CM.first] = melinatorfit;
-    }
-    else if (CalibratorType == "poly3") {
+    } else if (CalibratorType == "poly3") {
       double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
@@ -156,16 +150,18 @@ bool MSubModuleStripReadout::Initialize()
       melinatorfit->FixParameter(3, a3);
 
       m_Calibration[CM.first] = melinatorfit;
+    } else {
+      // TODO: Add all the other types of fits melinator can do
+      // So far, only added these ones because these are the ones we use for the ecals
+      if (g_Verbosity >= c_Error) {
+        cout<<m_Name<<": Unhandled CalibratorType: "<<CalibratorType<<endl<<"Please update this module."<<endl;
+      }
+      return false;
     }
-    //TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
-    // So far only added these ones because these are the ones we use for the ecals
   }
 
   return MSubModule::Initialize();
 }
-
-
-////////////////////////////////////////////////////////////////////////////////
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -181,6 +177,7 @@ void MSubModuleStripReadout::Clear()
 
 ////////////////////////////////////////////////////////////////////////////////
 
+
 bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
@@ -194,7 +191,7 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
       TF1* Fit = m_Calibration[SH.m_ROE];
 
       if (Fit != nullptr) {
-        // Run it in reverse, using ROOT's poly inverter (keV -> ADC), in the allowed ADC range
+        // Apply the inverse energy calibration using ROOT's poly inverter (keV -> ADC) in the allowed ADC range
         double calculatedADC = Fit->GetX(SH.m_Energy, 0., m_MaxADCRange);
         
         // Apply hardware limits
@@ -213,8 +210,6 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 
   return true;
 }
-
-////////////////////////////////////////////////////////////////////////////////
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/MSubModuleStripReadoutNoise.cxx
+++ b/src/MSubModuleStripReadoutNoise.cxx
@@ -91,6 +91,9 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level 
 
+  // TODO: Update this to take energy resolution into account
+  
+  /*
   // Dummy code:
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
   for (MDEEStripHit& SH: LVHits) {
@@ -102,6 +105,7 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
     SH.m_ADC = 2000 + 4*SH.m_Energy;
     if (SH.m_ADC > 16383) SH.m_ADC = 16383;
   }
+  */
 
   return true;
 }


### PR DESCRIPTION
The credit for implementing the inverse energy calibration for DEE should all go to @robin4730.

The only thing I added to her nice implementation was:
- removing code duplication, 
- restricting the determination of ADCs from energies to the ADC range, and
- remove the old dummy implementation for the inverse energy calibration 
  (which would otherwise overrule what's happening here)