### PR TITLE
[DEE] Implement smearing simulated strip energies based on measured FWHM curves

### DIFF
--- a/include/MGUIOptionsDEESMEX.h
+++ b/include/MGUIOptionsDEESMEX.h
@@ -25,7 +25,6 @@
 #include <TGButton.h>
 #include <MString.h>
 #include <TGClient.h>
-#include <TGButton.h>
 
 // MEGAlib libs:
 #include "MGlobal.h"

--- a/include/MGUIOptionsDEESMEX.h
+++ b/include/MGUIOptionsDEESMEX.h
@@ -99,7 +99,7 @@ class MGUIOptionsDEESMEX : public MGUIOptions
   MGUIEFileSelector* m_DeadtimeFileSelector;
   
   //! Button to toggle noise addition
-  TGCheckButton* m_AddNoiseButton;
+  TGCheckButton* m_ResolutionCalibrationButton;
 
 
 #ifdef ___CLING___

--- a/include/MGUIOptionsDEESMEX.h
+++ b/include/MGUIOptionsDEESMEX.h
@@ -25,6 +25,7 @@
 #include <TGButton.h>
 #include <MString.h>
 #include <TGClient.h>
+#include <TGButton.h>
 
 // MEGAlib libs:
 #include "MGlobal.h"
@@ -97,6 +98,9 @@ class MGUIOptionsDEESMEX : public MGUIOptions
   MGUIEFileSelector* m_ShieldEnergyCorrectionFileSelector;
   //! Select deadtime constants file
   MGUIEFileSelector* m_DeadtimeFileSelector;
+  
+  //! Button to toggle noise addition
+  TGCheckButton* m_AddNoiseButton;
 
 
 #ifdef ___CLING___

--- a/include/MModuleDEESMEX.h
+++ b/include/MModuleDEESMEX.h
@@ -95,6 +95,7 @@ class MModuleDEESMEX : public MModule
   void SetEnergyCalibrationFileName(const MString& FileName)
   {
     m_StripReadout.SetEnergyCalibrationFileName(FileName);
+    m_StripReadoutNoise.SetEnergyCalibrationFileName(FileName);
   }
   //! Set energy calibration file name
   MString GetEnergyCalibrationFileName() const

--- a/include/MModuleDEESMEX.h
+++ b/include/MModuleDEESMEX.h
@@ -123,6 +123,12 @@ class MModuleDEESMEX : public MModule
   {
     return m_StripTrigger.GetDeadtimeFileName();
   }
+  
+  //! Button to add noise
+  bool GetAddNoise() const { return m_AddNoise; }
+  void SetAddNoise(bool AddNoise) {
+    m_AddNoise = AddNoise;
+  }
 
   // protected methods:
  protected:
@@ -167,6 +173,9 @@ class MModuleDEESMEX : public MModule
 
   //! The sub module handling the output of the DEE in to the standard nuclearizer classes
   MSubModuleDEEOutput m_Output;
+  
+  //! Option to add noise
+  bool m_AddNoise;
 
 
 #ifdef ___CLING___

--- a/include/MModuleDEESMEX.h
+++ b/include/MModuleDEESMEX.h
@@ -124,10 +124,10 @@ class MModuleDEESMEX : public MModule
     return m_StripTrigger.GetDeadtimeFileName();
   }
   
-  //! Button to apply  the FWHM energy resolution to the enegries 
-  bool GetResolutionCalibration() const { return m_ResolutionCalibration; }
-  void SetResolutionCalibration(bool ResolutionCalibration) {
-    m_ResolutionCalibration = ResolutionCalibration;
+  //! Button to apply the FWHM energy resolution to the enegries 
+  bool GetApplyResolutionCalibration() const { return m_ApplyResolutionCalibration; }
+  void SetApplyResolutionCalibration(bool ApplyResolutionCalibration) {
+    m_ApplyResolutionCalibration = ApplyResolutionCalibration;
   }
 
   // protected methods:
@@ -175,7 +175,7 @@ class MModuleDEESMEX : public MModule
   MSubModuleDEEOutput m_Output;
   
   //! Option to add noise
-  bool m_ResolutionCalibration; 
+  bool m_ApplyResolutionCalibration; 
 
 
 #ifdef ___CLING___

--- a/include/MModuleDEESMEX.h
+++ b/include/MModuleDEESMEX.h
@@ -95,7 +95,6 @@ class MModuleDEESMEX : public MModule
   void SetEnergyCalibrationFileName(const MString& FileName)
   {
     m_StripReadout.SetEnergyCalibrationFileName(FileName);
-    m_StripReadoutNoise.SetEnergyCalibrationFileName(FileName);
   }
   //! Set energy calibration file name
   MString GetEnergyCalibrationFileName() const
@@ -125,10 +124,10 @@ class MModuleDEESMEX : public MModule
     return m_StripTrigger.GetDeadtimeFileName();
   }
   
-  //! Button to add noise
-  bool GetAddNoise() const { return m_AddNoise; }
-  void SetAddNoise(bool AddNoise) {
-    m_AddNoise = AddNoise;
+  //! Button to apply  the FWHM energy resolution to the enegries 
+  bool GetResolutionCalibration() const { return m_ResolutionCalibration; }
+  void SetResolutionCalibration(bool ResolutionCalibration) {
+    m_ResolutionCalibration = ResolutionCalibration;
   }
 
   // protected methods:
@@ -176,7 +175,7 @@ class MModuleDEESMEX : public MModule
   MSubModuleDEEOutput m_Output;
   
   //! Option to add noise
-  bool m_AddNoise;
+  bool m_ResolutionCalibration; 
 
 
 #ifdef ___CLING___

--- a/include/MSubModuleStripReadout.h
+++ b/include/MSubModuleStripReadout.h
@@ -52,9 +52,14 @@ class MSubModuleStripReadout : public MSubModule
   //! Default destructor
   virtual ~MSubModuleStripReadout();
 
+  //! Set if energies should be smeared based on FWHM
+  void SetApplyResolutionCalibration(bool ApplyResolutionCalibration) { m_ApplyResolutionCalibration = ApplyResolutionCalibration; }
+  //! Get if energies should be smeared based on FWHM
+  bool GetApplyResolutionCalibration() { return m_ApplyResolutionCalibration; }
+
   //! Set energy calibration file name
   void SetEnergyCalibrationFileName(const MString& FileName) { m_EnergyCalibrationFileName = FileName; }
-  //! Set energy calibration file name
+  //! Get energy calibration file name
   MString GetEnergyCalibrationFileName() const { return m_EnergyCalibrationFileName; }
 
   //! Initialize the module

--- a/include/MSubModuleStripReadout.h
+++ b/include/MSubModuleStripReadout.h
@@ -106,7 +106,7 @@ class MSubModuleStripReadout : public MSubModule
   std::map<MReadOutElementDoubleStrip, TF1*> m_ResolutionCalibration;
   
   //! Max value of the ADC units
-  double m_MaxADCRange;
+  static constexpr double m_MaxADCRange = 16383;
 
 
 

--- a/include/MSubModuleStripReadout.h
+++ b/include/MSubModuleStripReadout.h
@@ -94,7 +94,13 @@ class MSubModuleStripReadout : public MSubModule
   //! Name of the strip map
   std::map<MReadOutElementDoubleStrip, TF1*> m_Calibration;
   
-  //! Make value of the ADC units
+  //! Flag to determine if resolution calibration should be applied
+  bool m_ApplyResolutionCalibration;
+  
+  //! Map storing the FWHM fits for each strip
+  std::map<MReadOutElementDoubleStrip, TF1*> m_ResolutionCalibration;
+  
+  //! Max value of the ADC units
   double m_MaxADCRange;
 
 

--- a/include/MSubModuleStripReadoutNoise.h
+++ b/include/MSubModuleStripReadoutNoise.h
@@ -52,6 +52,11 @@ class MSubModuleStripReadoutNoise : public MSubModule
   //! Default destructor
   virtual ~MSubModuleStripReadoutNoise();
 
+  //! Set energy calibration file name
+  void SetEnergyCalibrationFileName(const MString& FileName) { m_EnergyCalibrationFileName = FileName; }
+  //! Set energy calibration file name
+  MString GetEnergyCalibrationFileName() const { return m_EnergyCalibrationFileName; }
+
   //! Initialize the module
   virtual bool Initialize();
 

--- a/include/MSubModuleStripReadoutNoise.h
+++ b/include/MSubModuleStripReadoutNoise.h
@@ -17,15 +17,12 @@
 
 
 // Standard libs:
-#include <map>
 
 // ROOT libs:
-#include "TF1.h"
 
 // MEGAlib libs:
 #include "MGlobal.h"
 #include "MSubModule.h"
-#include "MReadOutElementDoubleStrip.h"
 
 // Forward declarations:
 
@@ -83,6 +80,7 @@ class MSubModuleStripReadoutNoise : public MSubModule
 
   // private members:
  private:
+
 
 
 

--- a/include/MSubModuleStripReadoutNoise.h
+++ b/include/MSubModuleStripReadoutNoise.h
@@ -52,11 +52,6 @@ class MSubModuleStripReadoutNoise : public MSubModule
   //! Default destructor
   virtual ~MSubModuleStripReadoutNoise();
 
-  //! Set energy calibration file name
-  void SetEnergyCalibrationFileName(const MString& FileName) { m_EnergyCalibrationFileName = FileName; }
-  //! Set energy calibration file name
-  MString GetEnergyCalibrationFileName() const { return m_EnergyCalibrationFileName; }
-
   //! Initialize the module
   virtual bool Initialize();
 
@@ -88,9 +83,6 @@ class MSubModuleStripReadoutNoise : public MSubModule
 
   // private members:
  private:
-  MString m_EnergyCalibrationFileName;
-  std::map<MReadOutElementDoubleStrip, TF1*> m_ResolutionCalibration;
-
 
 
 

--- a/include/MSubModuleStripReadoutNoise.h
+++ b/include/MSubModuleStripReadoutNoise.h
@@ -17,12 +17,15 @@
 
 
 // Standard libs:
+#include <map>
 
 // ROOT libs:
+#include "TF1.h"
 
 // MEGAlib libs:
 #include "MGlobal.h"
 #include "MSubModule.h"
+#include "MReadOutElementDoubleStrip.h"
 
 // Forward declarations:
 
@@ -80,6 +83,8 @@ class MSubModuleStripReadoutNoise : public MSubModule
 
   // private members:
  private:
+  MString m_EnergyCalibrationFileName;
+  std::map<MReadOutElementDoubleStrip, TF1*> m_ResolutionCalibration;
 
 
 

--- a/src/MGUIOptionsDEESMEX.cxx
+++ b/src/MGUIOptionsDEESMEX.cxx
@@ -72,6 +72,10 @@ void MGUIOptionsDEESMEX::Create()
                                                           dynamic_cast<MModuleDEESMEX*>(m_Module)->GetEnergyCalibrationFileName());
   m_EnergyCalibrationFileSelector->SetFileType("Ecal file", "*.ecal");
   m_OptionsFrame->AddFrame(m_EnergyCalibrationFileSelector, LabelLayout);
+  
+  m_AddNoiseButton = new TGCheckButton(m_OptionsFrame, "Add noise to data");
+  m_AddNoiseButton->SetOn(dynamic_cast<MModuleDEESMEX*>(m_Module)->GetAddNoise());
+  m_OptionsFrame->AddFrame(m_AddNoiseButton, LabelLayout);
 
   m_DeadtimeFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Please select a deadtime parameters file:",
                                                           dynamic_cast<MModuleDEESMEX*>(m_Module)->GetDeadtimeFileName());
@@ -189,6 +193,8 @@ bool MGUIOptionsDEESMEX::OnApply()
   dynamic_cast<MModuleDEESMEX*>(m_Module)->SetEnergyCalibrationFileName(m_EnergyCalibrationFileSelector->GetFileName());
 
   dynamic_cast<MModuleDEESMEX*>(m_Module)->SetDeadtimeFileName(m_DeadtimeFileSelector->GetFileName());
+  
+  dynamic_cast<MModuleDEESMEX*>(m_Module)->SetAddNoise(m_AddNoiseButton->IsOn());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetThresholdFileName(m_ThresholdFileSelector->GetFileName());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetGuardRingThresholdFileName(m_GuardRingThresholdFileSelector->GetFileName());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetChargeSharingFileName(m_ChargeSharingFileSelector->GetFileName());

--- a/src/MGUIOptionsDEESMEX.cxx
+++ b/src/MGUIOptionsDEESMEX.cxx
@@ -73,9 +73,9 @@ void MGUIOptionsDEESMEX::Create()
   m_EnergyCalibrationFileSelector->SetFileType("Ecal file", "*.ecal");
   m_OptionsFrame->AddFrame(m_EnergyCalibrationFileSelector, LabelLayout);
   
-  m_AddNoiseButton = new TGCheckButton(m_OptionsFrame, "Add noise to data");
-  m_AddNoiseButton->SetOn(dynamic_cast<MModuleDEESMEX*>(m_Module)->GetAddNoise());
-  m_OptionsFrame->AddFrame(m_AddNoiseButton, LabelLayout);
+  m_ResolutionCalibrationButton = new TGCheckButton(m_OptionsFrame, "Smear energies based on FWHM");
+  m_ResolutionCalibrationButton->SetOn(dynamic_cast<MModuleDEESMEX*>(m_Module)->GetResolutionCalibration());
+  m_OptionsFrame->AddFrame(m_ResolutionCalibrationButton, LabelLayout);
 
   m_DeadtimeFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Please select a deadtime parameters file:",
                                                           dynamic_cast<MModuleDEESMEX*>(m_Module)->GetDeadtimeFileName());
@@ -194,7 +194,7 @@ bool MGUIOptionsDEESMEX::OnApply()
 
   dynamic_cast<MModuleDEESMEX*>(m_Module)->SetDeadtimeFileName(m_DeadtimeFileSelector->GetFileName());
   
-  dynamic_cast<MModuleDEESMEX*>(m_Module)->SetAddNoise(m_AddNoiseButton->IsOn());
+  dynamic_cast<MModuleDEESMEX*>(m_Module)->SetResolutionCalibration(m_ResolutionCalibrationButton->IsOn());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetThresholdFileName(m_ThresholdFileSelector->GetFileName());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetGuardRingThresholdFileName(m_GuardRingThresholdFileSelector->GetFileName());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetChargeSharingFileName(m_ChargeSharingFileSelector->GetFileName());

--- a/src/MGUIOptionsDEESMEX.cxx
+++ b/src/MGUIOptionsDEESMEX.cxx
@@ -74,7 +74,7 @@ void MGUIOptionsDEESMEX::Create()
   m_OptionsFrame->AddFrame(m_EnergyCalibrationFileSelector, LabelLayout);
   
   m_ResolutionCalibrationButton = new TGCheckButton(m_OptionsFrame, "Smear energies based on FWHM");
-  m_ResolutionCalibrationButton->SetOn(dynamic_cast<MModuleDEESMEX*>(m_Module)->GetResolutionCalibration());
+  m_ResolutionCalibrationButton->SetOn(dynamic_cast<MModuleDEESMEX*>(m_Module)->GetApplyResolutionCalibration());
   m_OptionsFrame->AddFrame(m_ResolutionCalibrationButton, LabelLayout);
 
   m_DeadtimeFileSelector = new MGUIEFileSelector(m_OptionsFrame, "Please select a deadtime parameters file:",
@@ -194,7 +194,7 @@ bool MGUIOptionsDEESMEX::OnApply()
 
   dynamic_cast<MModuleDEESMEX*>(m_Module)->SetDeadtimeFileName(m_DeadtimeFileSelector->GetFileName());
   
-  dynamic_cast<MModuleDEESMEX*>(m_Module)->SetResolutionCalibration(m_ResolutionCalibrationButton->IsOn());
+  dynamic_cast<MModuleDEESMEX*>(m_Module)->SetApplyResolutionCalibration(m_ResolutionCalibrationButton->IsOn());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetThresholdFileName(m_ThresholdFileSelector->GetFileName());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetGuardRingThresholdFileName(m_GuardRingThresholdFileSelector->GetFileName());
   //dynamic_cast<MModuleLoaderSimulationsSingleDet*>(m_Module)->SetChargeSharingFileName(m_ChargeSharingFileSelector->GetFileName());

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -75,7 +75,7 @@ MModuleDEESMEX::MModuleDEESMEX() : MModule()
   m_HasOptionsGUI = true;
   
   // Default to adding noise to the sim data
-  m_ResolutionCalibration = true;
+  m_ApplyResolutionCalibration = true;
 }
 
 
@@ -95,6 +95,7 @@ bool MModuleDEESMEX::Initialize()
 {
   // Set the geometry to the SubModules using it
   m_ChargeTransport.SetGeometry(m_Geometry);
+  m_StripReadout.SetApplyResolutionCalibration(m_ApplyResolutionCalibration);
 
   // Initialize the module 
 
@@ -179,7 +180,7 @@ bool MModuleDEESMEX::AnalyzeEvent(MReadOutAssembly* Event)
   // Step (7): Handle GeD charge transport to grid and voxelation into strips
   m_ChargeTransport.Clear();
   m_ChargeTransport.AnalyzeEvent(Event);
-  
+
   // Step (8): Handle the strip readout: energy -> ADCs
   // Also includes user selected energy resolution with the FWHM values from the ecal 
   m_StripReadout.Clear();
@@ -239,8 +240,8 @@ void MModuleDEESMEX::Finalize()
   m_ShieldReadout.Finalize();
   m_ShieldTrigger.Finalize();
   m_ChargeTransport.Finalize();
-  m_StripReadoutNoise.Finalize();
   m_StripReadout.Finalize();
+  m_StripReadoutNoise.Finalize();
   m_StripTrigger.Finalize();
   m_DepthReadout.Finalize();
   m_Output.Finalize();
@@ -282,9 +283,9 @@ bool MModuleDEESMEX::ReadXmlConfiguration(MXmlNode* Node)
   m_Output.ReadXmlConfiguration(Node);
   
   // Add noise button
-  MXmlNode* ResolutionCalibrationNode = Node->GetNode("ResolutionCalibration");
+  MXmlNode* ResolutionCalibrationNode = Node->GetNode("ApplyResolutionCalibration");
   if (ResolutionCalibrationNode != nullptr) {
-    m_ResolutionCalibration  = ResolutionCalibrationNode->GetValueAsBoolean();
+    m_ApplyResolutionCalibration  = ResolutionCalibrationNode->GetValueAsBoolean();
   }
 
   return true;
@@ -312,7 +313,7 @@ MXmlNode* MModuleDEESMEX::CreateXmlConfiguration()
   m_Output.CreateXmlConfiguration(Node);
   
   // Add noise button
-  new MXmlNode(Node, "ResolutionCalibration", m_ResolutionCalibration);
+  new MXmlNode(Node, "ApplyResolutionCalibration", m_ApplyResolutionCalibration);
 
   return Node;
 }

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -180,7 +180,7 @@ bool MModuleDEESMEX::AnalyzeEvent(MReadOutAssembly* Event)
   m_ChargeTransport.Clear();
   m_ChargeTransport.AnalyzeEvent(Event);
   
-  // Step (8)): Simulate micro-phonics random noise for triggered strips & next neighbors
+  // Step (8): Simulate micro-phonics random noise
   // Do this before energy -> ADCs because the FWHMs from the ecal are in keV
   if (m_AddNoise == true) {
     m_StripReadoutNoise.Clear();

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -105,6 +105,7 @@ bool MModuleDEESMEX::Initialize()
   if (m_ShieldReadout.Initialize() == false) return false;
   if (m_ShieldTrigger.Initialize() == false) return false;
   if (m_ChargeTransport.Initialize() == false) return false;
+  if (m_StripReadoutNoise.Initialize() == false) return false;
   if (m_StripReadout.Initialize() == false) return false;
   if (m_StripTrigger.Initialize() == false) return false;
   if (m_DepthReadout.Initialize() == false) return false;
@@ -240,6 +241,7 @@ void MModuleDEESMEX::Finalize()
   m_ShieldReadout.Finalize();
   m_ShieldTrigger.Finalize();
   m_ChargeTransport.Finalize();
+  m_StripReadoutNoise.Finalize();
   m_StripReadout.Finalize();
   m_StripTrigger.Finalize();
   m_DepthReadout.Finalize();

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -75,7 +75,7 @@ MModuleDEESMEX::MModuleDEESMEX() : MModule()
   m_HasOptionsGUI = true;
   
   // Default to adding noise to the sim data
-  m_AddNoise = true;
+  m_ResolutionCalibration = true;
 }
 
 
@@ -180,16 +180,16 @@ bool MModuleDEESMEX::AnalyzeEvent(MReadOutAssembly* Event)
   m_ChargeTransport.Clear();
   m_ChargeTransport.AnalyzeEvent(Event);
   
-  // Step (8): Simulate micro-phonics random noise
-  // Do this before energy -> ADCs because the FWHMs from the ecal are in keV
-  if (m_AddNoise == true) {
+  // Step (8): Handle the strip readout: energy -> ADCs
+  // Also includes user selected energy resolution with the FWHM values from the ecal 
+  m_StripReadout.Clear();
+  m_StripReadout.AnalyzeEvent(Event);
+  
+  // Step (9): Simulate micro-phonics random noise
+  if (m_ResolutionCalibration == true) {
     m_StripReadoutNoise.Clear();
     m_StripReadoutNoise.AnalyzeEvent(Event);
   }
-
-  // Step (9): Handle the strip readout: energy -> ADCs
-  m_StripReadout.Clear();
-  m_StripReadout.AnalyzeEvent(Event);
 
   // Step (10): Handles triggers and guard ring vetoes, pre-scalers, calculate dead-time, add nearest neighbor noise, calculate random coincidence time
   m_StripTrigger.Clear();
@@ -284,9 +284,9 @@ bool MModuleDEESMEX::ReadXmlConfiguration(MXmlNode* Node)
   m_Output.ReadXmlConfiguration(Node);
   
   // Add noise button
-  MXmlNode* AddNoiseNode = Node->GetNode("AddNoise");
-  if (AddNoiseNode != nullptr) {
-    m_AddNoise = AddNoiseNode->GetValueAsBoolean();
+  MXmlNode* ResolutionCalibrationNode = Node->GetNode("ResolutionCalibration");
+  if (ResolutionCalibrationNode != nullptr) {
+    m_ResolutionCalibration  = ResolutionCalibrationNode->GetValueAsBoolean();
   }
 
   return true;
@@ -314,7 +314,7 @@ MXmlNode* MModuleDEESMEX::CreateXmlConfiguration()
   m_Output.CreateXmlConfiguration(Node);
   
   // Add noise button
-  new MXmlNode(Node, "AddNoise", m_AddNoise);
+  new MXmlNode(Node, "ResolutionCalibration", m_ResolutionCalibration);
 
   return Node;
 }

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -73,6 +73,9 @@ MModuleDEESMEX::MModuleDEESMEX() : MModule()
   AddSucceedingModuleType(MAssembly::c_NoRestriction);
   
   m_HasOptionsGUI = true;
+  
+  // Default to adding noise to the sim data
+  m_AddNoise = true;
 }
 
 
@@ -175,15 +178,17 @@ bool MModuleDEESMEX::AnalyzeEvent(MReadOutAssembly* Event)
   // Step (7): Handle GeD charge transport to grid and voxelation into strips
   m_ChargeTransport.Clear();
   m_ChargeTransport.AnalyzeEvent(Event);
+  
+  // Step (8)): Simulate micro-phonics random noise for triggered strips & next neighbors
+  // Do this before energy -> ADCs because the FWHMs from the ecal are in keV
+  if (m_AddNoise == true) {
+    m_StripReadoutNoise.Clear();
+    m_StripReadoutNoise.AnalyzeEvent(Event);
+  }
 
-  // Step (8): Handle the strip readout: energy -> ADCs
+  // Step (9): Handle the strip readout: energy -> ADCs
   m_StripReadout.Clear();
   m_StripReadout.AnalyzeEvent(Event);
-
-
-  // Step (9)): Simulate micro-phonics random noise for triggered strips & next neighbors
-  m_StripReadoutNoise.Clear();
-  m_StripReadoutNoise.AnalyzeEvent(Event);
 
   // Step (10): Handles triggers and guard ring vetoes, pre-scalers, calculate dead-time, add nearest neighbor noise, calculate random coincidence time
   m_StripTrigger.Clear();
@@ -275,6 +280,12 @@ bool MModuleDEESMEX::ReadXmlConfiguration(MXmlNode* Node)
   m_StripTrigger.ReadXmlConfiguration(Node);
   m_DepthReadout.ReadXmlConfiguration(Node);
   m_Output.ReadXmlConfiguration(Node);
+  
+  // Add noise button
+  MXmlNode* AddNoiseNode = Node->GetNode("AddNoise");
+  if (AddNoiseNode != nullptr) {
+    m_AddNoise = AddNoiseNode->GetValueAsBoolean();
+  }
 
   return true;
 }
@@ -299,6 +310,9 @@ MXmlNode* MModuleDEESMEX::CreateXmlConfiguration()
   m_StripTrigger.CreateXmlConfiguration(Node);
   m_DepthReadout.CreateXmlConfiguration(Node);
   m_Output.CreateXmlConfiguration(Node);
+  
+  // Add noise button
+  new MXmlNode(Node, "AddNoise", m_AddNoise);
 
   return Node;
 }

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -186,10 +186,8 @@ bool MModuleDEESMEX::AnalyzeEvent(MReadOutAssembly* Event)
   m_StripReadout.AnalyzeEvent(Event);
   
   // Step (9): Simulate micro-phonics random noise
-  if (m_ResolutionCalibration == true) {
-    m_StripReadoutNoise.Clear();
-    m_StripReadoutNoise.AnalyzeEvent(Event);
-  }
+  m_StripReadoutNoise.Clear();
+  m_StripReadoutNoise.AnalyzeEvent(Event);
 
   // Step (10): Handles triggers and guard ring vetoes, pre-scalers, calculate dead-time, add nearest neighbor noise, calculate random coincidence time
   m_StripTrigger.Clear();

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -48,10 +48,6 @@ ClassImp(MSubModuleStripReadout)
 MSubModuleStripReadout::MSubModuleStripReadout() : MSubModule()
 {
   // Construct an instance of MSubModuleStripReadout
-  
-  // Set all modules, which have to be done before this module
-  //TODO: @RobinAnthonyPetersen, need to make sure the strip noise gets added first! 
-  //AddPreceedingModuleType(MAssembly::c_StripReadoutNoise, true);
 
   m_Name = "DEE strip readout module";
 

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -54,9 +54,7 @@ MSubModuleStripReadout::MSubModuleStripReadout() : MSubModule()
   m_Name = "DEE strip readout module";
 
   m_EnergyCalibrationFileName = "";
-  
-  // Max value for the ADC range (14-bit ADC maximum)
-  m_MaxADCRange = 16383;
+
 }
 
 
@@ -151,8 +149,9 @@ bool MSubModuleStripReadout::Initialize()
         } else {
           // TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
           // So far, only added these ones because these are the ones we use for the ecals
-          if (g_Verbosity >= c_Warning) {
+          if (g_Verbosity >= c_Error) {
             cout << m_Name << ": Unknown FWHM calibrator type: " << ResolutionCalibrationType << endl;
+            return false;
           }
         }
       }
@@ -251,7 +250,7 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
       // If the user wants it applied, apply the FWHM Guassian energy resolution
       if (m_ApplyResolutionCalibration == true) {
         // Look up the FWHM fit for this strip
-        if (m_ResolutionCalibration.count(SH.m_ROE) > 0) {
+        if (m_ResolutionCalibration.count(SH.m_ROE) == 1) {
           
           // Calculate FWHM (keV) at this energy
           double fwhm = m_ResolutionCalibration[SH.m_ROE]->Eval(SH.m_Energy);

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -33,7 +33,6 @@
 #include "TMath.h"
 
 // MEGAlib libs:
-#include "MSubModule.h"
 #include "MParser.h"
 
 
@@ -106,7 +105,7 @@ bool MSubModuleStripReadout::Initialize()
     MTokenizer* T = Parser.GetTokenizerAt(i);
     
     // IFF user wants it, get the fits to smear the energies based on the FWHM from the ecal
-    if (m_ApplyResolutionCalibration) {
+    if (m_ApplyResolutionCalibration == true) {
       
       if (T->GetNTokens() >= 6 && T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
         MReadOutElementDoubleStrip R;
@@ -160,7 +159,7 @@ bool MSubModuleStripReadout::Initialize()
     }
     
     
-    // Get enegry calirbation fits second
+    // Get enegry calibration fits second
     if (T->GetNTokens() >= 2 && T->IsTokenAt(0, "CM") == true && T->IsTokenAt(1, "dss") == true) {
       
       MReadOutElementDoubleStrip R;
@@ -242,16 +241,16 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
   
-  double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
+  static const double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
 
   // Get low-voltage and high-voltage hits
   for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
     
     for (MDEEStripHit& SH : *Hits) {
       
-      // IFF the user wants it applied, apply the FWHM Guassian energy resolution
+      // If the user wants it applied, apply the FWHM Guassian energy resolution
       
-      if (m_ApplyResolutionCalibration) {
+      if (m_ApplyResolutionCalibration == true) {
         // Look up the FWHM fit for this strip
         if (m_ResolutionCalibration.count(SH.m_ROE) > 0) {
           
@@ -265,7 +264,16 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
           SH.m_Energy = gRandom->Gaus(SH.m_Energy, sigma);
           
           // If energy is lower than zero now, floor it to zero
-          if (SH.m_Energy < 0) SH.m_Energy = 0;
+          if (SH.m_Energy < 0) {
+            SH.m_Energy = 0;
+          }
+          
+        } else {
+          // The fit wasn't found! Handle the error
+          if (g_Verbosity >= c_Warning) {
+          cout << m_Name << ": Warning - No resolution calibration fit found for strip ID " << SH.m_ROE.GetStripID() << endl;
+          }
+          // Note, if there is not calibration found then the energy remains unsmeared
         }
       }
       

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -48,6 +48,10 @@ ClassImp(MSubModuleStripReadout)
 MSubModuleStripReadout::MSubModuleStripReadout() : MSubModule()
 {
   // Construct an instance of MSubModuleStripReadout
+  
+  // Set all modules, which have to be done before this module
+  //TODO: @RobinAnthonyPetersen, need to make sure the strip noise gets added first! 
+  //AddPreceedingModuleType(MAssembly::c_StripReadoutNoise, true);
 
   m_Name = "DEE strip readout module";
 

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -29,8 +29,11 @@
 // Standard libs:
 
 // ROOT libs:
+#include "TRandom.h"
+#include "TMath.h"
 
 // MEGAlib libs:
+#include "MSubModule.h"
 #include "MParser.h"
 
 
@@ -73,7 +76,7 @@ MSubModuleStripReadout::~MSubModuleStripReadout()
 bool MSubModuleStripReadout::Initialize()
 {
   // Initialize the module
-
+  
   // Check if we have a file
   if (m_EnergyCalibrationFileName == "") {
     if (g_Verbosity >= c_Error) {
@@ -90,73 +93,130 @@ bool MSubModuleStripReadout::Initialize()
     }
     return false;
   }
-
-  // Create the map (same as the Universal Energy Calibrator)
+  
+  // Create the map to store line numbers
   map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine;
+    
+  // Clear the maps before reading
+  m_ResolutionCalibration.clear();
+  m_Calibration.clear();
 
-  // Add case to handle shorted strips
+    
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
-    if (Parser.GetTokenizerAt(i)->GetNTokens() < 2) continue;
-
-    if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CM") == true &&
-        Parser.GetTokenizerAt(i)->IsTokenAt(1, "dss") == true) {
-
-      MReadOutElementDoubleStrip R;
-      R.SetDetectorID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(2));
-      R.SetStripID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(3));
-      R.IsLowVoltageStrip((Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "p") ||
-                          (Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "l"));
+    MTokenizer* T = Parser.GetTokenizerAt(i);
+    
+    // IFF user wants it, get the fits to smear the energies based on the FWHM from the ecal
+    if (m_ApplyResolutionCalibration) {
       
-      CM_ROEToLine[R] = i;
-    }
-  }
-
-  // Get the parameters and store the energy calibration fit function as ROOT's built-in TF1 
-  for (auto CM : CM_ROEToLine) {
-    unsigned int Pos = 5;
-    MString CalibratorType = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsString(Pos);
-    CalibratorType.ToLower();
-
-    if (CalibratorType == "poly1") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., m_MaxADCRange);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-
-      m_Calibration[CM.first] = melinatorfit;
-    } else if (CalibratorType == "poly2") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., m_MaxADCRange);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-      melinatorfit->FixParameter(2, a2);
-
-      m_Calibration[CM.first] = melinatorfit;
-    } else if (CalibratorType == "poly3") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., m_MaxADCRange);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-      melinatorfit->FixParameter(2, a2);
-      melinatorfit->FixParameter(3, a3);
-
-      m_Calibration[CM.first] = melinatorfit;
-    } else {
-      // TODO: Add all the other types of fits melinator can do
-      // So far, only added these ones because these are the ones we use for the ecals
-      if (g_Verbosity >= c_Error) {
-        cout<<m_Name<<": Unhandled CalibratorType: "<<CalibratorType<<endl<<"Please update this module."<<endl;
+      if (T->GetNTokens() >= 6 && T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
+        MReadOutElementDoubleStrip R;
+        R.SetDetectorID(T->GetTokenAtAsUnsignedInt(2));
+        R.SetStripID(T->GetTokenAtAsUnsignedInt(3));
+        R.IsLowVoltageStrip((T->GetTokenAtAsString(4) == "p") || (T->GetTokenAtAsString(4) == "l"));
+        
+        MString ResolutionCalibrationType = T->GetTokenAtAsString(5);
+        ResolutionCalibrationType.ToLower();
+        
+        // position of the fwhm and max keV value
+        unsigned int PosResolution = 6;
+        unsigned int HistMaxkeV = 10000;
+        
+        // Look for the CR lines
+        if (ResolutionCalibrationType == "poly1") {
+          double a0 = T->GetTokenAtAsDouble(PosResolution++);
+          double a1 = T->GetTokenAtAsDouble(PosResolution++);
+          
+          TF1* resFit = new TF1("res_poly1", "[0] + [1]*x", 0., HistMaxkeV);
+          resFit->SetParameters(a0, a1);
+          m_ResolutionCalibration[R] = resFit;
+          
+        } else if (ResolutionCalibrationType == "poly2") {
+          double a0 = T->GetTokenAtAsDouble(PosResolution++);
+          double a1 = T->GetTokenAtAsDouble(PosResolution++);
+          double a2 = T->GetTokenAtAsDouble(PosResolution++);
+          
+          TF1* resFit = new TF1("res_poly2", "[0] + [1]*x + [2]*x^2", 0., HistMaxkeV);
+          resFit->SetParameters(a0, a1, a2);
+          m_ResolutionCalibration[R] = resFit;
+          
+        } else if (ResolutionCalibrationType == "poly3") {
+          double a0 = T->GetTokenAtAsDouble(PosResolution++);
+          double a1 = T->GetTokenAtAsDouble(PosResolution++);
+          double a2 = T->GetTokenAtAsDouble(PosResolution++);
+          double a3 = T->GetTokenAtAsDouble(PosResolution++);
+          
+          TF1* resFit = new TF1("res_poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., HistMaxkeV);
+          resFit->SetParameters(a0, a1, a2, a3);
+          m_ResolutionCalibration[R] = resFit;
+          
+        } else {
+          // TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
+          // So far, only added these ones because these are the ones we use for the ecals
+          if (g_Verbosity >= c_Warning) {
+            cout << m_Name << ": Unknown FWHM calibrator type: " << ResolutionCalibrationType << endl;
+          }
+        }
       }
-      return false;
+    }
+    
+    
+    // Get enegry calirbation fits second
+    if (T->GetNTokens() >= 2 && T->IsTokenAt(0, "CM") == true && T->IsTokenAt(1, "dss") == true) {
+      
+      MReadOutElementDoubleStrip R;
+      R.SetDetectorID(T->GetTokenAtAsUnsignedInt(2));
+      R.SetStripID(T->GetTokenAtAsUnsignedInt(3));
+      R.IsLowVoltageStrip((T->GetTokenAtAsString(4) == "p") ||
+                          (T->GetTokenAtAsString(4) == "l"));
+      
+      unsigned int Pos = 5;
+      
+      // Get CM token
+      MString CalibratorType = T->GetTokenAtAsString(Pos);
+      CalibratorType.ToLower();
+      
+      
+      if (CalibratorType == "poly1") {
+        double a0 = T->GetTokenAtAsDouble(++Pos);
+        double a1 = T->GetTokenAtAsDouble(++Pos);
+        
+        TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., m_MaxADCRange);
+        melinatorfit->FixParameter(0, a0);
+        melinatorfit->FixParameter(1, a1);
+        
+        m_Calibration[R] = melinatorfit;
+      } else if (CalibratorType == "poly2") {
+        double a0 = T->GetTokenAtAsDouble(++Pos);
+        double a1 = T->GetTokenAtAsDouble(++Pos);
+        double a2 = T->GetTokenAtAsDouble(++Pos);
+        
+        TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., m_MaxADCRange);
+        melinatorfit->FixParameter(0, a0);
+        melinatorfit->FixParameter(1, a1);
+        melinatorfit->FixParameter(2, a2);
+        
+        m_Calibration[R] = melinatorfit;
+      } else if (CalibratorType == "poly3") {
+        double a0 = T->GetTokenAtAsDouble(++Pos);
+        double a1 = T->GetTokenAtAsDouble(++Pos);
+        double a2 = T->GetTokenAtAsDouble(++Pos);
+        double a3 = T->GetTokenAtAsDouble(++Pos);
+        
+        TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., m_MaxADCRange);
+        melinatorfit->FixParameter(0, a0);
+        melinatorfit->FixParameter(1, a1);
+        melinatorfit->FixParameter(2, a2);
+        melinatorfit->FixParameter(3, a3);
+        
+        m_Calibration[R] = melinatorfit;
+      } else {
+        // TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
+        // So far, only added these ones because these are the ones we use for the ecals
+        if (g_Verbosity >= c_Error) {
+          cout<<m_Name<<": Unhandled CalibratorType: "<<CalibratorType<<endl<<"Please update this module."<<endl;
+        }
+        return false;
+      }
     }
   }
 
@@ -181,12 +241,35 @@ void MSubModuleStripReadout::Clear()
 bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
+  
+  double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
 
   // Get low-voltage and high-voltage hits
   for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
     
     for (MDEEStripHit& SH : *Hits) {
-    
+      
+      // IFF the user wants it applied, apply the FWHM Guassian energy resolution
+      
+      if (m_ApplyResolutionCalibration) {
+        // Look up the FWHM fit for this strip
+        if (m_ResolutionCalibration.count(SH.m_ROE) > 0) {
+          
+          // Calculate FWHM (keV) at this energy
+          double fwhm = m_ResolutionCalibration[SH.m_ROE]->Eval(SH.m_Energy);
+          
+          // Convert FWHM to Sigma (FWHM = 2.355 * Sigma)
+          double sigma = fwhm / FWHMtoSigma;
+          
+          // Smear the hit energy using a Gaussian distribution
+          SH.m_Energy = gRandom->Gaus(SH.m_Energy, sigma);
+          
+          // If energy is lower than zero now, floor it to zero
+          if (SH.m_Energy < 0) SH.m_Energy = 0;
+        }
+      }
+      
+      // Apply the inverse energy calibration
       // Look up the fit using the ecal
       TF1* Fit = m_Calibration[SH.m_ROE];
 
@@ -224,6 +307,12 @@ void MSubModuleStripReadout::Finalize()
     delete F.second;
   }
   m_Calibration.clear();
+  
+  // Clean up the resolution calibration memory
+  for (auto& F : m_ResolutionCalibration) {
+    delete F.second;
+  }
+  m_ResolutionCalibration.clear();
 
   MSubModule::Finalize();
 }

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -75,7 +75,7 @@ MSubModuleStripReadout::~MSubModuleStripReadout()
 bool MSubModuleStripReadout::Initialize()
 {
   // Initialize the module
-  
+
   // Check if we have a file
   if (m_EnergyCalibrationFileName == "") {
     if (g_Verbosity >= c_Error) {
@@ -92,7 +92,7 @@ bool MSubModuleStripReadout::Initialize()
     }
     return false;
   }
-  
+
   // Create the map to store line numbers
   map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine;
     
@@ -100,7 +100,7 @@ bool MSubModuleStripReadout::Initialize()
   m_ResolutionCalibration.clear();
   m_Calibration.clear();
 
-    
+  
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
     MTokenizer* T = Parser.GetTokenizerAt(i);
     
@@ -241,7 +241,7 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
   
-  constexpr double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
+  static const double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
 
   // Get low-voltage and high-voltage hits
   for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
@@ -249,7 +249,6 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
     for (MDEEStripHit& SH : *Hits) {
       
       // If the user wants it applied, apply the FWHM Guassian energy resolution
-      
       if (m_ApplyResolutionCalibration == true) {
         // Look up the FWHM fit for this strip
         if (m_ResolutionCalibration.count(SH.m_ROE) > 0) {

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -104,7 +104,7 @@ bool MSubModuleStripReadout::Initialize()
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
     MTokenizer* T = Parser.GetTokenizerAt(i);
     
-    // IFF user wants it, get the fits to smear the energies based on the FWHM from the ecal
+    // If user wants it, get the fits to smear the energies based on the FWHM from the ecal
     if (m_ApplyResolutionCalibration == true) {
       
       if (T->GetNTokens() >= 6 && T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
@@ -241,7 +241,7 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
   
-  static const double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
+  constexpr double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
 
   // Get low-voltage and high-voltage hits
   for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {

--- a/src/MSubModuleStripReadoutNoise.cxx
+++ b/src/MSubModuleStripReadoutNoise.cxx
@@ -29,12 +29,9 @@
 // Standard libs:
 
 // ROOT libs:
-#include "TRandom.h"
-#include "TMath.h"
 
 // MEGAlib libs:
 #include "MSubModule.h"
-#include "MParser.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -53,7 +50,6 @@ MSubModuleStripReadoutNoise::MSubModuleStripReadoutNoise() : MSubModule()
   // Construct an instance of MSubModuleStripReadoutNoise
 
   m_Name = "DEE strip readout noise module";
-  m_EnergyCalibrationFileName = "";
 }
 
 
@@ -73,78 +69,6 @@ bool MSubModuleStripReadoutNoise::Initialize()
 {
   // Initialize the module
 
-  // Check for ecal file
-  if (m_EnergyCalibrationFileName == "") {
-    if (g_Verbosity >= c_Error) {
-      cout << m_Name << ": No energy calibration file specified." << endl;
-    }
-    return false;
-  }
-
-  // Open ecal file
-  MParser Parser;
-  if (Parser.Open(m_EnergyCalibrationFileName, MFile::c_Read) == false) {
-    if (g_Verbosity >= c_Error) {
-      cout << m_Name << ": Unable to open calibration file " << m_EnergyCalibrationFileName << endl;
-    }
-    return false;
-  }
-
-  // Look for the CR lines
-  m_ResolutionCalibration.clear();
-  for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
-    MTokenizer* T = Parser.GetTokenizerAt(i);
-    if (T->GetNTokens() < 6) continue;
-
-    if (T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
-      
-      MReadOutElementDoubleStrip R;
-      R.SetDetectorID(T->GetTokenAtAsUnsignedInt(2));
-      R.SetStripID(T->GetTokenAtAsUnsignedInt(3));
-      R.IsLowVoltageStrip((T->GetTokenAtAsString(4) == "p") ||
-                          (T->GetTokenAtAsString(4) == "l"));
-
-      MString CalibratorType = T->GetTokenAtAsString(5);
-      CalibratorType.ToLower();
-      
-      // position of the fwhm
-      unsigned int Pos = 6;
-      unsigned int HistMaxkeV = 10000;
-
-      if (CalibratorType == "poly1") {
-        double a0 = T->GetTokenAtAsDouble(Pos++);
-        double a1 = T->GetTokenAtAsDouble(Pos++);
-
-        TF1* resFit = new TF1("res_poly1", "[0] + [1]*x", 0., HistMaxkeV);
-        resFit->SetParameters(a0, a1);
-        m_ResolutionCalibration[R] = resFit;
-
-      } else if (CalibratorType == "poly2") {
-        double a0 = T->GetTokenAtAsDouble(Pos++);
-        double a1 = T->GetTokenAtAsDouble(Pos++);
-        double a2 = T->GetTokenAtAsDouble(Pos++);
-
-        TF1* resFit = new TF1("res_poly2", "[0] + [1]*x + [2]*x^2", 0., HistMaxkeV);
-        resFit->SetParameters(a0, a1, a2);
-        m_ResolutionCalibration[R] = resFit;
-
-      } else if (CalibratorType == "poly3") {
-        double a0 = T->GetTokenAtAsDouble(Pos++);
-        double a1 = T->GetTokenAtAsDouble(Pos++);
-        double a2 = T->GetTokenAtAsDouble(Pos++);
-        double a3 = T->GetTokenAtAsDouble(Pos++);
-
-        TF1* resFit = new TF1("res_poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., HistMaxkeV);
-        resFit->SetParameters(a0, a1, a2, a3);
-        m_ResolutionCalibration[R] = resFit;
-
-      } else {
-        if (g_Verbosity >= c_Warning) {
-          cout << m_Name << ": Unknown resolution calibrator type: " << CalibratorType << endl;
-        }
-      }
-    }
-  }
   return MSubModule::Initialize();
 }
 
@@ -166,31 +90,6 @@ void MSubModuleStripReadoutNoise::Clear()
 bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
-  
-  double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
-
-  // Apply energy resolution smearing to both sides
-  for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
-    
-    for (MDEEStripHit& SH : *Hits) {
-      
-      // Look up the FWHM fit for this strip
-      if (m_ResolutionCalibration.count(SH.m_ROE) > 0) {
-        
-        // Calculate FWHM (keV) at this energy
-        double fwhm = m_ResolutionCalibration[SH.m_ROE]->Eval(SH.m_Energy);
-        
-        // Convert FWHM to Sigma (FWHM = 2.355 * Sigma)
-        double sigma = fwhm / FWHMtoSigma;
-        
-        // Smear the hit energy using a Gaussian distribution
-        SH.m_Energy = gRandom->Gaus(SH.m_Energy, sigma);
-        
-        // If energy is lower than zero now, floor it to zero
-        if (SH.m_Energy < 0) SH.m_Energy = 0;
-      }
-    }
-  }
 
   /*
   // Dummy code:
@@ -215,13 +114,7 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
 
 void MSubModuleStripReadoutNoise::Finalize()
 {
-  // Finalize the analysis - do all cleanup, i.e., undo Initialize() 
-
-  // Clean up the memory 
-  for (auto& F : m_ResolutionCalibration) {
-    delete F.second;
-  }
-  m_ResolutionCalibration.clear();
+  // Finalize the analysis - do all cleanup, i.e., undo Initialize()
 
   MSubModule::Finalize();
 }
@@ -241,11 +134,6 @@ bool MSubModuleStripReadoutNoise::ReadXmlConfiguration(MXmlNode* Node)
   }
   */
   
-  MXmlNode* EnergyCalibrationFileNode = Node->GetNode("EnergyCalibrationFileName");
-  if (EnergyCalibrationFileNode != 0) {
-    m_EnergyCalibrationFileName = EnergyCalibrationFileNode->GetValue();
-  }
-
   return true;
 }
 
@@ -261,8 +149,6 @@ MXmlNode* MSubModuleStripReadoutNoise::CreateXmlConfiguration(MXmlNode* Node)
   MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
   */
   
-  new MXmlNode(Node, "EnergyCalibrationFileName", m_EnergyCalibrationFileName);
-
   return Node;
 }
 

--- a/src/MSubModuleStripReadoutNoise.cxx
+++ b/src/MSubModuleStripReadoutNoise.cxx
@@ -52,7 +52,7 @@ MSubModuleStripReadoutNoise::MSubModuleStripReadoutNoise() : MSubModule()
 {
   // Construct an instance of MSubModuleStripReadoutNoise
 
-  m_Name = "DEE strip readout module";
+  m_Name = "DEE strip readout noise module";
   m_EnergyCalibrationFileName = "";
 }
 
@@ -91,9 +91,10 @@ bool MSubModuleStripReadoutNoise::Initialize()
   }
 
   // Look for the CR lines
+  m_ResolutionCalibration.clear();
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
     MTokenizer* T = Parser.GetTokenizerAt(i);
-    if (T->GetNTokens() < 5) continue;
+    if (T->GetNTokens() < 6) continue;
 
     if (T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
       
@@ -185,7 +186,7 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
         // Smear the hit energy using a Gaussian distribution
         SH.m_Energy = gRandom->Gaus(SH.m_Energy, sigma);
         
-        // If enegry is lower than zero now, floor it to zero
+        // If energy is lower than zero now, floor it to zero
         if (SH.m_Energy < 0) SH.m_Energy = 0;
       }
     }
@@ -215,6 +216,12 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
 void MSubModuleStripReadoutNoise::Finalize()
 {
   // Finalize the analysis - do all cleanup, i.e., undo Initialize() 
+
+  // Clean up the memory 
+  for (auto& F : m_ResolutionCalibration) {
+    delete F.second;
+  }
+  m_ResolutionCalibration.clear();
 
   MSubModule::Finalize();
 }

--- a/src/MSubModuleStripReadoutNoise.cxx
+++ b/src/MSubModuleStripReadoutNoise.cxx
@@ -31,7 +31,6 @@
 // ROOT libs:
 
 // MEGAlib libs:
-#include "MSubModule.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -104,7 +103,7 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
     if (SH.m_ADC > 16383) SH.m_ADC = 16383;
   }
   */
- 
+
   return true;
 }
 
@@ -114,7 +113,7 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
 
 void MSubModuleStripReadoutNoise::Finalize()
 {
-  // Finalize the analysis - do all cleanup, i.e., undo Initialize()
+  // Finalize the analysis - do all cleanup, i.e., undo Initialize() 
 
   MSubModule::Finalize();
 }
@@ -133,7 +132,7 @@ bool MSubModuleStripReadoutNoise::ReadXmlConfiguration(MXmlNode* Node)
     m_SomeTagValue = SomeTagNode->GetValue();
   }
   */
-  
+
   return true;
 }
 
@@ -148,7 +147,7 @@ MXmlNode* MSubModuleStripReadoutNoise::CreateXmlConfiguration(MXmlNode* Node)
   /*
   MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
   */
-  
+
   return Node;
 }
 

--- a/src/MSubModuleStripReadoutNoise.cxx
+++ b/src/MSubModuleStripReadoutNoise.cxx
@@ -29,9 +29,12 @@
 // Standard libs:
 
 // ROOT libs:
+#include "TRandom.h"
+#include "TMath.h"
 
 // MEGAlib libs:
 #include "MSubModule.h"
+#include "MParser.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -50,6 +53,7 @@ MSubModuleStripReadoutNoise::MSubModuleStripReadoutNoise() : MSubModule()
   // Construct an instance of MSubModuleStripReadoutNoise
 
   m_Name = "DEE strip readout module";
+  m_EnergyCalibrationFileName = "";
 }
 
 
@@ -69,6 +73,77 @@ bool MSubModuleStripReadoutNoise::Initialize()
 {
   // Initialize the module
 
+  // Check for ecal file
+  if (m_EnergyCalibrationFileName == "") {
+    if (g_Verbosity >= c_Error) {
+      cout << m_Name << ": No energy calibration file specified." << endl;
+    }
+    return false;
+  }
+
+  // Open ecal file
+  MParser Parser;
+  if (Parser.Open(m_EnergyCalibrationFileName, MFile::c_Read) == false) {
+    if (g_Verbosity >= c_Error) {
+      cout << m_Name << ": Unable to open calibration file " << m_EnergyCalibrationFileName << endl;
+    }
+    return false;
+  }
+
+  // Look for the CR lines
+  for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
+    MTokenizer* T = Parser.GetTokenizerAt(i);
+    if (T->GetNTokens() < 5) continue;
+
+    if (T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
+      
+      MReadOutElementDoubleStrip R;
+      R.SetDetectorID(T->GetTokenAtAsUnsignedInt(2));
+      R.SetStripID(T->GetTokenAtAsUnsignedInt(3));
+      R.IsLowVoltageStrip((T->GetTokenAtAsString(4) == "p") ||
+                          (T->GetTokenAtAsString(4) == "l"));
+
+      MString CalibratorType = T->GetTokenAtAsString(5);
+      CalibratorType.ToLower();
+      
+      // position of the fwhm
+      unsigned int Pos = 6;
+      unsigned int HistMaxkeV = 10000;
+
+      if (CalibratorType == "poly1") {
+        double a0 = T->GetTokenAtAsDouble(Pos++);
+        double a1 = T->GetTokenAtAsDouble(Pos++);
+
+        TF1* resFit = new TF1("res_poly1", "[0] + [1]*x", 0., HistMaxkeV);
+        resFit->SetParameters(a0, a1);
+        m_ResolutionCalibration[R] = resFit;
+
+      } else if (CalibratorType == "poly2") {
+        double a0 = T->GetTokenAtAsDouble(Pos++);
+        double a1 = T->GetTokenAtAsDouble(Pos++);
+        double a2 = T->GetTokenAtAsDouble(Pos++);
+
+        TF1* resFit = new TF1("res_poly2", "[0] + [1]*x + [2]*x^2", 0., HistMaxkeV);
+        resFit->SetParameters(a0, a1, a2);
+        m_ResolutionCalibration[R] = resFit;
+
+      } else if (CalibratorType == "poly3") {
+        double a0 = T->GetTokenAtAsDouble(Pos++);
+        double a1 = T->GetTokenAtAsDouble(Pos++);
+        double a2 = T->GetTokenAtAsDouble(Pos++);
+        double a3 = T->GetTokenAtAsDouble(Pos++);
+
+        TF1* resFit = new TF1("res_poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., HistMaxkeV);
+        resFit->SetParameters(a0, a1, a2, a3);
+        m_ResolutionCalibration[R] = resFit;
+
+      } else {
+        if (g_Verbosity >= c_Warning) {
+          cout << m_Name << ": Unknown resolution calibrator type: " << CalibratorType << endl;
+        }
+      }
+    }
+  }
   return MSubModule::Initialize();
 }
 
@@ -89,10 +164,33 @@ void MSubModuleStripReadoutNoise::Clear()
 
 bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
 {
-  // Main data analysis routine, which updates the event to a new level 
-
-  // TODO: Update this to take energy resolution into account
+  // Main data analysis routine, which updates the event to a new level
   
+  double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
+
+  // Apply energy resolution smearing to both sides
+  for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
+    
+    for (MDEEStripHit& SH : *Hits) {
+      
+      // Look up the FWHM fit for this strip
+      if (m_ResolutionCalibration.count(SH.m_ROE) > 0) {
+        
+        // Calculate FWHM (keV) at this energy
+        double fwhm = m_ResolutionCalibration[SH.m_ROE]->Eval(SH.m_Energy);
+        
+        // Convert FWHM to Sigma (FWHM = 2.355 * Sigma)
+        double sigma = fwhm / FWHMtoSigma;
+        
+        // Smear the hit energy using a Gaussian distribution
+        SH.m_Energy = gRandom->Gaus(SH.m_Energy, sigma);
+        
+        // If enegry is lower than zero now, floor it to zero
+        if (SH.m_Energy < 0) SH.m_Energy = 0;
+      }
+    }
+  }
+
   /*
   // Dummy code:
   list<MDEEStripHit>& LVHits = Event->GetDEEStripHitLVListReference();
@@ -106,7 +204,7 @@ bool MSubModuleStripReadoutNoise::AnalyzeEvent(MReadOutAssembly* Event)
     if (SH.m_ADC > 16383) SH.m_ADC = 16383;
   }
   */
-
+ 
   return true;
 }
 
@@ -135,6 +233,11 @@ bool MSubModuleStripReadoutNoise::ReadXmlConfiguration(MXmlNode* Node)
     m_SomeTagValue = SomeTagNode->GetValue();
   }
   */
+  
+  MXmlNode* EnergyCalibrationFileNode = Node->GetNode("EnergyCalibrationFileName");
+  if (EnergyCalibrationFileNode != 0) {
+    m_EnergyCalibrationFileName = EnergyCalibrationFileNode->GetValue();
+  }
 
   return true;
 }
@@ -150,6 +253,8 @@ MXmlNode* MSubModuleStripReadoutNoise::CreateXmlConfiguration(MXmlNode* Node)
   /*
   MXmlNode* SomeTagNode = new MXmlNode(Node, "SomeTag", "SomeValue");
   */
+  
+  new MXmlNode(Node, "EnergyCalibrationFileName", m_EnergyCalibrationFileName);
 
   return Node;
 }


### PR DESCRIPTION
Another DEE pull request where @robin4730 deserves all the credit!
It adds the functionality to smear the simulated strip energies after charge transport based on the FWHM curves defined in the ecal file.

This PR implements:
- parsing the FWHM curves from the ecal files
- smearing all hit energies based on the FWHM evaluated at that energies

The user can choose whether the energies should be smeared via the nuclearizer GUI (`"Add noise to data"`):
<img width="551" height="410" alt="image" src="https://github.com/user-attachments/assets/dc685032-a319-48a8-8835-bb31a3f75ec6" />