### PR TITLE
Timing cleanup

### DIFF
--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -56,18 +56,10 @@ class MReadOutAssembly : public MReadOutSequence
   //! Delete Hits
   void DeleteHits();
 
-  //! TODO Scrub all clock/time variables for COSI SMEX 
-  //! set and get Unix clock time
-  void SetTI(unsigned long long TI) { m_TI = TI;}
-  unsigned long long GetTI() const { return m_TI;}
-
-  //! set and get clock tick
-  void SetCL(uint64_t CL) { m_CL = CL;}
-  uint64_t GetCL() const { return m_CL;}
-
-  //! Set and get the Modified Julian Date of this event
-  void SetMJD(double MJD) { m_MJD = MJD; }
-  double GetMJD() const { return m_MJD; }
+  //! Set and get the Reference Time System for this event
+  //! The RTS is mission time in seconds since Jan 1, 2025 in TT
+  void SetTimeRTS(double TimeRTS) { m_EventTimeRTS = TimeRTS; }
+  double GetTimeRTS() const { return m_EventTimeRTS; }
   
   //! Set and get the UTC time of this event
   void SetTimeUTC(const MTime& TimeUTC) { m_EventTimeUTC = TimeUTC; }
@@ -284,11 +276,11 @@ class MReadOutAssembly : public MReadOutSequence
   bool GetNextFromDatFile(MFile &F);
 
   //! Use the info in m_Aspect to turn m_CL into an absolute UTC time
-  bool ComputeAbsoluteTime();
+  bool ComputeAbsoluteUTCTime();
   //! Set the MTime corresponding to absolute UTC time
-  void SetAbsoluteTime(MTime T) {m_EventTimeUTC = T;}
+  void SetAbsoluteUTCTime(MTime T) {m_EventTimeUTC = T;}
   //! Get the MTime corresponding to absolute UTC time
-  MTime GetAbsoluteTime() const {return m_EventTimeUTC; }
+  MTime GetAbsoluteUTCTime() const {return m_EventTimeUTC; }
 
   // protected methods:
  protected:
@@ -313,13 +305,8 @@ class MReadOutAssembly : public MReadOutSequence
   //! Unique assembly identifier
   unsigned long m_AssemblyID;
 
-  //! Clock tick (Unix and UHF)
-  unsigned long long m_TI;
-  uint64_t m_CL;
-
-  //! Time and MJD of this event
-  double m_MJD;
-  // MTime m_Time; // in base class
+  //! The time of the event in COSI Reference Time System (seconds since Jan 1, 2025) in TT
+  double m_EventTimeRTS;
 
   //! The time of the event in absolute UTC time
   MTime m_EventTimeUTC;

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -58,8 +58,8 @@ class MReadOutAssembly : public MReadOutSequence
 
   //! Set and get the Reference Time System for this event
   //! The RTS is mission time in seconds since Jan 1, 2025 in TT
-  void SetTimeRTS(double TimeRTS) { m_EventTimeRTS = TimeRTS; }
-  double GetTimeRTS() const { return m_EventTimeRTS; }
+  void SetTimeRTS(const MTime& TimeRTS) { m_EventTimeRTS = TimeRTS; }
+  MTime GetTimeRTS() const { return m_EventTimeRTS; }
   
   //! Set and get the UTC time of this event
   void SetTimeUTC(const MTime& TimeUTC) { m_EventTimeUTC = TimeUTC; }
@@ -275,12 +275,10 @@ class MReadOutAssembly : public MReadOutSequence
   //! Build the next MReadoutAssemply from a .dat file
   bool GetNextFromDatFile(MFile &F);
 
-  //! Use the info in m_Aspect to turn m_CL into an absolute UTC time
-  bool ComputeAbsoluteUTCTime();
-  //! Set the MTime corresponding to absolute UTC time
-  void SetAbsoluteUTCTime(MTime T) {m_EventTimeUTC = T;}
-  //! Get the MTime corresponding to absolute UTC time
-  MTime GetAbsoluteUTCTime() const {return m_EventTimeUTC; }
+  //! Compute the RTS time from known UTC time
+  MTime ComputeRTSfromUTCTime(MTime UTCTime);
+  //! Compute the UTC time from known RTS
+  MTime ComputeUTCfromRTSTime(MTime RTSTime);
 
   // protected methods:
  protected:
@@ -306,7 +304,7 @@ class MReadOutAssembly : public MReadOutSequence
   unsigned long m_AssemblyID;
 
   //! The time of the event in COSI Reference Time System (seconds since Jan 1, 2025) in TT
-  double m_EventTimeRTS;
+  MTime m_EventTimeRTS;
 
   //! The time of the event in absolute UTC time
   MTime m_EventTimeUTC;

--- a/src/MModuleLoaderMeasurementsFITS.cxx
+++ b/src/MModuleLoaderMeasurementsFITS.cxx
@@ -323,7 +323,7 @@ bool MModuleLoaderMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 
   // Set event-level properties
   // Event->SetID();  // TODO: No EventID
-  Event->SetCL(eventTime);     // Mission time in seconds
+  Event->SetTimeRTS(eventTime);     // Mission time in seconds since Jan 1, 2025
 
   // Loop through strip hits and create MStripHit objects
   for (uint8_t hitIdx = 0; hitIdx < numStripHit; ++hitIdx) {

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -813,14 +813,14 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
 
     Event->SetID(LongEventID);
     if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
-      Event->SetCL(TimeCode);
+      Event->SetTimeUTC(TimeCode);
     } else if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_0)  {
-      Event->SetTI(TimeCode);
+      Event->SetTimeUTC(TimeCode);
       if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_2) {
-        Event->SetCL(SPWTimeCode);
+        Event->SetTimeUTC(SPWTimeCode);
       }
     } else {
-      Event->SetTI(TimeCode);
+      Event->SetTimeUTC(TimeCode);
     }
   }
 

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -813,6 +813,7 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     unsigned long LongEventID = EventID + m_NumberOfEventIDRollOvers*(numeric_limits<uint16_t>::max() + 1);
 
     Event->SetID(LongEventID);
+
     if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
       TimeUTC.Set(TimeCode,0);
       Event->SetTimeUTC(TimeUTC);

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -611,6 +611,7 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     uint16_t EventID;
     uint64_t TimeCode;
     uint8_t NumberOfHits;
+    MTime TimeUTC;
 
     // Setting SPWTimeCode default to 0, as it is defined only iin HDF version >= 2.2
     uint64_t SPWTimeCode = 0;
@@ -813,14 +814,17 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
 
     Event->SetID(LongEventID);
     if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
-      Event->SetTimeUTC(TimeCode);
+      TimeUTC.Set(TimeCode,0);
+      Event->SetTimeUTC(TimeUTC);
     } else if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_0)  {
-      Event->SetTimeUTC(TimeCode);
-      if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_2) {
-        Event->SetTimeUTC(SPWTimeCode);
-      }
+      TimeUTC.Set(TimeCode,0);
+      Event->SetTimeUTC(TimeUTC);
+    } else if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_2) {
+      TimeUTC.Set(TimeCode,0);
+      Event->SetTimeUTC(TimeUTC);
     } else {
-      Event->SetTimeUTC(TimeCode);
+      TimeUTC.Set(TimeCode,0);
+      Event->SetTimeUTC(TimeUTC);
     }
   }
 

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -101,8 +101,12 @@ bool MModuleLoaderMeasurementsHDF::Initialize()
   m_FileType = "Unknown";
   m_Detector = "Unknown";
   m_Version = -1;
-  /*
+  
+  // Start time of the file taken from the file name
+  // to be used to find absolute time for Spacewire brick
+  //TODO: Get more accurate start time from data files?
   m_StartObservationTime = MTime(0);
+  /*
   m_EndObservationTime = MTime(0);
   m_StartClock = numeric_limits<long>::max();
   m_EndClock = numeric_limits<long>::max();
@@ -171,6 +175,23 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
   try { // HDF5 throws exceptions, thus need to encapsulate everything in try..catch
 
     MFile::ExpandFileName(FileName);
+    
+    // Get the observation start time from the file name 
+    if (FileName.EndsWith(".hdf5") == true && FileName.Contains("gse_") == true)  {
+      MString FileDateTime = FileName.Extract("gse_",".hdf5");
+      unsigned int Year = FileDateTime.GetSubString(0,4).ToInt();
+      unsigned int Month = FileDateTime.GetSubString(4,2).ToInt();
+      unsigned int Day = FileDateTime.GetSubString(6,2).ToInt();
+      unsigned int Hour = FileDateTime.GetSubString(9,2).ToInt();
+      unsigned int Min = FileDateTime.GetSubString(11,2).ToInt();
+      unsigned int Sec = FileDateTime.GetSubString(13,2).ToInt();
+      m_StartObservationTime = MTime(Year, Month, Day, Hour, Min, Sec, 0);
+      if (g_Verbosity >= c_Info) cout<<m_XmlTag<<": Found start time from file name (UTC): "<<m_StartObservationTime<<endl;
+    } else {
+      if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unable to determine start time from file name: "<<FileName<<endl;
+      return false;
+    }
+    
     m_HDFFile = H5File(FileName, H5F_ACC_RDONLY);
 
     // JSON config string containing the information on the ASIC polarities
@@ -392,7 +413,7 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         m_EventCompoundDataType = CompType(sizeof(MHDFEvent_V2_0));
         m_EventCompoundDataType.insertMember("event_id",          HOFFSET(MHDFEvent_V2_0, m_EventID),                PredType::STD_U16LE);
         m_EventCompoundDataType.insertMember("timecode",          HOFFSET(MHDFEvent_V2_0, m_TimeCode),               PredType::STD_U64LE);
-        m_EventCompoundDataType.insertMember("gse_timecode",      HOFFSET(MHDFEvent_V2_0, m_GSETimeCode),            PredType::IEEE_F64LE);
+        m_EventCompoundDataType.insertMember("gse_timecode",      HOFFSET(MHDFEvent_V2_0, m_GSETimeCode),            PredType::STD_U64LE);
         m_EventCompoundDataType.insertMember("hits",              HOFFSET(MHDFEvent_V2_0, m_Hits),                   PredType::STD_U8LE);
         m_EventCompoundDataType.insertMember("bytes",             HOFFSET(MHDFEvent_V2_0, m_Bytes),                  PredType::STD_U16LE);
         m_EventCompoundDataType.insertMember("event_type",        HOFFSET(MHDFEvent_V2_0, m_EventType),              PredType::STD_U8LE);
@@ -401,8 +422,8 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
         m_EventCompoundDataType = CompType(sizeof(MHDFEvent_V2_2));
         m_EventCompoundDataType.insertMember("event_id",          HOFFSET(MHDFEvent_V2_2, m_EventID),                PredType::STD_U16LE);
         m_EventCompoundDataType.insertMember("timecode",          HOFFSET(MHDFEvent_V2_2, m_TimeCode),               PredType::STD_U64LE);
-        m_EventCompoundDataType.insertMember("gse_timecode",      HOFFSET(MHDFEvent_V2_2, m_GSETimeCode),            PredType::IEEE_F64LE);
-        m_EventCompoundDataType.insertMember("spw_timecode",      HOFFSET(MHDFEvent_V2_2, m_SPWTimeCode),            PredType::IEEE_F64LE);
+        m_EventCompoundDataType.insertMember("gse_timecode",      HOFFSET(MHDFEvent_V2_2, m_GSETimeCode),            PredType::STD_U64LE);
+        m_EventCompoundDataType.insertMember("spw_timecode",      HOFFSET(MHDFEvent_V2_2, m_SPWTimeCode),            PredType::STD_U64LE);
         m_EventCompoundDataType.insertMember("hits",              HOFFSET(MHDFEvent_V2_2, m_Hits),                   PredType::STD_U8LE);
         m_EventCompoundDataType.insertMember("bytes",             HOFFSET(MHDFEvent_V2_2, m_Bytes),                  PredType::STD_U16LE);
         m_EventCompoundDataType.insertMember("event_type",        HOFFSET(MHDFEvent_V2_2, m_EventType),              PredType::STD_U8LE);
@@ -609,7 +630,7 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
 
     // Extract the data we need
     uint16_t EventID;
-    uint64_t TimeCode;
+    double TimeCode; // Sometimes TimeCode is int, but here we'll define double to not lose precision for HDF v1.2
     uint8_t NumberOfHits;
     MTime TimeUTC;
 
@@ -645,7 +666,7 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
         ++m_CurrentHit;
 
         EventID = Hit.m_EventID;
-        TimeCode = Hit.m_TimeCode;
+        TimeCode = Hit.m_GSETimeCode;
         StripID = Hit.m_StripID;
         ADCs = Hit.m_EnergyData;
         TACs = Hit.m_TimingData;
@@ -738,10 +759,11 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
         EventID = HitEvent.m_EventID;
         TimeCode = HitEvent.m_GSETimeCode;
         NumberOfHits = HitEvent.m_Hits;
-      } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
+      } else if (m_HDFStripHitVersion == MHDFStripHitVersion::V2_2) {
         MHDFEvent_V2_2& HitEvent = m_EventData_2_2[m_CurrentBatchIndex];
         EventID = HitEvent.m_EventID;
         TimeCode = HitEvent.m_GSETimeCode;
+        SPWTimeCode = HitEvent.m_SPWTimeCode;
         NumberOfHits = HitEvent.m_Hits;
       } else {
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
@@ -814,17 +836,15 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
 
     Event->SetID(LongEventID);
 
-    if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
-      TimeUTC.Set(TimeCode,0);
-      Event->SetTimeUTC(TimeUTC);
-    } else if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_0)  {
-      TimeUTC.Set(TimeCode,0);
+    // Define event time based on the timecode within the HDF versions
+    if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_0) {
+      TimeUTC.Set(TimeCode); // Timecode in early versions is GSE computer time in s since Epoch
       Event->SetTimeUTC(TimeUTC);
     } else if (m_HDFStripHitVersion >= MHDFStripHitVersion::V2_2) {
-      TimeUTC.Set(TimeCode,0);
-      Event->SetTimeUTC(TimeUTC);
+      MTime SPWTimeforEvent(m_StartObservationTime.GetAsSystemSeconds(),SPWTimeCode); // Spacewire Timecode is ns since start of aquisition
+      Event->SetTimeUTC(SPWTimeforEvent);
     } else {
-      TimeUTC.Set(TimeCode,0);
+      TimeUTC.Set(TimeCode);
       Event->SetTimeUTC(TimeUTC);
     }
   }
@@ -925,4 +945,3 @@ void MModuleLoaderMeasurementsHDF::ShowOptionsGUI()
 
 
 // MModuleLoaderMeasurementsHDF.cxx: the end...
-////////////////////////////////////////////////////////////////////////////////

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -243,7 +243,17 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   // Add this event to the batch, write batch when full
 
   // Extract event-level data
-  double time = Event->GetTimeRTS();
+  double time = 0;
+  if (Event->GetTimeRTS() != 0) {
+    time = Event->GetTimeRTS().GetAsDouble();
+  } else if (Event->GetTimeRTS() == 0 && Event->GetTimeUTC() != 0) {
+    // If UTC time is defined, calculate RTS
+    MTime RTS = Event->ComputeRTSfromUTCTime(Event->GetTimeUTC());
+    Event->SetTimeRTS(RTS);
+    time = RTS.GetAsDouble();
+  } else {
+    //if verbosity
+  }
   unsigned int numHits = Event->GetNHits();
 
   // Event-level metadata (placeholders for now - can be filled in later)

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -244,15 +244,13 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 
   // Extract event-level data
   double time = 0;
-  if (Event->GetTimeRTS() != 0) {
-    time = Event->GetTimeRTS().GetAsDouble();
-  } else if (Event->GetTimeRTS() == 0 && Event->GetTimeUTC() != 0) {
+  if (Event->GetTimeRTS() == 0 && Event->GetTimeUTC() != 0) {
     // If UTC time is defined, calculate RTS
     MTime RTS = Event->ComputeRTSfromUTCTime(Event->GetTimeUTC());
     Event->SetTimeRTS(RTS);
     time = RTS.GetAsDouble();
   } else {
-    //if verbosity
+    time = Event->GetTimeRTS().GetAsDouble();
   }
   unsigned int numHits = Event->GetNHits();
 

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -243,7 +243,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   // Add this event to the batch, write batch when full
 
   // Extract event-level data
-  double time = Event->GetCL();
+  double time = Event->GetTimeRTS();
   unsigned int numHits = Event->GetNHits();
 
   // Event-level metadata (placeholders for now - can be filled in later)

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -557,8 +557,13 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
-  S<<"TI "<<m_EventTimeUTC<<endl;
-    
+  
+  if (m_EventTimeUTC == 0 && m_EventTimeRTS != 0) {
+    S<<"TI "<<ComputeUTCfromRTSTime(m_EventTimeRTS)<<endl;
+  } else {
+    S<<"TI "<<m_EventTimeUTC<<endl;
+  }
+
   for (MSimIA& IA: m_SimIAs) {
     S<<IA.ToSimString()<<endl; 
   }
@@ -596,7 +601,12 @@ void MReadOutAssembly::StreamEvta(ostream& S)
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
-  S<<"TI "<<m_EventTimeUTC<<endl;
+
+  if (m_EventTimeUTC == 0 && m_EventTimeRTS != 0) {
+    S<<"TI "<<ComputeUTCfromRTSTime(m_EventTimeRTS)<<endl;
+  } else {
+    S<<"TI "<<m_EventTimeUTC<<endl;
+  }
 
   if (m_HasSimAspectInfo){
     S<<"GX "<<m_GalacticPointingXAxisPhi<<" "<<m_GalacticPointingXAxisTheta<<endl;
@@ -626,7 +636,12 @@ void MReadOutAssembly::StreamRoa(ostream& S, bool WithADCs, bool WithTACs, bool 
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
-  S<<"TI "<<m_EventTimeUTC<<endl;
+
+  if (m_EventTimeUTC == 0 && m_EventTimeRTS != 0) {
+    S<<"TI "<<ComputeUTCfromRTSTime(m_EventTimeRTS)<<endl;
+  } else {
+    S<<"TI "<<m_EventTimeUTC<<endl;
+  }
 
   for (MSimIA& IA: m_SimIAs) {
     S<<IA.ToSimString()<<endl; 

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -126,11 +126,8 @@ void MReadOutAssembly::Clear()
   MReadOutSequence::Clear();
   
   m_ID = g_UnsignedIntNotDefined;
-  m_TI = 0;
-  m_CL = 0;
-  m_Time = 0;
+  m_EventTimeRST = 0;
   m_EventTimeUTC = 0;
-  m_MJD = 0.0;
 
   m_ShieldVeto = false;
   m_GuardRingVeto = false;
@@ -425,13 +422,6 @@ bool MReadOutAssembly::Parse(MString& Line, int Version)
   // Handles SE, TI, RO, IA
   if (MReadOutSequence::Parse(Line) == true) return true;
   
-  /* In base class
-  if (Line.BeginsWith("SE")) return true;
-  if (Line.BeginsWith("TI")) {
-    m_Time.Set(Line);
-    return true;
-  }
-  */
   if (Line.BeginsWith("HT")) {
     MHit* h = new MHit();
     if( h->Parse(Line,1) ){
@@ -535,7 +525,6 @@ bool MReadOutAssembly::StreamDat(ostream& S, int Version)
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
-  S<<"CL "<<m_Time<<endl;
   S<<"TI "<<m_EventTimeUTC<<endl;
     
   for (MSimIA& IA: m_SimIAs) {
@@ -575,7 +564,6 @@ void MReadOutAssembly::StreamEvta(ostream& S)
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
-  S<<"CL "<<m_Time<<endl;
   S<<"TI "<<m_EventTimeUTC<<endl;
 
   if (m_HasSimAspectInfo){
@@ -606,7 +594,6 @@ void MReadOutAssembly::StreamRoa(ostream& S, bool WithADCs, bool WithTACs, bool 
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
-  S<<"CL "<<m_Time<<endl;
   S<<"TI "<<m_EventTimeUTC<<endl;
 
   for (MSimIA& IA: m_SimIAs) {

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -126,7 +126,7 @@ void MReadOutAssembly::Clear()
   MReadOutSequence::Clear();
   
   m_ID = g_UnsignedIntNotDefined;
-  m_EventTimeRST = 0;
+  m_EventTimeRTS = 0;
   m_EventTimeUTC = 0;
 
   m_ShieldVeto = false;

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -417,6 +417,38 @@ void MReadOutAssembly::RemoveHit(unsigned int i)
 ////////////////////////////////////////////////////////////////////////////////
 
 
+MTime MReadOutAssembly::ComputeRTSfromUTCTime(MTime UTCTime)
+{
+  //! Compute the RTS time if the event only has UTC time defined
+  //! RTS is elapsed time since Jan 1, 2025 in TT
+  //! TT = UTC + 37 + 32.184
+  MTime RTS_Unix = MTime(2025,1,1,0,0,0,0);
+  MTime RTS_TT = UTCTime - RTS_Unix + 37 + 32.184;
+  
+  return RTS_TT;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MTime MReadOutAssembly::ComputeUTCfromRTSTime(MTime RTSTime)
+{
+  //! Compute the UTC time if the event only has RTS time defined
+  //! RTS is elapsed time since Jan 1, 2025 in TT
+  //! TT = UTC + 37 + 32.184
+  MTime RTS_Unix = MTime(2025,1,1,0,0,0,0);
+  MTime UTCTime = RTSTime + RTS_Unix - 37 - 32.184;
+
+  return UTCTime;
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
 bool MReadOutAssembly::Parse(MString& Line, int Version)
 {  
   // Handles SE, TI, RO, IA


### PR DESCRIPTION
I scrubbed the modules to remove balloon timing variables CL and TI, and introduced a new variable RTS for Reference Time Standard (mission time in seconds from Jan 1, 2025 in TT). We should now only have RTS time and UTC time for each event.

The RTS variable will only be used for the FITS formatted files (it will be passed to Nuclearizer from the L1a files). UTC time will be recorded as TI for each event in the EVTA/ROA/DAT files.

The calculation of EventTimeUTC from TimeCode for each HDF file version needs to be corrected in MModuleLoaderMeasurementsHDF.cxx once the time variable in the data is meaningful. I wasn't able to check this with older hdf file formats.