### PR TITLE
FIX: Initialize and finalize `MSubModuleShieldEnergyCorrection`

### DIFF
--- a/src/MSubModuleShieldEnergyCorrection.cxx
+++ b/src/MSubModuleShieldEnergyCorrection.cxx
@@ -71,9 +71,11 @@ MSubModuleShieldEnergyCorrection::~MSubModuleShieldEnergyCorrection()
 bool MSubModuleShieldEnergyCorrection::Initialize()
 {
   // Initialize the module
+  m_Centroid.clear();
+  m_FWHM.clear();
 
   //! load shield energy correction file
-  if (!ParseShieldEnergyCorrectionFile()) {
+  if (ParseShieldEnergyCorrectionFile() == false) {
     if (g_Verbosity >= c_Error) {
       cout << "ERROR: Failed to parse shield energy correction file " << m_ShieldEnergyCorrectionFileName << endl;
     }
@@ -187,6 +189,8 @@ bool MSubModuleShieldEnergyCorrection::AnalyzeEvent(MReadOutAssembly* Event)
 void MSubModuleShieldEnergyCorrection::Finalize()
 {
   //! Finalize the analysis - do all cleanup, i.e., undo Initialize()
+  m_Centroid.clear();
+  m_FWHM.clear();
 
   MSubModule::Finalize();
 }


### PR DESCRIPTION
Currently, after running the DEE, when closing the GUI via the "X"  on the top right, I am getting a segmentation fault (attached to the end of this message). It looks like this was due to some ownership clash while trying to delete `TF1` ROOT objects when destroying `m_Centroid` and `m_FWHM` in `MSubModuleShieldEnergyCorrection`.

The current PR should initialize and finalize the submodule, preventing this segmentation fault.

```
*** Break *** segmentation violation



===========================================================
There was a crash.
This is the entire stack trace of all threads:
===========================================================
#0  0x000073232f910813 in __GI___wait4 (pid=111464, stat_loc=stat_loc
entry=0x7fff13e5c4a8, options=options
entry=0, usage=usage
entry=0x0) at ../sysdeps/unix/sysv/linux/wait4.c:30
#1  0x000073232f91091b in __GI___waitpid (pid=<optimized out>, stat_loc=stat_loc
entry=0x7fff13e5c4a8, options=options
entry=0) at ./posix/waitpid.c:38
#2  0x000073232f8585bb in do_system (line=<optimized out>) at ../sysdeps/posix/system.c:172
#3  0x000073233032b5f3 in TUnixSystem::StackTrace() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#4  0x000073233032af64 in TUnixSystem::DispatchSignals(ESignals) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#5  <signal handler called>
#6  0x0000574674cacbf0 in ?? ()
#7  0x000073233103b146 in std::default_delete<TF1>::operator() (__ptr=<optimized out>, this=<optimized out>) at /usr/include/c++/13/bits/unique_ptr.h:93
#8  std::unique_ptr<TF1, std::default_delete<TF1> >::~unique_ptr (this=0x574674ccd2e8, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/unique_ptr.h:404
#9  0x000073233103b55b in std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >::~pair (this=0x574674ccd2a0, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/stl_pair.h:187
#10 0x000073233103b5a3 in std::__new_allocator<std::_Rb_tree_node<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::destroy<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > (__p=0x574674ccd2a0, this=0x5746747949a0) at /usr/include/c++/13/bits/new_allocator.h:196
#11 std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > > >::destroy<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > (__p=0x574674ccd2a0, __a=...) at /usr/include/c++/13/bits/alloc_traits.h:558
#12 std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::_M_destroy_node (__p=0x574674ccd280, this=0x5746747949a0) at /usr/include/c++/13/bits/stl_tree.h:625
#13 std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::_M_drop_node (this=this
entry=0x5746747949a0, __p=__p
entry=0x574674ccd280) at /usr/include/c++/13/bits/stl_tree.h:633
#14 0x000073233103b5e8 in std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::_M_erase (this=0x5746747949a0, __x=0x574674ccd280) at /usr/include/c++/13/bits/stl_tree.h:1938
#15 0x000073233103b603 in std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::~_Rb_tree (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/stl_tree.h:986
#16 0x0000732331039b42 in std::map<MReadOutElementVoxel3D, std::unique_ptr<TF1, std::default_delete<TF1> >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::~map (this=0x5746747949a0, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/stl_map.h:314
#17 MSubModuleShieldEnergyCorrection::~MSubModuleShieldEnergyCorrection (this=this
entry=0x574674794918, __in_chrg=<optimized out>) at src/MSubModuleShieldEnergyCorrection.cxx:65
#18 0x0000732330fc9c7c in MModuleDEESMEX::~MModuleDEESMEX (this=0x574674794720, __in_chrg=<optimized out>) at src/MModuleDEESMEX.cxx:88
#19 0x0000732330fc9cb7 in MModuleDEESMEX::~MModuleDEESMEX (this=0x574674794720, __in_chrg=<optimized out>) at src/MModuleDEESMEX.cxx:88
#20 0x000073233105247c in MSupervisor::~MSupervisor (this=0x7323310f2080 <MSupervisor::GetSupervisor()::Instance>, __in_chrg=<optimized out>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MSupervisor.cxx:138
#21 0x000073232f847a76 in __run_exit_handlers (status=0, listp=<optimized out>, run_list_atexit=run_list_atexit
entry=true, run_dtors=run_dtors
entry=true) at ./stdlib/exit.c:108
#22 0x000073232f847bbe in __GI_exit (status=<optimized out>) at ./stdlib/exit.c:138
#23 0x0000732330323cff in TUnixSystem::Exit(int, bool) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#24 0x00007323301b04f7 in TApplication::Terminate(int) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#25 0x0000732331051e82 in MSupervisor::Terminate (this=0x7323310f2080 <MSupervisor::GetSupervisor()::Instance>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MSupervisor.cxx:1178
#26 0x0000732331051ef6 in MSupervisor::Exit (this=<optimized out>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MSupervisor.cxx:1165
#27 0x00007323310459cf in MGUIMainFretalon::OnExit (this=0x57467450a3e0) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MGUIMainFretalon.cxx:471
#28 0x0000732331045825 in MGUIMainFretalon::CloseWindow (this=<optimized out>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MGUIMainFretalon.cxx:417
#29 0x000073232f47160e in TGMainFrame::HandleClientMessage(Event_t*) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#30 0x000073232f478fe7 in TGFrame::HandleEvent(Event_t*) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#31 0x000073232f4130fc in TGClient::HandleEvent(Event_t*) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#32 0x000073232f41370d in TGClient::ProcessOneEvent() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#33 0x000073232f41375a in TGClient::HandleInput() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#34 0x000073233032a7d0 in TUnixSystem::DispatchOneEvent(bool) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#35 0x0000732330227544 in TSystem::Run() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#36 0x00007323301acc77 in TApplication::Run(bool) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#37 0x0000574663e4c4df in main (argc=1, argv=0x7fff13e5fe68) at /home/hagemann/Software/COSItools/nuclearizer/src/MNuclearizerMain.cxx:88
===========================================================


The lines below might hint at the cause of the crash. If you see question
marks as part of the stack trace, try to recompile with debugging information
enabled and export CLING_DEBUG=1 environment variable before running.
You may get help by asking at the ROOT forum https://root.cern/forum
preferably using the command (.forum bug) in the ROOT prompt.
Only if you are really convinced it is a bug in ROOT then please submit a
report at https://root.cern/bugs or (preferably) using the command (.gh bug) in
the ROOT prompt. Please post the ENTIRE stack trace
from above as an attachment in addition to anything else
that might help us fixing this issue.
===========================================================
#6  0x0000574674cacbf0 in ?? ()
#7  0x000073233103b146 in std::default_delete<TF1>::operator() (__ptr=<optimized out>, this=<optimized out>) at /usr/include/c++/13/bits/unique_ptr.h:93
#8  std::unique_ptr<TF1, std::default_delete<TF1> >::~unique_ptr (this=0x574674ccd2e8, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/unique_ptr.h:404
#9  0x000073233103b55b in std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >::~pair (this=0x574674ccd2a0, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/stl_pair.h:187
#10 0x000073233103b5a3 in std::__new_allocator<std::_Rb_tree_node<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::destroy<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > (__p=0x574674ccd2a0, this=0x5746747949a0) at /usr/include/c++/13/bits/new_allocator.h:196
#11 std::allocator_traits<std::allocator<std::_Rb_tree_node<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > > >::destroy<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > (__p=0x574674ccd2a0, __a=...) at /usr/include/c++/13/bits/alloc_traits.h:558
#12 std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::_M_destroy_node (__p=0x574674ccd280, this=0x5746747949a0) at /usr/include/c++/13/bits/stl_tree.h:625
#13 std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::_M_drop_node (this=this
entry=0x5746747949a0, __p=__p
entry=0x574674ccd280) at /usr/include/c++/13/bits/stl_tree.h:633
#14 0x000073233103b5e8 in std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::_M_erase (this=0x5746747949a0, __x=0x574674ccd280) at /usr/include/c++/13/bits/stl_tree.h:1938
#15 0x000073233103b603 in std::_Rb_tree<MReadOutElementVoxel3D, std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > >, std::_Select1st<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::~_Rb_tree (this=<optimized out>, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/stl_tree.h:986
#16 0x0000732331039b42 in std::map<MReadOutElementVoxel3D, std::unique_ptr<TF1, std::default_delete<TF1> >, std::less<MReadOutElementVoxel3D>, std::allocator<std::pair<MReadOutElementVoxel3D const, std::unique_ptr<TF1, std::default_delete<TF1> > > > >::~map (this=0x5746747949a0, __in_chrg=<optimized out>) at /usr/include/c++/13/bits/stl_map.h:314
#17 MSubModuleShieldEnergyCorrection::~MSubModuleShieldEnergyCorrection (this=this
entry=0x574674794918, __in_chrg=<optimized out>) at src/MSubModuleShieldEnergyCorrection.cxx:65
#18 0x0000732330fc9c7c in MModuleDEESMEX::~MModuleDEESMEX (this=0x574674794720, __in_chrg=<optimized out>) at src/MModuleDEESMEX.cxx:88
#19 0x0000732330fc9cb7 in MModuleDEESMEX::~MModuleDEESMEX (this=0x574674794720, __in_chrg=<optimized out>) at src/MModuleDEESMEX.cxx:88
#20 0x000073233105247c in MSupervisor::~MSupervisor (this=0x7323310f2080 <MSupervisor::GetSupervisor()::Instance>, __in_chrg=<optimized out>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MSupervisor.cxx:138
#21 0x000073232f847a76 in __run_exit_handlers (status=0, listp=<optimized out>, run_list_atexit=run_list_atexit
entry=true, run_dtors=run_dtors
entry=true) at ./stdlib/exit.c:108
#22 0x000073232f847bbe in __GI_exit (status=<optimized out>) at ./stdlib/exit.c:138
#23 0x0000732330323cff in TUnixSystem::Exit(int, bool) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#24 0x00007323301b04f7 in TApplication::Terminate(int) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#25 0x0000732331051e82 in MSupervisor::Terminate (this=0x7323310f2080 <MSupervisor::GetSupervisor()::Instance>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MSupervisor.cxx:1178
#26 0x0000732331051ef6 in MSupervisor::Exit (this=<optimized out>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MSupervisor.cxx:1165
#27 0x00007323310459cf in MGUIMainFretalon::OnExit (this=0x57467450a3e0) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MGUIMainFretalon.cxx:471
#28 0x0000732331045825 in MGUIMainFretalon::CloseWindow (this=<optimized out>) at /home/hagemann/Software/COSItools/megalib/src/fretalon/framework/src/MGUIMainFretalon.cxx:417
#29 0x000073232f47160e in TGMainFrame::HandleClientMessage(Event_t*) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#30 0x000073232f478fe7 in TGFrame::HandleEvent(Event_t*) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#31 0x000073232f4130fc in TGClient::HandleEvent(Event_t*) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#32 0x000073232f41370d in TGClient::ProcessOneEvent() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#33 0x000073232f41375a in TGClient::HandleInput() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libGui.so.6.36
#34 0x000073233032a7d0 in TUnixSystem::DispatchOneEvent(bool) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#35 0x0000732330227544 in TSystem::Run() () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#36 0x00007323301acc77 in TApplication::Run(bool) () from /home/hagemann/Software/COSItools/external/root_v6.36.4/lib/libCore.so.6.36
#37 0x0000574663e4c4df in main (argc=1, argv=0x7fff13e5fe68) at /home/hagemann/Software/COSItools/nuclearizer/src/MNuclearizerMain.cxx:88
===========================================================
```