### PR TITLE
FIX: bug in `MModuleDepthCalibration::Initialize`

### DIFF
--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -182,7 +182,7 @@ bool MModuleDepthCalibration::Initialize()
   if (m_MaskMetrologyEnabled == true) {
     if (g_Verbosity >= c_Info) cout << m_XmlTag << ": !!! Mask Metrology Enabled !!!" << endl;
     m_MaskMetrologyFileIsLoaded = LoadMaskMetrologyFile(m_MaskMetrologyFile);
-    if (m_MaskMetrologyFile == false) {
+    if (m_MaskMetrologyFileIsLoaded == false) {
       if (g_Verbosity >= c_Error) cout << m_XmlTag << "Unable to open Metrology file" << endl;
       return false;
     }


### PR DESCRIPTION
In `MModuleDepthCalibration::Initialize`, after trying to read metrology files, we check if the filename is `true` instead of if the loading of the file was successful.
