### PR TITLE
FIX: Reading calibrated timing in `MModuleLoaderMeasurementsROA`

### DIFF
--- a/src/MModuleLoaderMeasurementsROA.cxx
+++ b/src/MModuleLoaderMeasurementsROA.cxx
@@ -208,7 +208,7 @@ bool MModuleLoaderMeasurementsROA::ReadNextEvent(MReadOutAssembly* Event)
     SH->SetStripID(Strip->GetStripID());
     
     if (Timing != nullptr) {
-      SH->SetTAC(Timing->GetTiming());
+      SH->SetTiming(Timing->GetTiming());
     }
     if (TAC != nullptr) {
       SH->SetTAC(TAC->GetTAC());


### PR DESCRIPTION
The ROA loader is currently assigning the values for `Timing` to `m_TAC` instead of `m_Timing`.
This is fixed now.
