### PR TITLE
BUG: Remove events in the HDF5 parser with no valid strip hits

### DIFF
--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -321,14 +321,17 @@ bool MModuleLoaderMeasurementsHDF::OpenHDF5File(MString FileName)
     if (PropertyList.getLayout() == H5D_CHUNKED) {
       hsize_t ChunkDims[H5S_MAX_RANK];
       PropertyList.getChunk(Rank, ChunkDims);
-
-      cout<<"Chunk dimensions: ";
-      for (int i = 0; i < Rank; ++i) {
-        cout<<ChunkDims[i]<<" ";
+      if (g_Verbosity > c_Info) {
+        cout<<"Chunk dimensions: ";
+        for (int i = 0; i < Rank; ++i) {
+          cout<<ChunkDims[i]<<" ";
+        }
+        cout<<endl;
       }
-      cout<<endl;
     } else {
-      cout<<"Dataset is not chunked (layout is not H5D_CHUNKED)."<<endl;
+      if (g_Verbosity > c_Info) {
+        cout<<"Dataset is not chunked (layout is not H5D_CHUNKED)."<<endl;
+      }
     }
 
     if (m_HDFStripHitVersion == MHDFStripHitVersion::V1_0) {
@@ -752,11 +755,12 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       // Create objects for all hits that belong to that event
       for (uint32_t i = EventIndices.m_FEEHits[0]; i < EventIndices.m_FEEHits[1]; i++) {
 
-        uint32_t IndexInBatch = i - m_MinHitIndex;
         if (i < m_MinHitIndex || i >= (m_MinHitIndex + m_Buffer_2.size())) {
           if (g_Verbosity >= c_Error) cout << m_XmlTag << ": Entry " << i << " is NOT in the current FEEHits buffer!" << endl;
           return false;
         } 
+
+        uint32_t IndexInBatch = i - m_MinHitIndex;
         
         MHDFStripHit_V2& Hit = m_Buffer_2[IndexInBatch];
         if (m_StripMap.HasReadOutID(Hit.m_StripID) == true) {

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -711,6 +711,17 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<StripID<<" not found in strip map"<<endl;
         return false;
       }
+
+      // Remove incomplete events (fewer strip hits than what is listed in HITS)
+      if (StripHitIndex > 0 && NumberOfHits != NStripHits) {
+        if (g_Verbosity >= c_Error) {
+          cout<<m_XmlTag<<": Event "<<Event->GetID()<<" had fewer strip hits ("<<StripHitIndex<<") than expected ("<<NStripHits<<"). Ignoring event."<<endl;
+        }
+        // Reduce the batch index and current hit counter to still process the hit from the next event
+        m_CurrentBatchIndex--;
+        m_CurrentHit--;
+        return false;
+      }
       
     } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
 
@@ -779,17 +790,6 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       }
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
-      return false;
-    }
-
-    // Remove incomplete events (fewer strip hits than what is listed in HITS)
-    if (StripHitIndex > 0 && NumberOfHits != NStripHits) {
-      if (g_Verbosity >= c_Error) {
-        cout<<m_XmlTag<<": Event "<<Event->GetID()<<" had fewer strip hits ("<<StripHitIndex<<") than expected according to the HDF5 file ("<<NStripHits<<")."<<endl;
-      }
-      // Reduce the batch index and current hit counter to still process the hit from the next event
-      m_CurrentBatchIndex--;
-      m_CurrentHit--;
       return false;
     }
 

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -725,6 +725,10 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
         m_CurrentHit--;
         return false;
       }
+
+      // Increase counters
+      NStripHits = static_cast<unsigned int>(NumberOfHits);
+      StripHitIndex++;
       
     } else if (m_HDFStripHitVersion <= MHDFStripHitVersion::V2_2) {
 
@@ -791,6 +795,9 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
           if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<Hit.m_StripID<<" not found in strip map"<<endl;
           return false;
         }
+
+        // Use StripIndex here (without updating NStripHits) to exit the while-loop after finalizing the Event
+        StripHitIndex++;
       }
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
@@ -815,8 +822,6 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     } else {
       Event->SetTI(TimeCode);
     }
-    NStripHits = static_cast<unsigned int>(NumberOfHits);
-    StripHitIndex++;
   }
 
   // Remove all Events with no (valid) strip hits

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -704,13 +704,9 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
         // NOTE: at some point we will want to remove this code and always include nearest neighbor data
         if (m_IncludeNearestNeighbor == false && HitType == 1) {
           delete H; // Clean up the memory we just allocated
-          // Increase counters
-          NStripHits = static_cast<unsigned int>(NumberOfHits);
-          StripHitIndex++;
-          continue;
+        } else {
+          Event->AddStripHit(H);
         }
-          
-        Event->AddStripHit(H);
       } else {
         if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<StripID<<" not found in strip map"<<endl;
         return false;
@@ -773,13 +769,9 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
           // NOTE: at some point we will want to remove this code and always include nearest neighbor data
           if (m_IncludeNearestNeighbor == false && Hit.m_HitType == 1) {
             delete H; // Clean up the memory we just allocated
-            // Increase counters
-            NStripHits = static_cast<unsigned int>(NumberOfHits);
-            StripHitIndex++;
-            continue;
+          } else {
+            Event->AddStripHit(H);
           }
-            
-          Event->AddStripHit(H);
         } else {
           if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Read-out ID "<<Hit.m_StripID<<" not found in strip map"<<endl;
           return false;
@@ -787,6 +779,17 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
       }
     } else {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unhandled HDF hit version found: "<<m_HDFStripHitVersion<<endl<<"Please update this module."<<endl;
+      return false;
+    }
+
+    // Remove incomplete events (fewer strip hits than what is listed in HITS)
+    if (StripHitIndex > 0 && NumberOfHits != NStripHits) {
+      if (g_Verbosity >= c_Error) {
+        cout<<m_XmlTag<<": Event "<<Event->GetID()<<" had fewer strip hits ("<<StripHitIndex<<") than expected according to the HDF5 file ("<<NStripHits<<")."<<endl;
+      }
+      // Reduce the batch index and current hit counter to still process the hit from the next event
+      m_CurrentBatchIndex--;
+      m_CurrentHit--;
       return false;
     }
 
@@ -814,6 +817,9 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
 
   // Remove all Events with no (valid) strip hits
   if (Event->GetNStripHits() == 0){
+    if (g_Verbosity >= c_Error) {
+      cout<<m_XmlTag<<": Event had no (valid) strip hits"<< endl;
+    }
     return false;
   }
 

--- a/src/MModuleLoaderMeasurementsHDF.cxx
+++ b/src/MModuleLoaderMeasurementsHDF.cxx
@@ -812,6 +812,11 @@ bool MModuleLoaderMeasurementsHDF::AnalyzeEvent(MReadOutAssembly* Event)
     StripHitIndex++;
   }
 
+  // Remove all Events with no (valid) strip hits
+  if (Event->GetNStripHits() == 0){
+    return false;
+  }
+
   Event->SetAnalysisProgress(MAssembly::c_EventLoader | MAssembly::c_EventLoaderMeasurement);
 
   m_NEventsInFile++;


### PR DESCRIPTION
Addressing the bug in the HDF5 parser seen in #133:

All of the events with bogus event ID seemed to have no strip hits.
<img width="164" height="85" alt="image" src="https://github.com/user-attachments/assets/81f6adf7-d698-43af-bdfc-bc621d65cd4e" />

I think what is happening that these Events end up having no (valid) strip hits, and therefore never get assigned any event ID in the HDF5 parser, resulting in uninitialized (bogus) event IDs.

The most straight-forward fix would be to remove those `Events` with no valid strip hits.
After this fix, I do not see these events with bogus IDs (4294967284) anymore.
