### PR TITLE
Wing/fits saver l1a small fix, l1b and l2 saver added

### DIFF
--- a/include/MGUIOptionsSaverMeasurementsFITS.h
+++ b/include/MGUIOptionsSaverMeasurementsFITS.h
@@ -30,6 +30,7 @@
 #include "MGlobal.h"
 #include "MGUIEFileSelector.h"
 #include "MGUIOptions.h"
+#include <TGComboBox.h>
 
 // Nuclearizer libs:
 #include "MModule.h"
@@ -71,6 +72,9 @@ class MGUIOptionsSaverMeasurementsFITS : public MGUIOptions
  private:
   //! Select which FITS file to save to
   MGUIEFileSelector* m_FileSelectorFITS;
+
+  //! Select output level: L1b or L2
+  TGComboBox* m_OutputLevelCombo;
 
 
 

--- a/include/MGUIOptionsSaverMeasurementsFITS.h
+++ b/include/MGUIOptionsSaverMeasurementsFITS.h
@@ -74,7 +74,7 @@ class MGUIOptionsSaverMeasurementsFITS : public MGUIOptions
   MGUIEFileSelector* m_FileSelectorFITS;
 
   //! Select output level: L1b or L2
-  TGComboBox* m_OutputLevelCombo;
+  TGComboBox* m_OutputDataLevelCombo;
 
 
 

--- a/include/MGUIOptionsSaverMeasurementsFITS.h
+++ b/include/MGUIOptionsSaverMeasurementsFITS.h
@@ -23,14 +23,14 @@
 #include <TObjArray.h>
 #include <TGFrame.h>
 #include <TGButton.h>
-#include <MString.h>
 #include <TGClient.h>
+#include <TGComboBox.h>
 
 // MEGAlib libs:
 #include "MGlobal.h"
+#include <MString.h>
 #include "MGUIEFileSelector.h"
 #include "MGUIOptions.h"
-#include <TGComboBox.h>
 
 // Nuclearizer libs:
 #include "MModule.h"

--- a/include/MModuleSaverMeasurementsFITS.h
+++ b/include/MModuleSaverMeasurementsFITS.h
@@ -72,6 +72,11 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Get the output file name
   MString GetFileName() const { return m_FileName; }
 
+  //! Set the output level: 0 = L1b, 1 = L2
+  void SetOutputLevel(int Level) { m_OutputLevel = Level; }
+  //! Get the output level
+  int GetOutputLevel() const { return m_OutputLevel; }
+
 
   // protected methods:
  protected:
@@ -94,6 +99,9 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Output file name
   MString m_FileName;
 
+  //! Output level: 0 = L1b (all events, with BAD_FLAG), 1 = L2 (screened, no BAD_FLAG)
+  int m_OutputLevel;
+
   //! The FITS file object pointer
   FITS* m_FITSFile;
 
@@ -105,6 +113,18 @@ class MModuleSaverMeasurementsFITS : public MModule
 
   //! Total number of events written
   long m_TotalEventsWritten;
+
+  //! Total number of events skipped (L2 screening)
+  long m_TotalEventsSkipped;
+
+  //! First event time seen (mission seconds since 2025-01-01)
+  double m_FirstEventTime;
+
+  //! Last event time seen (mission seconds since 2025-01-01)
+  double m_LastEventTime;
+
+  //! Whether any events have been processed yet
+  bool m_HasEvents;
 
   //! Batch size for writing FITS data
   static const long m_BatchSize = 100;

--- a/include/MModuleSaverMeasurementsFITS.h
+++ b/include/MModuleSaverMeasurementsFITS.h
@@ -19,6 +19,8 @@
 // Standard libs:
 #include <vector>
 #include <valarray>
+#include <string>
+#include <cstdint>
 
 // ROOT libs:
 
@@ -137,19 +139,20 @@ class MModuleSaverMeasurementsFITS : public MModule
 
   //! Batch data storage for scalar columns
   std::vector<double> m_BatchTIME;
-  std::vector<unsigned long> m_BatchEVENTID;
+  std::vector<uint32_t> m_BatchEVENTID;       // Document said 1J = signed 32-bit, but I think we should use unsigned because EVENTID should always be >= 1?
   std::vector<uint8_t> m_BatchEVENTTYPE;
   std::vector<uint8_t> m_BatchEVENTCLASS;
   std::vector<uint8_t> m_BatchNUMHIT;
   std::vector<uint8_t> m_BatchVETO;
-  std::vector<uint8_t> m_BatchSEQHIT;
+  std::vector<std::string> m_BatchQUALITY_FLAG; //64A string
 
   //! Batch data storage for fixed-length array columns (event-level)
-  std::vector<std::valarray<float>> m_BatchSTATTEST;
-  std::vector<std::valarray<float>> m_BatchRECOILDIR;
-  std::vector<std::valarray<float>> m_BatchRECOILDIR_ERR;
+  std::vector<std::valarray<float>> m_BatchSTATTEST;     // 8E
+  std::vector<std::valarray<float>> m_BatchRECOILDIR;    // 3E
+  std::vector<std::valarray<float>> m_BatchRECOILDIR_ERR;// 3E
 
   //! Batch data storage for variable-length array columns (hit-level data)
+  std::vector<std::valarray<uint8_t>> m_BatchSEQHIT; //L1b PB(50), L2: 10B
   std::vector<std::valarray<float>> m_BatchX;
   std::vector<std::valarray<float>> m_BatchY;
   std::vector<std::valarray<float>> m_BatchZ;
@@ -158,7 +161,6 @@ class MModuleSaverMeasurementsFITS : public MModule
   std::vector<std::valarray<float>> m_BatchZ_ERR;
   std::vector<std::valarray<float>> m_BatchENERGY;
   std::vector<std::valarray<float>> m_BatchENERGY_ERR;
-  std::vector<std::valarray<float>> m_BatchQUALITY_FLAG;
 
 
 #ifdef ___CLING___

--- a/include/MModuleSaverMeasurementsFITS.h
+++ b/include/MModuleSaverMeasurementsFITS.h
@@ -72,10 +72,10 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Get the output file name
   MString GetFileName() const { return m_FileName; }
 
-  //! Set the output level: 0 = L1b, 1 = L2
-  void SetOutputLevel(int Level) { m_OutputLevel = Level; }
-  //! Get the output level
-  int GetOutputLevel() const { return m_OutputLevel; }
+  //! Set the output data level: 1 = L1b, 2 = L2
+  void SetOutputDataLevel(int Level) { m_OutputDataLevel = Level; }
+  //! Get the output data level: 1 = L1b, 2 = L2
+  int GetOutputDataLevel() const { return m_OutputDataLevel; }
 
 
   // protected methods:
@@ -99,8 +99,8 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Output file name
   MString m_FileName;
 
-  //! Output level: 0 = L1b (all events, with BAD_FLAG), 1 = L2 (screened, no BAD_FLAG)
-  int m_OutputLevel;
+  //! Output data level: 1 = L1b (all events, with QUALITY_FLAG), 2 = L2 (screened, no QUALITY_FLAG)
+  int m_OutputDataLevel;
 
   //! The FITS file object pointer
   FITS* m_FITSFile;
@@ -117,11 +117,11 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Total number of events skipped (L2 screening)
   long m_TotalEventsSkipped;
 
-  //! First event time seen (mission seconds since 2025-01-01)
-  double m_FirstEventTime;
+  //! First event time seen, RTS (mission seconds since 2025-01-01)
+  double m_FirstEventTime_RTS;
 
-  //! Last event time seen (mission seconds since 2025-01-01)
-  double m_LastEventTime;
+  //! Last event time seen, RTS (mission seconds since 2025-01-01)
+  double m_LastEventTime_RTS;
 
   //! Whether any events have been processed yet
   bool m_HasEvents;
@@ -137,14 +137,16 @@ class MModuleSaverMeasurementsFITS : public MModule
 
   //! Batch data storage for scalar columns
   std::vector<double> m_BatchTIME;
+  std::vector<unsigned long> m_BatchEVENTID;
   std::vector<uint8_t> m_BatchEVENTTYPE;
   std::vector<uint8_t> m_BatchEVENTCLASS;
   std::vector<uint8_t> m_BatchNUMHIT;
+  std::vector<uint8_t> m_BatchVETO;
   std::vector<uint8_t> m_BatchSEQHIT;
 
   //! Batch data storage for fixed-length array columns (event-level)
-  std::vector<std::valarray<float>> m_BatchSTATTEST;      
-  std::vector<std::valarray<float>> m_BatchRECOILDIR;     
+  std::vector<std::valarray<float>> m_BatchSTATTEST;
+  std::vector<std::valarray<float>> m_BatchRECOILDIR;
   std::vector<std::valarray<float>> m_BatchRECOILDIR_ERR;
 
   //! Batch data storage for variable-length array columns (hit-level data)
@@ -156,7 +158,7 @@ class MModuleSaverMeasurementsFITS : public MModule
   std::vector<std::valarray<float>> m_BatchZ_ERR;
   std::vector<std::valarray<float>> m_BatchENERGY;
   std::vector<std::valarray<float>> m_BatchENERGY_ERR;
-  std::vector<std::valarray<float>> m_BatchBAD_FLAG;
+  std::vector<std::valarray<float>> m_BatchQUALITY_FLAG;
 
 
 #ifdef ___CLING___

--- a/include/MModuleSaverMeasurementsL0.h
+++ b/include/MModuleSaverMeasurementsL0.h
@@ -78,11 +78,11 @@ class MModuleSaverMeasurementsL0 : public MModule
   //! Pack bits into a continuous bit stream
   void PackBitsIntoBitstream(std::vector<uint8_t>& bitstream, int& bitOffset, uint64_t bits, int numBits);
   //! Encode a normal strip hit (Type 0x0) - returns 44 bits
-  uint64_t EncodeNormalHit(int stripID, bool fastTiming, int energy, int timing);
+  uint64_t EncodeNormalHit(int stripID, bool fastTiming, int adc, int tac);
   //! Encode a neighboring strip hit (Type 0x1) - returns 36 bits
-  uint64_t EncodeNeighborHit(int stripID, bool fastTiming, int energy, int timing);
+  uint64_t EncodeNeighborHit(int stripID, bool fastTiming, int adc, int tac);
   //! Encode a guard ring hit (Type 0x2) - returns 24 bits
-  uint32_t EncodeGuardRingHit(int stripID, int energy);
+  uint32_t EncodeGuardRingHit(int stripID, int adc);
   //! Get event type based on detector count and veto status
   uint8_t GetEventType(MReadOutAssembly* Event);
   //! Write 16-bit value in big-endian

--- a/src/MGUIOptionsSaverMeasurementsFITS.cxx
+++ b/src/MGUIOptionsSaverMeasurementsFITS.cxx
@@ -74,6 +74,17 @@ void MGUIOptionsSaverMeasurementsFITS::Create()
   m_FileSelectorFITS->SetFileType("FITS file", "*.fit");
   m_OptionsFrame->AddFrame(m_FileSelectorFITS, LabelLayout);
 
+  // Output level selector: L1b or L2
+  TGLabel* LevelLabel = new TGLabel(m_OptionsFrame, "Output Level:");
+  m_OptionsFrame->AddFrame(LevelLabel, LabelLayout);
+
+  m_OutputLevelCombo = new TGComboBox(m_OptionsFrame);
+  m_OutputLevelCombo->AddEntry("L1b (all events, with BAD_FLAG)", 0);
+  m_OutputLevelCombo->AddEntry("L2 (screened, no BAD_FLAG)", 1);
+  m_OutputLevelCombo->Select(dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->GetOutputLevel());
+  m_OutputLevelCombo->Resize(300, 25);
+  m_OptionsFrame->AddFrame(m_OutputLevelCombo, LabelLayout);
+
   PostCreate();
 }
 
@@ -117,6 +128,7 @@ bool MGUIOptionsSaverMeasurementsFITS::OnApply()
   // Modify this to store the data in the module!
 
   dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetFileName(m_FileSelectorFITS->GetFileName());
+  dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetOutputLevel(m_OutputLevelCombo->GetSelected());
 
   return true;
 }

--- a/src/MGUIOptionsSaverMeasurementsFITS.cxx
+++ b/src/MGUIOptionsSaverMeasurementsFITS.cxx
@@ -27,7 +27,7 @@
 #include <TGResourcePool.h>
 
 // MEGAlib libs:
-#include <MString.h>
+#include "MString.h"
 #include "MStreams.h"
 #include "MModuleSaverMeasurementsFITS.h"
 
@@ -78,12 +78,12 @@ void MGUIOptionsSaverMeasurementsFITS::Create()
   TGLabel* LevelLabel = new TGLabel(m_OptionsFrame, "Output Level:");
   m_OptionsFrame->AddFrame(LevelLabel, LabelLayout);
 
-  m_OutputLevelCombo = new TGComboBox(m_OptionsFrame);
-  m_OutputLevelCombo->AddEntry("L1b (all events, with BAD_FLAG)", 0);
-  m_OutputLevelCombo->AddEntry("L2 (screened, no BAD_FLAG)", 1);
-  m_OutputLevelCombo->Select(dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->GetOutputLevel());
-  m_OutputLevelCombo->Resize(300, 25);
-  m_OptionsFrame->AddFrame(m_OutputLevelCombo, LabelLayout);
+  m_OutputDataLevelCombo = new TGComboBox(m_OptionsFrame);
+  m_OutputDataLevelCombo->AddEntry("L1b (all events, with QUALITY_FLAG)", 1);
+  m_OutputDataLevelCombo->AddEntry("L2 (screened, no QUALITY_FLAG)", 2);
+  m_OutputDataLevelCombo->Select(dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->GetOutputDataLevel());
+  m_OutputDataLevelCombo->Resize(300, 25);
+  m_OptionsFrame->AddFrame(m_OutputDataLevelCombo, LabelLayout);
 
   PostCreate();
 }
@@ -128,7 +128,7 @@ bool MGUIOptionsSaverMeasurementsFITS::OnApply()
   // Modify this to store the data in the module!
 
   dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetFileName(m_FileSelectorFITS->GetFileName());
-  dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetOutputLevel(m_OutputLevelCombo->GetSelected());
+  dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetOutputDataLevel(m_OutputDataLevelCombo->GetSelected());
 
   return true;
 }

--- a/src/MGUIOptionsSaverMeasurementsFITS.cxx
+++ b/src/MGUIOptionsSaverMeasurementsFITS.cxx
@@ -23,11 +23,11 @@
 
 // ROOT libs:
 #include <TSystem.h>
-#include <MString.h>
 #include <TGLabel.h>
 #include <TGResourcePool.h>
 
 // MEGAlib libs:
+#include <MString.h>
 #include "MStreams.h"
 #include "MModuleSaverMeasurementsFITS.h"
 

--- a/src/MModuleLoaderMeasurementsFITS.cxx
+++ b/src/MModuleLoaderMeasurementsFITS.cxx
@@ -98,7 +98,7 @@ bool MModuleLoaderMeasurementsFITS::Initialize()
 
   // Clean:
   m_FileType = "Unknown";
-  
+
   if (MFile::Exists(m_FileName) == false) {
     if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": The file "<<m_FileName<<" does not exist."<<endl;
     return false;
@@ -310,6 +310,8 @@ bool MModuleLoaderMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   //which mean we will not read a new batch. Instead we will read from the current batch we have
 
   if (ReadBatch() == false) {
+    cout<<m_Name<<": No more events!"<<endl;
+    m_IsFinished = true;
     return false; // No more events
   }
 

--- a/src/MModuleLoaderMeasurementsFITS.cxx
+++ b/src/MModuleLoaderMeasurementsFITS.cxx
@@ -41,6 +41,7 @@ using namespace std;
 #include "MReadOutDataADCValue.h"
 #include "MReadOutDataTiming.h"
 #include "MReadOutDataOrigins.h"
+#include "MTime.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -325,7 +326,7 @@ bool MModuleLoaderMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 
   // Set event-level properties
   // Event->SetID();  // TODO: No EventID
-  Event->SetCL(eventTime);     // Mission time in seconds
+  Event->SetTime(MTime(eventTime));     // Typed MTime object built from seconds
 
   // Loop through strip hits and create MStripHit objects
   for (uint8_t hitIdx = 0; hitIdx < numStripHit; ++hitIdx) {

--- a/src/MModuleLoaderMeasurementsFITS.cxx
+++ b/src/MModuleLoaderMeasurementsFITS.cxx
@@ -311,7 +311,9 @@ bool MModuleLoaderMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   //which mean we will not read a new batch. Instead we will read from the current batch we have
 
   if (ReadBatch() == false) {
-    cout<<m_Name<<": No more events!"<<endl;
+    if (g_Verbosity >= c_Info) {
+      cout << m_XmlTag << ": No more events!" << endl;
+    }
     m_IsFinished = true;
     return false; // No more events
   }

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -37,6 +37,9 @@ using namespace std;
 // MEGAlib libs:
 #include "MGUIOptionsSaverMeasurementsFITS.h"
 #include "MHit.h"
+#include "MPhysicalEvent.h"
+#include "MComptonEvent.h"
+#include "MPhotoEvent.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -57,7 +60,7 @@ MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS() : MModule()
   // Set all module relevant information
 
   // Set the module name --- has to be unique
-  m_Name = "Save events to FITS files (L1b)";
+  m_Name = "Save events to FITS files (L1b/L2)";
 
   // Set the XML tag --- has to be unique --- no spaces allowed
   m_XmlTag = "XmlTagSaverMeasurementsFITS";
@@ -80,8 +83,13 @@ MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS() : MModule()
   m_PrimaryHDU = nullptr;
   m_ScienceTable = nullptr;
   m_TotalEventsWritten = 0;
+  m_TotalEventsSkipped = 0;
   m_BatchStartRow = 1;
   m_BatchEventCount = 0;
+  m_OutputLevel = 0; // 0 = L1b (default), 1 = L2
+  m_FirstEventTime = 0.0;
+  m_LastEventTime = 0.0;
+  m_HasEvents = false;
 }
 
 
@@ -124,7 +132,8 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
   // Create the FITS file using CCfits
   try {
 
-    if (g_Verbosity >= c_Info) cout<<m_XmlTag<<": Creating FITS file: "<<string(FileName)<<endl;
+    string levelStr = (m_OutputLevel == 1) ? "L2" : "L1b";
+    if (g_Verbosity >= c_Info) cout<<m_XmlTag<<": Creating "<<levelStr<<" FITS file: "<<string(FileName)<<endl;
 
     // Create new FITS file (overwrite if exists)
     m_FITSFile = new FITS(string(FileName), RWmode::Write);
@@ -153,12 +162,13 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     // PE(100) = variable-length single-precision float array (max 100)
     // 4E = fixed-length array of 4 single-precision floats
     // 3E = fixed-length array of 3 single-precision floats
+    // L1b has BAD_FLAG, L2 does not (per spec: L2 removes bad events and BAD_FLAG column)
     std::vector<string> colNames = {
       "TIME", "EVENTTYPE", "EVENTCLASS", "NUMHIT", "SEQHIT",
       "STATTEST", "RECOILDIR", "RECOILDIR_ERR",
       "X", "Y", "Z",
       "X_ERR", "Y_ERR", "Z_ERR",
-      "ENERGY", "ENERGY_ERR", "BAD_FLAG"
+      "ENERGY", "ENERGY_ERR"
     };
 
     std::vector<string> colFormats = {
@@ -167,8 +177,8 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
       "1B",      // EVENTCLASS - scalar byte
       "1B",      // NUMHIT - scalar byte
       "1B",      // SEQHIT - scalar byte
-      "4E",      // STATTEST 
-      "3E",      // RECOILDIR 
+      "4E",      // STATTEST
+      "3E",      // RECOILDIR
       "3E",      // RECOILDIR_ERR
       "PE(100)", // X - variable-length float array
       "PE(100)", // Y
@@ -177,23 +187,30 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
       "PE(100)", // Y_ERR
       "PE(100)", // Z_ERR
       "PE(100)", // ENERGY
-      "PE(100)", // ENERGY_ERR
-      "PE(100)"  // BAD_FLAG
+      "PE(100)"  // ENERGY_ERR
     };
 
     std::vector<string> colUnits = {
       "s", "", "", "", "",
-      "", "unit", "unit",
-      "cm", "unit", "unit",
+      "", "", "",
+      "cm", "cm", "cm",
       "unit", "unit", "unit",
-      "keV", "unit", ""
+      "keV", "unit"
     };
 
+    // L1b includes BAD_FLAG column, L2 does not
+    if (m_OutputLevel == 0) {
+      colNames.push_back("BAD_FLAG");
+      colFormats.push_back("PE(100)");
+      colUnits.push_back("");
+    }
+
     // Create binary table extension
-    m_ScienceTable = m_FITSFile->addTable("Compton_L1b_1st_Ext", 0, colNames, colFormats, colUnits);
+    string extName = (m_OutputLevel == 1) ? "GED_L2" : "GED_L1B";
+    m_ScienceTable = m_FITSFile->addTable(extName, 0, colNames, colFormats, colUnits);
 
     // Add keywords to science table
-    m_ScienceTable->addKey("EXTNAME", "GED_L1B", "name of this HDU");
+    m_ScienceTable->addKey("EXTNAME", extName, "name of this HDU");
     m_ScienceTable->addKey("TELESCOP", "COSI", "Telescope mission name");
     m_ScienceTable->addKey("INSTRUME", "GED", "Instrument name");
     m_ScienceTable->addKey("DATAMODE", "TBD", "Instrument datamode");
@@ -208,10 +225,10 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     m_ScienceTable->addKey("TIMEUNIT", "s", "Time unit for timing header keywords");
     m_ScienceTable->addKey("TIMEDEL", 0.0, "Integration time");
     m_ScienceTable->addKey("CLOCKAPP", false, "If clock corrections are applied (T/F)");
-    m_ScienceTable->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date"); //DATE-OBS and DATA-END should match the primary header
-    m_ScienceTable->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date"); //DATE-OBS and DATA-END should match the primary header
-    m_ScienceTable->addKey("TSTART", 0.0, "Start time"); //TSTART and TSTOP are the start and stop of the dataset written in seconds from the reference time
-    m_ScienceTable->addKey("TSTOP", 0.0, "Stop time"); //TSTART and TSTOP are the start and stop of the dataset written in seconds from the reference time
+    m_ScienceTable->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date"); //placeholder, this will be wroten after we read through all the event
+    m_ScienceTable->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date"); // 
+    m_ScienceTable->addKey("TSTART", 0.0, "Start time"); //placeholder, this will be wroten after we read through all the event
+    m_ScienceTable->addKey("TSTOP", 0.0, "Stop time"); //
     m_ScienceTable->addKey("HDUCLASS", "OGIP", "format conforms to OGIP standard");
     m_ScienceTable->addKey("HDUCLAS1", "ARRAY", "hduclass1");
     m_ScienceTable->addKey("HDUCLAS2", "TOTAL", "hduclas2");
@@ -242,21 +259,83 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Add this event to the batch, write batch when full
 
+  // L2 mode: skip bad events (screening)
+  if (m_OutputLevel == 1 && Event->IsBad()) {
+    m_TotalEventsSkipped++;
+    Event->SetAnalysisProgress(MAssembly::c_EventSaver);
+    return true;
+  }
+
   // Extract event-level data
-  double time = Event->GetCL();
+  MTime eventTime = Event->GetTime();
+  //Get the seconds since epoch in double format
+  double time = eventTime.GetAsSeconds();
   unsigned int numHits = Event->GetNHits();
 
-  // Event-level metadata (placeholders for now - can be filled in later)
+  // loop through all event, and record the start and end time for TSTART/TSTOP
+  if (!m_HasEvents) {
+    m_FirstEventTime = time;
+    m_LastEventTime = time;
+    m_HasEvents = true;
+  } else {
+    if (time < m_FirstEventTime) m_FirstEventTime = time;
+    if (time > m_LastEventTime) m_LastEventTime = time;
+  }
+
+  // Event-level metadata defaults
   uint8_t eventType = 0;    // 0 = unknown/default
-  uint8_t eventClass = 0;   // 0 = unknown (can check for Compton/photoabsorption later)
-  uint8_t seqHit = 0;       // 0 = first/only sequence
+  uint8_t eventClass = 2;   // 2 = unreconstructed
+  uint8_t seqHit = 0;
 
   // Fixed-length arrays for event-level data (initialize to zeros)
-  std::valarray<float> statTest(0.0f, 4);         // 4 statistical test values
-  std::valarray<float> recoilDir(0.0f, 3);        // Recoil electron direction (x,y,z)
-  std::valarray<float> recoilDirErr(0.0f, 3);     // Recoil direction error
+  std::valarray<float> statTest(0.0f, 4);
+  std::valarray<float> recoilDir(0.0f, 3);
+  std::valarray<float> recoilDirErr(0.0f, 3);
 
-  // Resize arrays for this event's hits (using float to match PE format)
+  // Extract revan reconstruction data if available
+  MPhysicalEvent* PE = Event->GetPhysicalEvent();
+  if (PE != nullptr) {
+    int peType = PE->GetType();
+
+    if (peType == MPhysicalEvent::c_Compton) {
+      eventClass = 0;  // 0 = Compton
+
+      MComptonEvent* CE = dynamic_cast<MComptonEvent*>(PE);
+      if (CE != nullptr) {
+        seqHit = (uint8_t)CE->SequenceLength();
+
+        MVector de = CE->De();
+        recoilDir[0] = (float)de.X();
+        recoilDir[1] = (float)de.Y();
+        recoilDir[2] = (float)de.Z();
+
+        MVector dde = CE->dDe();
+        recoilDirErr[0] = (float)dde.X();
+        recoilDirErr[1] = (float)dde.Y();
+        recoilDirErr[2] = (float)dde.Z();
+
+        // TODO: Statistical test values (spec TBD) 
+        statTest[0] = (float)CE->Phi();
+        statTest[1] = (float)CE->DeltaTheta();
+        statTest[2] = (float)CE->MinLeverArm();
+        statTest[3] = 0.0f;
+      }
+
+    } else if (peType == MPhysicalEvent::c_Photo) {
+      eventClass = 1;  // 1 = photoabsorption
+      seqHit = 1;
+
+    } else {
+      eventClass = 2;  // 2 = unreconstructed
+    }
+  }
+
+  // Override eventClass for bad events (per spec: 3 = bad)
+  if (Event->IsBad()) {
+    eventClass = 3;
+  }
+
+  // Hit-level arrays
   std::valarray<float> x(numHits);
   std::valarray<float> y(numHits);
   std::valarray<float> z(numHits);
@@ -265,25 +344,28 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   std::valarray<float> z_err(numHits);
   std::valarray<float> energy(numHits);
   std::valarray<float> energy_err(numHits);
-  std::valarray<float> bad_flag(0.0f, numHits);   // Initialize flags to 0
+  std::valarray<float> bad_flag(0.0f, numHits);
+
+  // TODO: Set bad flag if event failed any calibration step (L1b only)
+  // Detail TBD, for now setting bad_flag based on IsBad()
+  if (m_OutputLevel == 0 && Event->IsBad()) {
+    bad_flag = 1.0f;
+  }
 
   // Extract hit-level data
   for (unsigned int i = 0; i < numHits; ++i) {
     MHit* hit = Event->GetHit(i);
 
-    // Get position
     MVector position = hit->GetPosition();
     x[i] = (float)position.X();
     y[i] = (float)position.Y();
     z[i] = (float)position.Z();
 
-    // Get position errors
     MVector positionResolution = hit->GetPositionResolution();
     x_err[i] = (float)positionResolution.X();
     y_err[i] = (float)positionResolution.Y();
     z_err[i] = (float)positionResolution.Z();
 
-    // Get energy
     energy[i] = (float)hit->GetEnergy();
     energy_err[i] = (float)hit->GetEnergyResolution();
   }
@@ -305,7 +387,9 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   m_BatchZ_ERR.push_back(z_err);
   m_BatchENERGY.push_back(energy);
   m_BatchENERGY_ERR.push_back(energy_err);
-  m_BatchBAD_FLAG.push_back(bad_flag);
+  if (m_OutputLevel == 0) {
+    m_BatchBAD_FLAG.push_back(bad_flag);
+  }
 
   m_BatchEventCount++;
 
@@ -363,7 +447,9 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
     m_ScienceTable->column("Z_ERR").writeArrays(m_BatchZ_ERR, m_BatchStartRow);
     m_ScienceTable->column("ENERGY").writeArrays(m_BatchENERGY, m_BatchStartRow);
     m_ScienceTable->column("ENERGY_ERR").writeArrays(m_BatchENERGY_ERR, m_BatchStartRow);
-    m_ScienceTable->column("BAD_FLAG").writeArrays(m_BatchBAD_FLAG, m_BatchStartRow);
+    if (m_OutputLevel == 0) {
+      m_ScienceTable->column("BAD_FLAG").writeArrays(m_BatchBAD_FLAG, m_BatchStartRow);
+    }
 
     // Update tracking
     m_TotalEventsWritten += m_BatchEventCount;
@@ -415,11 +501,57 @@ void MModuleSaverMeasurementsFITS::Finalize()
     FlushBatch();
   }
 
+  // Update time-related header keywords with actual values from event data: TSTART, TSTOP, DATE-OBS, DATE-END
+  if (m_HasEvents && m_ScienceTable != nullptr && m_PrimaryHDU != nullptr) {
+    try {
+      // Mission epoch is 2025-01-01 00:00:00 UTC
+      const time_t MISSION_EPOCH_UNIX = 1735689600;
+
+      time_t startUnix = MISSION_EPOCH_UNIX + (time_t)m_FirstEventTime;
+      time_t stopUnix = MISSION_EPOCH_UNIX + (time_t)m_LastEventTime;
+
+      //convert to ISO string
+      char startBuf[32], stopBuf[32];
+      strftime(startBuf, sizeof(startBuf), "%Y-%m-%dT%H:%M:%S", gmtime(&startUnix));
+      strftime(stopBuf, sizeof(stopBuf), "%Y-%m-%dT%H:%M:%S", gmtime(&stopUnix));
+
+      // Update primary HDU
+      m_PrimaryHDU->addKey("DATE-OBS", string(startBuf), "Start Date");
+      m_PrimaryHDU->addKey("DATE-END", string(stopBuf), "Stop Date");
+
+      // Update science table HDU
+      m_ScienceTable->addKey("DATE-OBS", string(startBuf), "Start Date");
+      m_ScienceTable->addKey("DATE-END", string(stopBuf), "Stop Date");
+      m_ScienceTable->addKey("TSTART", m_FirstEventTime, "Start time");
+      m_ScienceTable->addKey("TSTOP", m_LastEventTime, "Stop time");
+
+      // Also update OBS_ID to match the start date (YYMMDD format)
+      char obsIdBuf[8];
+      strftime(obsIdBuf, sizeof(obsIdBuf), "%y%m%d", gmtime(&startUnix));
+      m_PrimaryHDU->addKey("OBS_ID", string(obsIdBuf), "Observation ID");
+      m_ScienceTable->addKey("OBS_ID", string(obsIdBuf), "Observation ID");
+
+      if (g_Verbosity >= c_Info) {
+        cout<<m_XmlTag<<": Updated time headers — DATE-OBS="<<startBuf
+            <<", DATE-END="<<stopBuf<<", TSTART="<<m_FirstEventTime
+            <<", TSTOP="<<m_LastEventTime<<endl;
+      }
+    } catch (const CCfits::FitsException& e) {
+      if (g_Verbosity >= c_Error) {
+        cout<<m_XmlTag<<": Error updating time headers: "<<e.message()<<endl;
+      }
+    }
+  }
+
   MModule::Finalize();
 
   if (g_Verbosity >= c_Info) {
-    cout<< m_XmlTag <<": MModuleSaverMeasurementsFITS"<<endl;
+    string levelStr = (m_OutputLevel == 1) ? "L2" : "L1b";
+    cout<< m_XmlTag <<": MModuleSaverMeasurementsFITS ("<<levelStr<<")"<<endl;
     cout<< m_XmlTag <<":   * total events written: "<<m_TotalEventsWritten<<endl;
+    if (m_OutputLevel == 1) {
+      cout<< m_XmlTag <<":   * total events skipped (screening): "<<m_TotalEventsSkipped<<endl;
+    }
   }
 
   // Close the FITS file (CCfits automatically closes on delete)
@@ -442,6 +574,16 @@ bool MModuleSaverMeasurementsFITS::ReadXmlConfiguration(MXmlNode* Node)
     m_FileName = FileNameNode->GetValue();
   }
 
+  MXmlNode* OutputLevelNode = Node->GetNode("OutputLevel");
+  if (OutputLevelNode != nullptr) {
+    MString Level = OutputLevelNode->GetValue();
+    if (Level == "L2" || Level == "l2") {
+      m_OutputLevel = 1;
+    } else {
+      m_OutputLevel = 0;
+    }
+  }
+
   return true;
 }
 
@@ -455,6 +597,7 @@ MXmlNode* MModuleSaverMeasurementsFITS::CreateXmlConfiguration()
 
   MXmlNode* Node = new MXmlNode(0, m_XmlTag);
   new MXmlNode(Node, "FileName", m_FileName);
+  new MXmlNode(Node, "OutputLevel", (m_OutputLevel == 1) ? "L2" : "L1b");
 
   return Node;
 }

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -29,6 +29,7 @@
 // Standard libs:
 #include <algorithm>
 #include <ctime>
+#include <sstream>
 using namespace std;
 
 // ROOT libs:
@@ -38,6 +39,7 @@ using namespace std;
 #include "MGUIOptionsSaverMeasurementsFITS.h"
 #include "MHit.h"
 #include "MPhysicalEvent.h"
+#include "MPhysicalEventHit.h"
 #include "MComptonEvent.h"
 #include "MPhotoEvent.h"
 
@@ -158,13 +160,13 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
 
     m_PrimaryHDU->addKey("CREATOR", "TBD", "Software that created this file");
 
-    // Define columns for science data table per specification
-    // PE(100) = variable-length single-precision float array (max 100)
-    // 4E = fixed-length array of 4 single-precision floats
-    // 3E = fixed-length array of 3 single-precision floats
-    // L1b has QUALITY_FLAG, L2 does not (per spec: L2 removes bad events and QUALITY_FLAG column)
+    // Define columns for science data table per HEASARC Tech Agreement v1.1.
+    bool isL1b = (m_OutputDataLevel == 1);
+    string seqHitFormat = isL1b ? "PB(50)" : "10B";
+    string hitFormat    = isL1b ? "PE(50)" : "10E";
+
     std::vector<string> colNames = {
-      "TIME", "EVENTTYPE", "EVENTCLASS", "NUMHIT", "SEQHIT",
+      "TIME", "EVENTID", "EVENTTYPE", "EVENTCLASS", "NUMHIT", "SEQHIT",
       "STATTEST", "RECOILDIR", "RECOILDIR_ERR",
       "X", "Y", "Z",
       "X_ERR", "Y_ERR", "Z_ERR",
@@ -172,36 +174,42 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     };
 
     std::vector<string> colFormats = {
-      "1D",      // TIME - scalar double
-      "1B",      // EVENTTYPE - scalar byte
-      "1B",      // EVENTCLASS - scalar byte
-      "1B",      // NUMHIT - scalar byte
-      "1B",      // SEQHIT - scalar byte
-      "4E",      // STATTEST
-      "3E",      // RECOILDIR
-      "3E",      // RECOILDIR_ERR
-      "PE(100)", // X - variable-length float array
-      "PE(100)", // Y
-      "PE(100)", // Z
-      "PE(100)", // X_ERR
-      "PE(100)", // Y_ERR
-      "PE(100)", // Z_ERR
-      "PE(100)", // ENERGY
-      "PE(100)"  // ENERGY_ERR
+      "1D",          // TIME - scalar double
+      "1J",          // EVENTID - 32-bit int
+      "1B",          // EVENTTYPE - scalar byte
+      "1B",          // EVENTCLASS - scalar byte
+      "1B",          // NUMHIT - scalar byte
+      seqHitFormat,  // SEQHIT
+      "8E",          // STATTEST
+      "3E",          // RECOILDIR
+      "3E",          // RECOILDIR_ERR
+      hitFormat,     // X
+      hitFormat,     // Y
+      hitFormat,     // Z
+      hitFormat,     // X_ERR
+      hitFormat,     // Y_ERR
+      hitFormat,     // Z_ERR
+      hitFormat,     // ENERGY
+      hitFormat      // ENERGY_ERR
     };
 
     std::vector<string> colUnits = {
-      "s", "", "", "", "",
+      "s", "", "", "", "", "",
       "", "", "",
       "cm", "cm", "cm",
       "unit", "unit", "unit",
       "keV", "unit"
     };
 
-    // L1b includes QUALITY_FLAG column, L2 does not
+    // Only L1b includes VETO + QUALITY_FLAG columns;
+    // VETO: 0=none, 1=hard ACD veto, 2=soft ACD veto, 3=guard ring veto
     if (m_OutputDataLevel == 1) {
+      colNames.push_back("VETO");
+      colFormats.push_back("1B");
+      colUnits.push_back("");
+
       colNames.push_back("QUALITY_FLAG");
-      colFormats.push_back("PE(100)");
+      colFormats.push_back("64A");
       colUnits.push_back("");
     }
 
@@ -213,17 +221,16 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     m_ScienceTable->addKey("EXTNAME", extName, "name of this HDU");
     m_ScienceTable->addKey("TELESCOP", "COSI", "Telescope mission name");
     m_ScienceTable->addKey("INSTRUME", "GED", "Instrument name");
-    m_ScienceTable->addKey("DATAMODE", "TBD", "Instrument datamode");
-    // removed observer
+    m_ScienceTable->addKey("DATAMODE", "SYNC", "Instrument datamode: SYNC or ASYNC");
+    m_ScienceTable->addKey("OBSERVER", "John Tomsick", "Principal Investigator");
     m_ScienceTable->addKey("OBS_ID", "YYMMDD", "Observation ID"); //should match the YYMMDD of the filename
-    // removed object
+    m_ScienceTable->addKey("OBJECT", "ALL SKY", "Object/Target name or ALL SKY");
     m_ScienceTable->addKey("MJDREFI", 60676, "MJD reference day 01 Jan 2025 00:00:00");
     m_ScienceTable->addKey("MJDREFF", 8.007407407407E-04, "MJD reference (fraction of day)");
     m_ScienceTable->addKey("TIMEREF", "LOCAL", "Reference Frame");
     m_ScienceTable->addKey("TASSIGN", "SATELLITE", "Time assigned");
     m_ScienceTable->addKey("TIMESYS", "TT", "Time System");
     m_ScienceTable->addKey("TIMEUNIT", "s", "Time unit for timing header keywords");
-    m_ScienceTable->addKey("TIMEDEL", 0.0, "Integration time");
     m_ScienceTable->addKey("CLOCKAPP", false, "If clock corrections are applied (T/F)");
     m_ScienceTable->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date"); //placeholder, this will be written after we read through all the events
     m_ScienceTable->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date"); // 
@@ -235,7 +242,7 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     m_ScienceTable->addKey("CREATOR", "TBD", "Software that create 1st the file");
     m_ScienceTable->addKey("PROCVER", "TBD", "Processing Version");
     m_ScienceTable->addKey("CALDBVER", "TBD", "CALDB version");
-    m_ScienceTable->addKey("SEQPHUM", "TBD", "Times the dataset has been processed");
+    m_ScienceTable->addKey("SEQPNUM", "TBD", "Times the dataset has been processed");
     m_ScienceTable->addKey("ORIGIN", "SSL", "Origin of the FITS files");
     m_ScienceTable->addKey("DATE", "TOTAL", "File creation date"); //DATE should have the date of the file creation (same as primary header)
     //CHECKSUM
@@ -289,15 +296,36 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   }
 
   // Event-level metadata defaults
-  uint8_t eventType = 0;    // 0 = unknown/default
-  uint8_t eventClass = 2;   // 2 = unreconstructed
-  uint8_t seqHit = 0;
+  uint8_t eventType = 0;    // TODO: 0 = unknown/default
+  // EVENTCLASS per HEASARC Tech Agreement v1.1
+  //   0 = Compton, 1 = photoabsorption, 2 = tracked Compton, 3 = charge particle, 4 = pair, 5 = unknown.
+  uint8_t eventClass = 5;   // 5 = unknown
+  uint32_t eventID = (uint32_t)Event->GetID();
+
+  // TODO: figure out where to get VETO
+  uint8_t veto = 0;
+  std::string quality_flag;
+
+  // L2: fixed-length 10 hit arrays, zero-padded 
+  const unsigned int L2_HIT_LEN = 10;
+  bool isL2 = (m_OutputDataLevel == 2);
+  unsigned int arrayLen = isL2 ? L2_HIT_LEN : numHits;
 
   // Fixed-length arrays for event-level data (initialize to zeros)
-  std::valarray<float> statTest(0.0f, 4);
+  std::valarray<float> statTest(0.0f, 8);   // new spec changed to 8E
   std::valarray<float> recoilDir(0.0f, 3);
   std::valarray<float> recoilDirErr(0.0f, 3);
 
+  // Hit-level arrays sized to arrayLen (numHits for L1b, fixed length 10 for L2)
+  std::valarray<uint8_t> seqHitArr((uint8_t)0, arrayLen);
+  std::valarray<float> x(0.0f, arrayLen);
+  std::valarray<float> y(0.0f, arrayLen);
+  std::valarray<float> z(0.0f, arrayLen);
+  std::valarray<float> x_err(0.0f, arrayLen);
+  std::valarray<float> y_err(0.0f, arrayLen);
+  std::valarray<float> z_err(0.0f, arrayLen);
+  std::valarray<float> energy(0.0f, arrayLen);
+  std::valarray<float> energy_err(0.0f, arrayLen);
   // Extract revan reconstruction data if available
   MPhysicalEvent* PE = Event->GetPhysicalEvent();
   if (PE != nullptr) {
@@ -308,7 +336,6 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 
       MComptonEvent* CE = dynamic_cast<MComptonEvent*>(PE);
       if (CE != nullptr) {
-        seqHit = (uint8_t)CE->SequenceLength();
 
         MVector de = CE->De();
         recoilDir[0] = (float)de.X();
@@ -320,67 +347,78 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
         recoilDirErr[1] = (float)dde.Y();
         recoilDirErr[2] = (float)dde.Z();
 
-        // TODO: Statistical test values (spec TBD) 
+        // TODO: need to figure out what exactly should be in statTest[0-7]
         statTest[0] = (float)CE->Phi();
         statTest[1] = (float)CE->DeltaTheta();
         statTest[2] = (float)CE->MinLeverArm();
-        statTest[3] = 0.0f;
       }
 
     } else if (peType == MPhysicalEvent::c_Photo) {
       eventClass = 1;  // 1 = photoabsorption
-      seqHit = 1;
-
+      if (arrayLen > 0) seqHitArr[0] = 1;
     } else {
-      eventClass = 2;  // 2 = unreconstructed
+      eventClass = 5;  // 5 = unknown
     }
   }
 
-  // Override eventClass for bad events (per spec: 3 = bad)
-  if (Event->IsBad()) {
-    eventClass = 3;
-  }
-
-  // Hit-level arrays
-  std::valarray<float> x(numHits);
-  std::valarray<float> y(numHits);
-  std::valarray<float> z(numHits);
-  std::valarray<float> x_err(numHits);
-  std::valarray<float> y_err(numHits);
-  std::valarray<float> z_err(numHits);
-  std::valarray<float> energy(numHits);
-  std::valarray<float> energy_err(numHits);
-  std::valarray<float> quality_flag(0.0f, numHits);
-
-  // TODO: Set quality flag if event failed any calibration step (L1b only)
   if (m_OutputDataLevel == 1 && Event->IsBad()) {
-    quality_flag = 1.0f;
+    std::ostringstream oss;
+    Event->StreamBDFlags(oss);
+    quality_flag = oss.str();
+
+    std::replace(quality_flag.begin(), quality_flag.end(), '\n', ';');
+
+    if (quality_flag.length() > 64) {
+      quality_flag = quality_flag.substr(0, 64);
+    }
   }
 
-  // Extract hit-level data
+  // check if PE is Compton event, and PE-> GetNHits() is the same as the Event->GetNHits()
+  bool comptonEvent = (PE != nullptr && PE->GetType() == MPhysicalEvent::c_Compton && PE->GetNHits() == numHits);
+
   for (unsigned int i = 0; i < numHits; ++i) {
-    MHit* hit = Event->GetHit(i);
+    // For Compton events, get hits from MPhysicalEventHit
+    // For photo / unreconstructed events, get hits from MHit
+    if (comptonEvent) {
+      const MPhysicalEventHit& hit = PE->GetHit(i);
+      MVector position = hit.GetPosition();
+      x[i] = (float)position.X();
+      y[i] = (float)position.Y();
+      z[i] = (float)position.Z();
 
-    MVector position = hit->GetPosition();
-    x[i] = (float)position.X();
-    y[i] = (float)position.Y();
-    z[i] = (float)position.Z();
+      MVector positionUncertainty = hit.GetPositionUncertainty();
+      x_err[i] = (float)positionUncertainty.X();
+      y_err[i] = (float)positionUncertainty.Y();
+      z_err[i] = (float)positionUncertainty.Z();
 
-    MVector positionResolution = hit->GetPositionResolution();
-    x_err[i] = (float)positionResolution.X();
-    y_err[i] = (float)positionResolution.Y();
-    z_err[i] = (float)positionResolution.Z();
+      energy[i] = (float)hit.GetEnergy();
+      energy_err[i] = (float)hit.GetEnergyUncertainty();
 
-    energy[i] = (float)hit->GetEnergy();
-    energy_err[i] = (float)hit->GetEnergyResolution();
+      seqHitArr[i] = (uint8_t)(i + 1); 
+    } else {
+      MHit* hit = Event->GetHit(i);
+      MVector position = hit->GetPosition();
+      x[i] = (float)position.X();
+      y[i] = (float)position.Y();
+      z[i] = (float)position.Z();
+
+      MVector positionResolution = hit->GetPositionResolution();
+      x_err[i] = (float)positionResolution.X();
+      y_err[i] = (float)positionResolution.Y();
+      z_err[i] = (float)positionResolution.Z();
+
+      energy[i] = (float)hit->GetEnergy();
+      energy_err[i] = (float)hit->GetEnergyResolution();
+    }
   }
 
   // Add to batch
   m_BatchTIME.push_back(time);
+  m_BatchEVENTID.push_back(eventID);
   m_BatchEVENTTYPE.push_back(eventType);
   m_BatchEVENTCLASS.push_back(eventClass);
   m_BatchNUMHIT.push_back((uint8_t)numHits);
-  m_BatchSEQHIT.push_back(seqHit);
+  m_BatchSEQHIT.push_back(seqHitArr);
   m_BatchSTATTEST.push_back(statTest);
   m_BatchRECOILDIR.push_back(recoilDir);
   m_BatchRECOILDIR_ERR.push_back(recoilDirErr);
@@ -393,6 +431,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   m_BatchENERGY.push_back(energy);
   m_BatchENERGY_ERR.push_back(energy_err);
   if (m_OutputDataLevel == 1) {
+    m_BatchVETO.push_back(veto);
     m_BatchQUALITY_FLAG.push_back(quality_flag);
   }
 
@@ -433,10 +472,11 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
 
     // Write scalar columns
     m_ScienceTable->column("TIME").write(m_BatchTIME, m_BatchStartRow);
+    m_ScienceTable->column("EVENTID").write(m_BatchEVENTID, m_BatchStartRow);
     m_ScienceTable->column("EVENTTYPE").write(m_BatchEVENTTYPE, m_BatchStartRow);
     m_ScienceTable->column("EVENTCLASS").write(m_BatchEVENTCLASS, m_BatchStartRow);
     m_ScienceTable->column("NUMHIT").write(m_BatchNUMHIT, m_BatchStartRow);
-    m_ScienceTable->column("SEQHIT").write(m_BatchSEQHIT, m_BatchStartRow);
+    m_ScienceTable->column("SEQHIT").writeArrays(m_BatchSEQHIT, m_BatchStartRow);
 
     // Write fixed-length array columns (event-level)
     m_ScienceTable->column("STATTEST").writeArrays(m_BatchSTATTEST, m_BatchStartRow);
@@ -453,7 +493,8 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
     m_ScienceTable->column("ENERGY").writeArrays(m_BatchENERGY, m_BatchStartRow);
     m_ScienceTable->column("ENERGY_ERR").writeArrays(m_BatchENERGY_ERR, m_BatchStartRow);
     if (m_OutputDataLevel == 1) {
-      m_ScienceTable->column("QUALITY_FLAG").writeArrays(m_BatchQUALITY_FLAG, m_BatchStartRow);
+      m_ScienceTable->column("VETO").write(m_BatchVETO, m_BatchStartRow);
+      m_ScienceTable->column("QUALITY_FLAG").write(m_BatchQUALITY_FLAG, m_BatchStartRow);
     }
 
     // Update tracking
@@ -462,6 +503,7 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
 
     // Clear batch vectors - scalar columns
     m_BatchTIME.clear();
+    m_BatchEVENTID.clear();
     m_BatchEVENTTYPE.clear();
     m_BatchEVENTCLASS.clear();
     m_BatchNUMHIT.clear();
@@ -481,6 +523,7 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
     m_BatchZ_ERR.clear();
     m_BatchENERGY.clear();
     m_BatchENERGY_ERR.clear();
+    m_BatchVETO.clear();
     m_BatchQUALITY_FLAG.clear();
 
     m_BatchEventCount = 0;

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -86,9 +86,9 @@ MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS() : MModule()
   m_TotalEventsSkipped = 0;
   m_BatchStartRow = 1;
   m_BatchEventCount = 0;
-  m_OutputLevel = 0; // 0 = L1b (default), 1 = L2
-  m_FirstEventTime = 0.0;
-  m_LastEventTime = 0.0;
+  m_OutputDataLevel = 1; // 1 = L1b (default), 2 = L2
+  m_FirstEventTime_RTS = 0.0;
+  m_LastEventTime_RTS = 0.0;
   m_HasEvents = false;
 }
 
@@ -132,7 +132,7 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
   // Create the FITS file using CCfits
   try {
 
-    string levelStr = (m_OutputLevel == 1) ? "L2" : "L1b";
+    string levelStr = (m_OutputDataLevel == 2) ? "L2" : "L1b";
     if (g_Verbosity >= c_Info) cout<<m_XmlTag<<": Creating "<<levelStr<<" FITS file: "<<string(FileName)<<endl;
 
     // Create new FITS file (overwrite if exists)
@@ -162,7 +162,7 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     // PE(100) = variable-length single-precision float array (max 100)
     // 4E = fixed-length array of 4 single-precision floats
     // 3E = fixed-length array of 3 single-precision floats
-    // L1b has BAD_FLAG, L2 does not (per spec: L2 removes bad events and BAD_FLAG column)
+    // L1b has QUALITY_FLAG, L2 does not (per spec: L2 removes bad events and QUALITY_FLAG column)
     std::vector<string> colNames = {
       "TIME", "EVENTTYPE", "EVENTCLASS", "NUMHIT", "SEQHIT",
       "STATTEST", "RECOILDIR", "RECOILDIR_ERR",
@@ -198,15 +198,15 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
       "keV", "unit"
     };
 
-    // L1b includes BAD_FLAG column, L2 does not
-    if (m_OutputLevel == 0) {
-      colNames.push_back("BAD_FLAG");
+    // L1b includes QUALITY_FLAG column, L2 does not
+    if (m_OutputDataLevel == 1) {
+      colNames.push_back("QUALITY_FLAG");
       colFormats.push_back("PE(100)");
       colUnits.push_back("");
     }
 
     // Create binary table extension
-    string extName = (m_OutputLevel == 1) ? "GED_L2" : "GED_L1B";
+    string extName = (m_OutputDataLevel == 2) ? "GED_L2" : "GED_L1B";
     m_ScienceTable = m_FITSFile->addTable(extName, 0, colNames, colFormats, colUnits);
 
     // Add keywords to science table
@@ -225,9 +225,9 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     m_ScienceTable->addKey("TIMEUNIT", "s", "Time unit for timing header keywords");
     m_ScienceTable->addKey("TIMEDEL", 0.0, "Integration time");
     m_ScienceTable->addKey("CLOCKAPP", false, "If clock corrections are applied (T/F)");
-    m_ScienceTable->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date"); //placeholder, this will be wroten after we read through all the event
+    m_ScienceTable->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date"); //placeholder, this will be written after we read through all the events
     m_ScienceTable->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date"); // 
-    m_ScienceTable->addKey("TSTART", 0.0, "Start time"); //placeholder, this will be wroten after we read through all the event
+    m_ScienceTable->addKey("TSTART", 0.0, "Start time"); //placeholder, this will be written after we read through all the events
     m_ScienceTable->addKey("TSTOP", 0.0, "Stop time"); //
     m_ScienceTable->addKey("HDUCLASS", "OGIP", "format conforms to OGIP standard");
     m_ScienceTable->addKey("HDUCLAS1", "ARRAY", "hduclass1");
@@ -260,7 +260,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   // Add this event to the batch, write batch when full
 
   // L2 mode: skip bad events (screening)
-  if (m_OutputLevel == 1 && Event->IsBad()) {
+  if (m_OutputDataLevel == 2 && Event->IsBad()) {
     m_TotalEventsSkipped++;
     Event->SetAnalysisProgress(MAssembly::c_EventSaver);
     return true;
@@ -280,12 +280,12 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 
   // loop through all event, and record the start and end time for TSTART/TSTOP
   if (!m_HasEvents) {
-    m_FirstEventTime = time;
-    m_LastEventTime = time;
+    m_FirstEventTime_RTS = time;
+    m_LastEventTime_RTS = time;
     m_HasEvents = true;
   } else {
-    if (time < m_FirstEventTime) m_FirstEventTime = time;
-    if (time > m_LastEventTime) m_LastEventTime = time;
+    if (time < m_FirstEventTime_RTS) m_FirstEventTime_RTS = time;
+    if (time > m_LastEventTime_RTS) m_LastEventTime_RTS = time;
   }
 
   // Event-level metadata defaults
@@ -350,12 +350,11 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   std::valarray<float> z_err(numHits);
   std::valarray<float> energy(numHits);
   std::valarray<float> energy_err(numHits);
-  std::valarray<float> bad_flag(0.0f, numHits);
+  std::valarray<float> quality_flag(0.0f, numHits);
 
-  // TODO: Set bad flag if event failed any calibration step (L1b only)
-  // Detail TBD, for now setting bad_flag based on IsBad()
-  if (m_OutputLevel == 0 && Event->IsBad()) {
-    bad_flag = 1.0f;
+  // TODO: Set quality flag if event failed any calibration step (L1b only)
+  if (m_OutputDataLevel == 1 && Event->IsBad()) {
+    quality_flag = 1.0f;
   }
 
   // Extract hit-level data
@@ -393,8 +392,8 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   m_BatchZ_ERR.push_back(z_err);
   m_BatchENERGY.push_back(energy);
   m_BatchENERGY_ERR.push_back(energy_err);
-  if (m_OutputLevel == 0) {
-    m_BatchBAD_FLAG.push_back(bad_flag);
+  if (m_OutputDataLevel == 1) {
+    m_BatchQUALITY_FLAG.push_back(quality_flag);
   }
 
   m_BatchEventCount++;
@@ -453,8 +452,8 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
     m_ScienceTable->column("Z_ERR").writeArrays(m_BatchZ_ERR, m_BatchStartRow);
     m_ScienceTable->column("ENERGY").writeArrays(m_BatchENERGY, m_BatchStartRow);
     m_ScienceTable->column("ENERGY_ERR").writeArrays(m_BatchENERGY_ERR, m_BatchStartRow);
-    if (m_OutputLevel == 0) {
-      m_ScienceTable->column("BAD_FLAG").writeArrays(m_BatchBAD_FLAG, m_BatchStartRow);
+    if (m_OutputDataLevel == 1) {
+      m_ScienceTable->column("QUALITY_FLAG").writeArrays(m_BatchQUALITY_FLAG, m_BatchStartRow);
     }
 
     // Update tracking
@@ -482,7 +481,7 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
     m_BatchZ_ERR.clear();
     m_BatchENERGY.clear();
     m_BatchENERGY_ERR.clear();
-    m_BatchBAD_FLAG.clear();
+    m_BatchQUALITY_FLAG.clear();
 
     m_BatchEventCount = 0;
 
@@ -513,8 +512,8 @@ void MModuleSaverMeasurementsFITS::Finalize()
       // Mission epoch is 2025-01-01 00:00:00 UTC
       const time_t MISSION_EPOCH_UNIX = 1735689600;
 
-      time_t startUnix = MISSION_EPOCH_UNIX + (time_t)m_FirstEventTime;
-      time_t stopUnix = MISSION_EPOCH_UNIX + (time_t)m_LastEventTime;
+      time_t startUnix = MISSION_EPOCH_UNIX + (time_t)m_FirstEventTime_RTS;
+      time_t stopUnix = MISSION_EPOCH_UNIX + (time_t)m_LastEventTime_RTS;
 
       //convert to ISO string
       char startBuf[32], stopBuf[32];
@@ -528,8 +527,8 @@ void MModuleSaverMeasurementsFITS::Finalize()
       // Update science table HDU
       m_ScienceTable->addKey("DATE-OBS", string(startBuf), "Start Date");
       m_ScienceTable->addKey("DATE-END", string(stopBuf), "Stop Date");
-      m_ScienceTable->addKey("TSTART", m_FirstEventTime, "Start time");
-      m_ScienceTable->addKey("TSTOP", m_LastEventTime, "Stop time");
+      m_ScienceTable->addKey("TSTART", m_FirstEventTime_RTS, "Start time");
+      m_ScienceTable->addKey("TSTOP", m_LastEventTime_RTS, "Stop time");
 
       // Also update OBS_ID to match the start date (YYMMDD format)
       char obsIdBuf[8];
@@ -539,8 +538,8 @@ void MModuleSaverMeasurementsFITS::Finalize()
 
       if (g_Verbosity >= c_Info) {
         cout<<m_XmlTag<<": Updated time headers — DATE-OBS="<<startBuf
-            <<", DATE-END="<<stopBuf<<", TSTART="<<m_FirstEventTime
-            <<", TSTOP="<<m_LastEventTime<<endl;
+            <<", DATE-END="<<stopBuf<<", TSTART="<<m_FirstEventTime_RTS
+            <<", TSTOP="<<m_LastEventTime_RTS<<endl;
       }
     } catch (const CCfits::FitsException& e) {
       if (g_Verbosity >= c_Error) {
@@ -552,10 +551,10 @@ void MModuleSaverMeasurementsFITS::Finalize()
   MModule::Finalize();
 
   if (g_Verbosity >= c_Info) {
-    string levelStr = (m_OutputLevel == 1) ? "L2" : "L1b";
+    string levelStr = (m_OutputDataLevel == 2) ? "L2" : "L1b";
     cout<< m_XmlTag <<": MModuleSaverMeasurementsFITS ("<<levelStr<<")"<<endl;
     cout<< m_XmlTag <<":   * total events written: "<<m_TotalEventsWritten<<endl;
-    if (m_OutputLevel == 1) {
+    if (m_OutputDataLevel == 2) {
       cout<< m_XmlTag <<":   * total events skipped (screening): "<<m_TotalEventsSkipped<<endl;
     }
   }
@@ -584,9 +583,9 @@ bool MModuleSaverMeasurementsFITS::ReadXmlConfiguration(MXmlNode* Node)
   if (OutputLevelNode != nullptr) {
     MString Level = OutputLevelNode->GetValue();
     if (Level == "L2" || Level == "l2") {
-      m_OutputLevel = 1;
+      m_OutputDataLevel = 2;
     } else {
-      m_OutputLevel = 0;
+      m_OutputDataLevel = 1;
     }
   }
 
@@ -603,7 +602,7 @@ MXmlNode* MModuleSaverMeasurementsFITS::CreateXmlConfiguration()
 
   MXmlNode* Node = new MXmlNode(0, m_XmlTag);
   new MXmlNode(Node, "FileName", m_FileName);
-  new MXmlNode(Node, "OutputLevel", (m_OutputLevel == 1) ? "L2" : "L1b");
+  new MXmlNode(Node, "OutputLevel", (m_OutputDataLevel == 2) ? "L2" : "L1b");
 
   return Node;
 }

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -166,23 +166,19 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     string hitFormat    = isL1b ? "PE(50)" : "10E";
 
     std::vector<string> colNames = {
-      "TIME", "EVENTID", "EVENTTYPE", "EVENTCLASS", "NUMHIT", "SEQHIT",
-      "STATTEST", "RECOILDIR", "RECOILDIR_ERR",
+      "TIME", "EVENTID", "EVENTCLASS", "NUMHIT", "SEQHIT",
       "X", "Y", "Z",
       "X_ERR", "Y_ERR", "Z_ERR",
-      "ENERGY", "ENERGY_ERR"
+      "ENERGY", "ENERGY_ERR", 
+      "RECOILDIR", "RECOILDIR_ERR"
     };
 
     std::vector<string> colFormats = {
-      "1D",          // TIME - scalar double
-      "1J",          // EVENTID - 32-bit int
-      "1B",          // EVENTTYPE - scalar byte
-      "1B",          // EVENTCLASS - scalar byte
-      "1B",          // NUMHIT - scalar byte
+      "1D",          // TIME
+      "1J",          // EVENTID
+      "1B",          // EVENTCLASS
+      "1B",          // NUMHIT
       seqHitFormat,  // SEQHIT
-      "8E",          // STATTEST
-      "3E",          // RECOILDIR
-      "3E",          // RECOILDIR_ERR
       hitFormat,     // X
       hitFormat,     // Y
       hitFormat,     // Z
@@ -190,20 +186,30 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
       hitFormat,     // Y_ERR
       hitFormat,     // Z_ERR
       hitFormat,     // ENERGY
-      hitFormat      // ENERGY_ERR
+      hitFormat,     // ENERGY_ERR
+      "3E",          // RECOILDIR
+      "3E",          // RECOILDIR_ERR
     };
 
     std::vector<string> colUnits = {
-      "s", "", "", "", "", "",
-      "", "", "",
+      "s", "", "", "", "",
       "cm", "cm", "cm",
-      "unit", "unit", "unit",
-      "keV", "unit"
+      "cm", "cm", "cm",
+      "keV", "keV",
+      "", ""
     };
 
-    // Only L1b includes VETO + QUALITY_FLAG columns;
+    // L2 drops EVENTTYPE, STATTEST, VETO, and QUALITY_FLAG.
     // VETO: 0=none, 1=hard ACD veto, 2=soft ACD veto, 3=guard ring veto
     if (m_OutputDataLevel == 1) {
+      colNames.push_back("EVENTTYPE");
+      colFormats.push_back("1B");
+      colUnits.push_back("");
+
+      colNames.push_back("STATTEST");
+      colFormats.push_back("8E");
+      colUnits.push_back("");
+
       colNames.push_back("VETO");
       colFormats.push_back("1B");
       colUnits.push_back("");
@@ -297,11 +303,12 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
 
   // Event-level metadata defaults
   uint8_t eventType = 0;    // TODO: 0 = unknown/default
+
   // EVENTCLASS per HEASARC Tech Agreement v1.1
   //   0 = Compton, 1 = photoabsorption, 2 = tracked Compton, 3 = charge particle, 4 = pair, 5 = unknown.
   uint8_t eventClass = 5;   // 5 = unknown
   uint32_t eventID = (uint32_t)Event->GetID();
-
+  
   // TODO: figure out where to get VETO
   uint8_t veto = 0;
   std::string quality_flag;
@@ -316,7 +323,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   std::valarray<float> recoilDir(0.0f, 3);
   std::valarray<float> recoilDirErr(0.0f, 3);
 
-  // Hit-level arrays sized to arrayLen (numHits for L1b, fixed length 10 for L2)
+  // Hit-level arrays sized to arrayLen (numHits for L1b, fixed 10 for L2)
   std::valarray<uint8_t> seqHitArr((uint8_t)0, arrayLen);
   std::valarray<float> x(0.0f, arrayLen);
   std::valarray<float> y(0.0f, arrayLen);
@@ -326,6 +333,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   std::valarray<float> z_err(0.0f, arrayLen);
   std::valarray<float> energy(0.0f, arrayLen);
   std::valarray<float> energy_err(0.0f, arrayLen);
+  
   // Extract revan reconstruction data if available
   MPhysicalEvent* PE = Event->GetPhysicalEvent();
   if (PE != nullptr) {
@@ -373,7 +381,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
     }
   }
 
-  // check if PE is Compton event, and PE-> GetNHits() is the same as the Event->GetNHits()
+  // check if PE is Compton event, and the PE-> GetNHits() is the same as the Event->GetNHits()
   bool comptonEvent = (PE != nullptr && PE->GetType() == MPhysicalEvent::c_Compton && PE->GetNHits() == numHits);
 
   for (unsigned int i = 0; i < numHits; ++i) {
@@ -415,11 +423,9 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   // Add to batch
   m_BatchTIME.push_back(time);
   m_BatchEVENTID.push_back(eventID);
-  m_BatchEVENTTYPE.push_back(eventType);
   m_BatchEVENTCLASS.push_back(eventClass);
   m_BatchNUMHIT.push_back((uint8_t)numHits);
   m_BatchSEQHIT.push_back(seqHitArr);
-  m_BatchSTATTEST.push_back(statTest);
   m_BatchRECOILDIR.push_back(recoilDir);
   m_BatchRECOILDIR_ERR.push_back(recoilDirErr);
   m_BatchX.push_back(x);
@@ -430,7 +436,11 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   m_BatchZ_ERR.push_back(z_err);
   m_BatchENERGY.push_back(energy);
   m_BatchENERGY_ERR.push_back(energy_err);
+
+  // L1b-only columns (VENTTYPE, STATTEST, VETO, QUALITY_FLAG)
   if (m_OutputDataLevel == 1) {
+    m_BatchEVENTTYPE.push_back(eventType);
+    m_BatchSTATTEST.push_back(statTest);
     m_BatchVETO.push_back(veto);
     m_BatchQUALITY_FLAG.push_back(quality_flag);
   }
@@ -470,20 +480,14 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
       cout<< m_XmlTag <<": Writing batch: "<<m_BatchEventCount<<" events (rows "<<m_BatchStartRow<<" to "<<lastRow<<")"<<endl;
     }
 
-    // Write scalar columns
+    // Write columns common to both L1b and L2
     m_ScienceTable->column("TIME").write(m_BatchTIME, m_BatchStartRow);
     m_ScienceTable->column("EVENTID").write(m_BatchEVENTID, m_BatchStartRow);
-    m_ScienceTable->column("EVENTTYPE").write(m_BatchEVENTTYPE, m_BatchStartRow);
     m_ScienceTable->column("EVENTCLASS").write(m_BatchEVENTCLASS, m_BatchStartRow);
     m_ScienceTable->column("NUMHIT").write(m_BatchNUMHIT, m_BatchStartRow);
     m_ScienceTable->column("SEQHIT").writeArrays(m_BatchSEQHIT, m_BatchStartRow);
-
-    // Write fixed-length array columns (event-level)
-    m_ScienceTable->column("STATTEST").writeArrays(m_BatchSTATTEST, m_BatchStartRow);
     m_ScienceTable->column("RECOILDIR").writeArrays(m_BatchRECOILDIR, m_BatchStartRow);
     m_ScienceTable->column("RECOILDIR_ERR").writeArrays(m_BatchRECOILDIR_ERR, m_BatchStartRow);
-
-    // Write variable-length array columns (hit-level)
     m_ScienceTable->column("X").writeArrays(m_BatchX, m_BatchStartRow);
     m_ScienceTable->column("Y").writeArrays(m_BatchY, m_BatchStartRow);
     m_ScienceTable->column("Z").writeArrays(m_BatchZ, m_BatchStartRow);
@@ -492,7 +496,11 @@ bool MModuleSaverMeasurementsFITS::FlushBatch()
     m_ScienceTable->column("Z_ERR").writeArrays(m_BatchZ_ERR, m_BatchStartRow);
     m_ScienceTable->column("ENERGY").writeArrays(m_BatchENERGY, m_BatchStartRow);
     m_ScienceTable->column("ENERGY_ERR").writeArrays(m_BatchENERGY_ERR, m_BatchStartRow);
+
+    // Write L1b-only columns
     if (m_OutputDataLevel == 1) {
+      m_ScienceTable->column("EVENTTYPE").write(m_BatchEVENTTYPE, m_BatchStartRow);
+      m_ScienceTable->column("STATTEST").writeArrays(m_BatchSTATTEST, m_BatchStartRow);
       m_ScienceTable->column("VETO").write(m_BatchVETO, m_BatchStartRow);
       m_ScienceTable->column("QUALITY_FLAG").write(m_BatchQUALITY_FLAG, m_BatchStartRow);
     }

--- a/src/MModuleSaverMeasurementsL0.cxx
+++ b/src/MModuleSaverMeasurementsL0.cxx
@@ -406,7 +406,13 @@ bool MModuleSaverMeasurementsL0::AnalyzeEvent(MReadOutAssembly* Event)
     MStripHit* hit = Event->GetStripHit(i);
 
     // Get strip info
-    int stripID = hit->GetStripID();
+    // custom encoding 11-bit strip ID: [detectorID:4][side:1][stripNumber:6]
+    // GetStripID() dont actually return 0-2079 in simulation... Cannot map through the mapping file
+    // TODO: figure out exactly what to do in the future, but now this is a workaround
+    int detID = hit->GetDetectorID() & 0xF;     // 4 bits (0-15)
+    int side = hit->IsLowVoltageStrip() ? 0 : 1; // 1 bit
+    int stripNum = hit->GetStripID() & 0x3F;     // 6 bits (0-63)
+    int stripID = (detID << 7) | (side << 6) | stripNum;
     bool fastTiming = hit->HasFastTiming();
     int energy = (int)hit->GetADCUnits();
     int timing = (int)hit->GetTAC();

--- a/src/MModuleSaverMeasurementsL0.cxx
+++ b/src/MModuleSaverMeasurementsL0.cxx
@@ -213,17 +213,17 @@ void MModuleSaverMeasurementsL0::PackBitsIntoBitstream(std::vector<uint8_t>& bit
 ////////////////////////////////////////////////////////////////////////////////
 
 
-uint64_t MModuleSaverMeasurementsL0::EncodeNormalHit(int stripID, bool fastTiming, int energy, int timing)
+uint64_t MModuleSaverMeasurementsL0::EncodeNormalHit(int stripID, bool fastTiming, int adc, int tac)
 {
   // A normal strip hit (Type 0x0) - 44 bits
-  // Format: HitType: 4 bits + StripID 11 bits + Timing Type: 1bit + Energy Data: 14 bits + Timing data: 14 bits
+  // Format: HitType: 4 bits + StripID 11 bits + Timing Type: 1bit + ADC Data: 14 bits + TAC Data: 14 bits
   // Returns 44 bits packed into the lower bits of a uint64_t
 
   uint64_t hitType = 0x0;
   uint64_t strip = stripID & 0x7FF;      // 11 bits
   uint64_t dt = fastTiming ? 1 : 0;      // 1 bit
-  uint64_t eng = energy & 0x3FFF;        // 14 bits
-  uint64_t tim = timing & 0x3FFF;        // 14 bits
+  uint64_t eng = adc & 0x3FFF;           // 14 bits
+  uint64_t tim = tac & 0x3FFF;           // 14 bits
 
   // Pack bits: [HitType:4][StripID:11][TimingType:1][Energy:14][TimingData:14] = 44 bits
   uint64_t encoded = (hitType << 40) | (strip << 29) | (dt << 28) | (eng << 14) | tim;
@@ -235,17 +235,17 @@ uint64_t MModuleSaverMeasurementsL0::EncodeNormalHit(int stripID, bool fastTimin
 ////////////////////////////////////////////////////////////////////////////////
 
 
-uint64_t MModuleSaverMeasurementsL0::EncodeNeighborHit(int stripID, bool fastTiming, int energy, int timing)
+uint64_t MModuleSaverMeasurementsL0::EncodeNeighborHit(int stripID, bool fastTiming, int adc, int tac)
 {
   // A neighboring strip hit (Type 0x1) - 36 bits
-  // Format: HitType: 4 bits + StripID: 11 bits + Timing Type: 1 bit + Energy Data: 10 bits + Timing Data: 10 bits
+  // Format: HitType: 4 bits + StripID: 11 bits + Timing Type: 1 bit + ADC Data: 10 bits + TAC Data: 10 bits
   // Returns 36 bits packed into the lower bits of a uint64_t
 
   uint64_t hitType = 0x1;
   uint64_t strip = stripID & 0x7FF;      // 11 bits
   uint64_t dt = fastTiming ? 1 : 0;      // 1 bit
-  uint64_t eng = energy & 0x3FF;         // 10 bits
-  uint64_t tim = timing & 0x3FF;         // 10 bits
+  uint64_t eng = adc & 0x3FF;            // 10 bits
+  uint64_t tim = tac & 0x3FF;            // 10 bits
 
   // Pack bits: [HitType:4][StripID:11][TimingType:1][Energy:10][TimingData:10] = 36 bits
   uint64_t encoded = (hitType << 32) | (strip << 21) | (dt << 20) | (eng << 10) | tim;
@@ -257,15 +257,15 @@ uint64_t MModuleSaverMeasurementsL0::EncodeNeighborHit(int stripID, bool fastTim
 ////////////////////////////////////////////////////////////////////////////////
 
 
-uint32_t MModuleSaverMeasurementsL0::EncodeGuardRingHit(int stripID, int energy)
+uint32_t MModuleSaverMeasurementsL0::EncodeGuardRingHit(int stripID, int adc)
 {
   // A guard ring hit (Type 0x2) - 24 bits
-  // Format: HitType: 4 bits + StripID: 5 bits + Energy Data: 14 bits + Pad: 1 bit
+  // Format: HitType: 4 bits + StripID: 5 bits + ADC Data: 14 bits + Pad: 1 bit
   // Returns 24 bits packed into the lower bits of a uint32_t
 
   uint32_t hitType = 0x2;
   uint32_t strip = stripID & 0x1F;        // 5 bits
-  uint32_t eng = energy & 0x3FFF;         // 14 bits
+  uint32_t eng = adc & 0x3FFF;            // 14 bits
 
   // Pack bits: [HitType:4][StripID:5][Energy:14][Pad:1] = 24 bits
   uint32_t encoded = (hitType << 20) | (strip << 15) | (eng << 1) | 0;
@@ -414,19 +414,19 @@ bool MModuleSaverMeasurementsL0::AnalyzeEvent(MReadOutAssembly* Event)
     int stripNum = hit->GetStripID() & 0x3F;     // 6 bits (0-63)
     int stripID = (detID << 7) | (side << 6) | stripNum;
     bool fastTiming = hit->HasFastTiming();
-    int energy = (int)hit->GetADCUnits();
-    int timing = (int)hit->GetTAC();
+    int adc = (int)hit->GetADCUnits();
+    int tac = (int)hit->GetTAC();
 
     if (hit->IsGuardRing()) {
-      uint32_t encoded = EncodeGuardRingHit(stripID, energy);
+      uint32_t encoded = EncodeGuardRingHit(stripID, adc);
       PackBitsIntoBitstream(hitData, bitOffset, encoded, 24);
       totalBits += 24;
     } else if (hit->IsNearestNeighbor()) {
-      uint64_t encoded = EncodeNeighborHit(stripID, fastTiming, energy, timing);
+      uint64_t encoded = EncodeNeighborHit(stripID, fastTiming, adc, tac);
       PackBitsIntoBitstream(hitData, bitOffset, encoded, 36);
       totalBits += 36;
     } else {
-      uint64_t encoded = EncodeNormalHit(stripID, fastTiming, energy, timing);
+      uint64_t encoded = EncodeNormalHit(stripID, fastTiming, adc, tac);
       PackBitsIntoBitstream(hitData, bitOffset, encoded, 44);
       totalBits += 44;
     }

--- a/src/MModuleSaverMeasurementsL0.cxx
+++ b/src/MModuleSaverMeasurementsL0.cxx
@@ -386,8 +386,14 @@ bool MModuleSaverMeasurementsL0::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Write this event as a DD packet
 
-  // Get event timing (change from GetCL() to GetTime())
-  MTime eventTime = Event->GetTime();
+  // set/get eventTime from either the UTC time or the RTS time
+  MTime eventTime;
+  if (Event->GetTimeRTS() == 0 && Event->GetTimeUTC() != 0) {
+    eventTime = Event->ComputeRTSfromUTCTime(Event->GetTimeUTC());
+    Event->SetTimeRTS(eventTime);
+  } else {
+    eventTime = Event->GetTimeRTS();
+  }
   uint32_t eventSeconds = (uint32_t)eventTime.GetAsSeconds();
   uint32_t eventNanoseconds = eventTime.GetNanoSeconds();
 


### PR DESCRIPTION
There are 3 commits here. 
The first 2 commits address the issue of MModuleLoaderMeasurementsFITS.cxx. 
- Fixed infinite loop of loading events by adding the m_IsFinished flag

The third commit added the ability to save file to L1b or L2
- Added GUI option to the Fits saver to save to either L1b or L2
- Added feature to extract revan reconstruction and save that to L2