### PR TITLE
CHG: Print DEE trigger diagnostics only if verbosity is set to `Info`

### DIFF
--- a/src/MSubModuleShieldTrigger.cxx
+++ b/src/MSubModuleShieldTrigger.cxx
@@ -345,30 +345,33 @@ void MSubModuleShieldTrigger::Finalize()
 {
   // Finalize the analysis - do all cleanup
 
-  cout << "###################" << endl
-       << "SHIELD TRIGGER MODULE STATISTICS" << endl
-       << "###################" << endl;
-  
-  double simTime = m_LastTime - m_FirstTime;
-  if (simTime > 0) {
-    cout << "Simulation time: " << simTime << " seconds" << endl;
-  }
-  
-  cout << "Total BGO hits before BGO deadtime: " << m_NumShieldHitCounts << endl;
-  
-  for (int i = 0; i < nShieldPanels; i++) {
-    cout << "Shield Panel " << i << " dead time: " << m_TotalShieldDeadtime[i] << " seconds" << endl;
+  // Print shield trigger module diagnostics
+  if (g_Verbosity >= c_Info) {
+    cout << "###################" << endl
+        << "SHIELD TRIGGER MODULE STATISTICS" << endl
+        << "###################" << endl;
+    
+    double simTime = m_LastTime - m_FirstTime;
     if (simTime > 0) {
-      double liveFraction = 1.0 - (m_TotalShieldDeadtime[i] / simTime);
-      cout << "  Livetime fraction: " << liveFraction << endl;
+      cout << "Simulation time: " << simTime << " seconds" << endl;
     }
-  }
-  
-  cout << "BGO hits erased due to BGO being dead: " << m_NumBGOHitsErased << endl;
-  
-  if (simTime > 0) {
-    double rateAfterDT = (m_NumShieldHitCounts - m_NumBGOHitsErased) / simTime;
-    cout << "Shield rate after deadtime: " << rateAfterDT << " cps" << endl;
+    
+    cout << "Total BGO hits before BGO deadtime: " << m_NumShieldHitCounts << endl;
+    
+    for (int i = 0; i < nShieldPanels; i++) {
+      cout << "Shield Panel " << i << " dead time: " << m_TotalShieldDeadtime[i] << " seconds" << endl;
+      if (simTime > 0) {
+        double liveFraction = 1.0 - (m_TotalShieldDeadtime[i] / simTime);
+        cout << "  Livetime fraction: " << liveFraction << endl;
+      }
+    }
+    
+    cout << "BGO hits erased due to BGO being dead: " << m_NumBGOHitsErased << endl;
+    
+    if (simTime > 0) {
+      double rateAfterDT = (m_NumShieldHitCounts - m_NumBGOHitsErased) / simTime;
+      cout << "Shield rate after deadtime: " << rateAfterDT << " cps" << endl;
+    }
   }
 
   MSubModule::Finalize();

--- a/src/MSubModuleStripTrigger.cxx
+++ b/src/MSubModuleStripTrigger.cxx
@@ -473,37 +473,40 @@ void MSubModuleStripTrigger::Finalize()
 {
   // Finalize the analysis
 
-  cout << "###################" << endl
-       << "STRIP TRIGGER MODULE STATISTICS" << endl
-       << "###################" << endl;
-  
-  double simTime = m_LastTime - m_FirstTime;
-  if (simTime > 0) {
-    cout << "Simulation time: " << simTime << " seconds" << endl;
-  }
-  
-  cout << "Total strip hits after charge sharing (before deadtime): " << m_TotalStripHitsCounter << endl;
-  cout << "Total GR hits (before deadtime): " << m_TotalGRHitsCounter << endl;
-  cout << "Total dead time of the instrument: " << m_StripsTotalDeadtime << " seconds" << endl;
-  
-  if (simTime > 0) {
-    double liveFraction = 1.0 - (m_StripsTotalDeadtime / simTime);
-    cout << "Livetime fraction: " << liveFraction << endl;
-  }
-  
-  // cout << "Hits erased due to detector being dead: " << m_StripHitsErased << endl;
-  
-  if (m_TotalStripHitsCounter > 0) {
-    cout << "Avg deadtime per strip hit: " << m_StripsTotalDeadtime / m_TotalStripHitsCounter << " seconds" << endl;
-  }
-  
-  cout << "Trigger rates (events per detector):" << endl;
-  for (int i = 0; i < nDets; i++) {
-    cout << "  Detector " << i << ": " << m_NumStripTriggers[i] << " events";
+  // Print strip trigger module diagnostics
+  if (g_Verbosity >= c_Info) {
+    cout << "###################" << endl
+        << "STRIP TRIGGER MODULE STATISTICS" << endl
+        << "###################" << endl;
+    
+    double simTime = m_LastTime - m_FirstTime;
     if (simTime > 0) {
-      cout << " (" << (m_NumStripTriggers[i] / simTime) << " Hz)";
+      cout << "Simulation time: " << simTime << " seconds" << endl;
     }
-    cout << endl;
+    
+    cout << "Total strip hits after charge sharing (before deadtime): " << m_TotalStripHitsCounter << endl;
+    cout << "Total GR hits (before deadtime): " << m_TotalGRHitsCounter << endl;
+    cout << "Total dead time of the instrument: " << m_StripsTotalDeadtime << " seconds" << endl;
+    
+    if (simTime > 0) {
+      double liveFraction = 1.0 - (m_StripsTotalDeadtime / simTime);
+      cout << "Livetime fraction: " << liveFraction << endl;
+    }
+    
+    // cout << "Hits erased due to detector being dead: " << m_StripHitsErased << endl;
+    
+    if (m_TotalStripHitsCounter > 0) {
+      cout << "Avg deadtime per strip hit: " << m_StripsTotalDeadtime / m_TotalStripHitsCounter << " seconds" << endl;
+    }
+    
+    cout << "Trigger rates (events per detector):" << endl;
+    for (int i = 0; i < nDets; i++) {
+      cout << "  Detector " << i << ": " << m_NumStripTriggers[i] << " events";
+      if (simTime > 0) {
+        cout << " (" << (m_NumStripTriggers[i] / simTime) << " Hz)";
+      }
+      cout << endl;
+    }
   }
 
   MSubModule::Finalize();


### PR DESCRIPTION
Currently, when running the DEE, the strip and shield trigger module statistics are **always** printed streamed to `cout`.
With this PR, this will only be the case if the verbosity is explicitly set to `Info`.
