### PR TITLE
FIX: Update ASIC polarities only for HDF5 version 2

### DIFF
--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -149,9 +149,11 @@ bool MModuleLoaderMeasurementsHDF::Initialize()
     return false;
   }
 
-  if (m_StripMap.UpdateASICPolarities(m_ASICPolarities) == false) {
-    if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unable to update ASIC polarities based on the config JSON."<<endl;
-    return false;
+  if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_0) {
+    if (m_StripMap.UpdateASICPolarities(m_ASICPolarities) == false) {
+      if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unable to update ASIC polarities based on the config JSON."<<endl;
+      return false;
+    }
   }
 
   m_NEventsInFile = 0;


### PR DESCRIPTION
I am fixing a stupid mistake I introduced.
Now: the polarities of the ASICs are only updated based on the HDF5 files if they are minimum version 2