### PR TITLE
[DEE] Reduce code duplication in parsing energy calibration file

### DIFF
--- a/include/MModuleEnergyCalibration.h
+++ b/include/MModuleEnergyCalibration.h
@@ -137,6 +137,16 @@ class MModuleEnergyCalibration : public MModule
   //! Standalone function to return ADC of certain strip given energy
   double GetADC(MReadOutElementDoubleStrip R, double energy);
 
+  //! Get the energy calibration function map
+  void SetCalibration(map<MReadOutElementDoubleStrip, TF1*> Calibration) { m_Calibration = Calibration; }
+  //! Get the energy calibration function map
+  map<MReadOutElementDoubleStrip, TF1*> GetCalibration() { return m_Calibration; }
+
+  //! Get the energy resolution calibration function map
+  void SetResolutionCalibration(map<MReadOutElementDoubleStrip, TF1*> ResolutionCalibration) { m_ResolutionCalibration = ResolutionCalibration; }
+  //! Get the energy resolution calibration function map
+  map<MReadOutElementDoubleStrip, TF1*> GetResolutionCalibration() { return m_ResolutionCalibration; }
+
 
   // protected methods:
  protected:
@@ -186,6 +196,9 @@ class MModuleEnergyCalibration : public MModule
   map<MReadOutElementDoubleStrip, TF1*> m_ResolutionCalibration;
   //! Temperature Calibration map between read-out element and fitted function
   map<MReadOutElementDoubleStrip, double> m_ThresholdMap;
+
+  //! Max value of the ADC units
+  static constexpr double m_MaxADCRange = 16383;
  
 #ifdef ___CLING___
  public:

--- a/include/MModuleEnergyCalibration.h
+++ b/include/MModuleEnergyCalibration.h
@@ -115,6 +115,12 @@ class MModuleEnergyCalibration : public MModule
   //! Main data analysis routine, which updates the event to a new level 
   virtual bool AnalyzeEvent(MReadOutAssembly* Event);
 
+  //! Read the energy and energy resolution calibration from an .ecal file
+  virtual bool ReadEnergyCalibrationFile(MString FileName);
+
+  //! Read the slow thresholds from a file
+  virtual bool ReadSlowThresholdCutFile(MString FileName);
+
   //! Show the options GUI
   virtual void ShowOptionsGUI();
 

--- a/src/MModuleEnergyCalibration.cxx
+++ b/src/MModuleEnergyCalibration.cxx
@@ -329,7 +329,7 @@ bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
   MParser Parser;
   if (Parser.Open(FileName, MFile::c_Read) == false) {
     if (g_Verbosity >= c_Error) {
-      cout << m_XmlTag << ": Unable to open calibration file " << FileName << endl;
+      cout << m_XmlTag << ": Unable to open energy calibration file " << FileName << endl;
     }
     return false;
   }
@@ -339,7 +339,7 @@ bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
   map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine; //Energy Calibration Model
   map<MReadOutElementDoubleStrip, unsigned int> CR_ROEToLine; //Energy Resolution Calibration Model
 
-  //tokenize ecal file
+  // tokenize ecal file
   for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
     unsigned int NTokens = Parser.GetTokenizerAt(i)->GetNTokens();
     if (NTokens < 2) {
@@ -398,11 +398,11 @@ bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
     if (CalibratorType == "poly1zero") {
       double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
 
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly1zero", "0. + [0]*x", 0., 8191.);
+      // From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly1zero", "0. + [0]*x", 0., m_MaxADCRange);
       melinatorfit->FixParameter(0, a0);
 
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      // Define the map by saving the fit function I just created as a map to the current ReadOutElement
       m_Calibration[CM.first] = melinatorfit;
 
     }
@@ -412,12 +412,12 @@ bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
       double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
 
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., 8191.);
+      // From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., m_MaxADCRange);
       melinatorfit->FixParameter(0, a0);
       melinatorfit->FixParameter(1, a1);
 
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      // Define the map by saving the fit function I just created as a map to the current ReadOutElement
       m_Calibration[CM.first] = melinatorfit;
 
     } else if (CalibratorType == "poly2") {
@@ -425,31 +425,31 @@ bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
       double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
 
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., 8191.);
+      // From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., m_MaxADCRange);
       melinatorfit->FixParameter(0, a0);
       melinatorfit->FixParameter(1, a1);
       melinatorfit->FixParameter(2, a2);
 
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      // Define the map by saving the fit function I just created as a map to the current ReadOutElement
       m_Calibration[CM.first] = melinatorfit;
 
     }
-    //Eventually, I'll be including other possible fits, but for now, we've just include poly3 and poly4
+    // Eventually, I'll be including other possible fits, but for now, we've just include poly3 and poly4
     else if (CalibratorType == "poly3") {
       double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
 
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., 8191.);
+      // From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., m_MaxADCRange);
       melinatorfit->FixParameter(0, a0);
       melinatorfit->FixParameter(1, a1);
       melinatorfit->FixParameter(2, a2);
       melinatorfit->FixParameter(3, a3);
 
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      // Define the map by saving the fit function I just created as a map to the current ReadOutElement
       m_Calibration[CM.first] = melinatorfit;
 
     } else if (CalibratorType == "poly4") {
@@ -459,15 +459,15 @@ bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
       double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
       double a4 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
 
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly4", "[0] + [1]*x + [2]*x^2 + [3]*x^3 + [4]*x^4", 0., 8191.);
+      // From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly4", "[0] + [1]*x + [2]*x^2 + [3]*x^3 + [4]*x^4", 0., m_MaxADCRange);
       melinatorfit->FixParameter(0, a0);
       melinatorfit->FixParameter(1, a1);
       melinatorfit->FixParameter(2, a2);
       melinatorfit->FixParameter(3, a3);
       melinatorfit->FixParameter(4, a4);
 
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      // Define the map by saving the fit function I just created as a map to the current ReadOutElement
       m_Calibration[CM.first] = melinatorfit;
 
     } else {

--- a/src/MModuleEnergyCalibration.cxx
+++ b/src/MModuleEnergyCalibration.cxx
@@ -134,216 +134,15 @@ bool MModuleEnergyCalibration::Initialize()
 {
   // Initialize the module
 
-  //Parse the Energy Calibration file
-  MParser Parser;
-  if (Parser.Open(m_FileName, MFile::c_Read) == false) {
-    if (g_Verbosity >= c_Error) {
-      cout << m_XmlTag << ": Unable to open calibration file " << m_FileName << endl;
-    }
+  // Parse the energy calibration file
+  if (ReadEnergyCalibrationFile(m_FileName) == false) {
     return false;
   }
-  //Parse the slow Threshold file
+
+  // Parse the slow threshold file
   if (m_SlowThresholdCutMode == MSlowThresholdCutModes::e_File) {
-    MParser Parser_Threshold;
-    if (Parser_Threshold.Open(m_SlowThresholdCutFileName, MFile::c_Read) == false) {
-      if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unable to open Threshold file "<<m_SlowThresholdCutFileName<<endl;
+    if (ReadSlowThresholdCutFile(m_SlowThresholdCutFileName) == false) {
       return false;
-    } else {
-      MString Line; // each line of the threshold csv file
-      while (Parser_Threshold.ReadLine(Line)) {
-        if (!Line.BeginsWith("#")) {
-          std::vector<MString> Tokens = Line.Tokenize(","); // for each line, Create tokens seperated by commas
-          if (Tokens.size() == 6) {
-            int IndexOffset = Tokens.size() % 6; //index counter
-            int DetID = Tokens[1 + IndexOffset].ToInt(); // Detector ID
-            MString Side = Tokens[2 + IndexOffset].ToString(); // side is a string, either 'l' or 'h'
-            int StripID = Tokens[3 + IndexOffset].ToInt(); // stripID
-            //int ThresholdADC = Tokens[4 + IndexOffset].ToInt(); // energy threshold in ADC
-            double ThresholdKeVFile = Tokens[5 + IndexOffset].ToDouble(); //energy threshold in keV
-
-            MReadOutElementDoubleStrip R;
-            R.SetDetectorID(DetID);
-            R.SetStripID(StripID);
-            R.IsLowVoltageStrip(Side == "l");
-
-            // map detectorID, strip number, and voltage side to the threshold (keV)
-            m_ThresholdMap[R] = ThresholdKeVFile;
-          }
-        }
-      }
-    }
-  }
-  // create other maps
-  map<MReadOutElementDoubleStrip, unsigned int> CP_ROEToLine; //Peak fits
-  map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine; //Energy Calibration Model
-  map<MReadOutElementDoubleStrip, unsigned int> CR_ROEToLine; //Energy Resolution Calibration Model
-
-  //tokenize ecal file
-  for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
-    unsigned int NTokens = Parser.GetTokenizerAt(i)->GetNTokens();
-    if (NTokens < 2) {
-      continue;
-    }
-    if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CP") == true ||
-        Parser.GetTokenizerAt(i)->IsTokenAt(0, "CM") == true || Parser.GetTokenizerAt(i)->IsTokenAt(0, "CR") == true) {
-      if (Parser.GetTokenizerAt(i)->IsTokenAt(1, "dss") == true) {
-
-        // input token values to map
-        MReadOutElementDoubleStrip R;
-        R.SetDetectorID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(2));
-        R.SetStripID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(3));
-        R.IsLowVoltageStrip((Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "p") || (Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "l"));
-        if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CP") == true) {
-          CP_ROEToLine[R] = i;
-        } else if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CM") == true) {
-          CM_ROEToLine[R] = i;
-        } else {
-          CR_ROEToLine[R] = i;
-        }
-      } else {
-        if (g_Verbosity >= c_Error) {
-          cout << m_XmlTag << ": Line parser: Unknown read-out element (" << Parser.GetTokenizerAt(i)->GetTokenAt(1) << ")" << endl;
-        }
-        return false;
-      }
-    }
-  }
-
-  for (auto CM : CM_ROEToLine) {
-    // If we have at least three data points, we store the calibration
-
-    if (CP_ROEToLine.find(CM.first) != CP_ROEToLine.end()) {
-      unsigned int i = CP_ROEToLine[CM.first];
-      if (Parser.GetTokenizerAt(i)->IsTokenAt(5, "pakw") == false) {
-        if (g_Verbosity >= c_Warning) {
-          cout << m_XmlTag << ": Unknown calibration point descriptor found: " << Parser.GetTokenizerAt(i)->GetTokenAt(5) << endl;
-        }
-        continue;
-      }
-    } else {
-      if (g_Verbosity >= c_Warning) {
-        cout << m_XmlTag << ": No good calibration for the following strip found: " << CM.first << endl;
-      }
-      continue;
-    }
-
-    // Read the calibrator, i.e. read the fit function from the .ecal Melinator file.
-
-    unsigned int Pos = 5;
-    MString CalibratorType = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsString(Pos);
-    CalibratorType.ToLower();
-
-    // Below inclusion of poly1zero written by J. Beechert on 2019/11/15
-    if (CalibratorType == "poly1zero") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly1zero", "0. + [0]*x", 0., 8191.);
-      melinatorfit->FixParameter(0, a0);
-
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
-      m_Calibration[CM.first] = melinatorfit;
-
-    }
-
-    // Below inclusion of poly1 and poly2 written by J. Beechert on 2019/10/24
-    else if (CalibratorType == "poly1") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., 8191.);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
-      m_Calibration[CM.first] = melinatorfit;
-
-    } else if (CalibratorType == "poly2") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., 8191.);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-      melinatorfit->FixParameter(2, a2);
-
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
-      m_Calibration[CM.first] = melinatorfit;
-
-    }
-    //Eventually, I'll be including other possible fits, but for now, we've just include poly3 and poly4
-    else if (CalibratorType == "poly3") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., 8191.);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-      melinatorfit->FixParameter(2, a2);
-      melinatorfit->FixParameter(3, a3);
-
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
-      m_Calibration[CM.first] = melinatorfit;
-
-    } else if (CalibratorType == "poly4") {
-      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-      double a4 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
-
-      //From the fit parameters I just extracted from the .ecal file, I can define a function
-      TF1* melinatorfit = new TF1("poly4", "[0] + [1]*x + [2]*x^2 + [3]*x^3 + [4]*x^4", 0., 8191.);
-      melinatorfit->FixParameter(0, a0);
-      melinatorfit->FixParameter(1, a1);
-      melinatorfit->FixParameter(2, a2);
-      melinatorfit->FixParameter(3, a3);
-      melinatorfit->FixParameter(4, a4);
-
-      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
-      m_Calibration[CM.first] = melinatorfit;
-
-    } else {
-      if (g_Verbosity >= c_Error) {
-        cout << m_XmlTag << ": Line parser: Unknown calibrator type (" << CalibratorType << ") for strip" << CM.first << endl;
-      }
-      continue;
-    }
-  }
-
-  for (auto CR : CR_ROEToLine) {
-
-    unsigned int Pos = 5;
-    MString CalibratorType = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsString(Pos);
-    CalibratorType.ToLower();
-    if (CalibratorType == "p1" || CalibratorType == "poly1") {
-      double f0 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
-      double f1 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
-      TF1* resolutionfit = new TF1("P1", "([0]+[1]*x) / 2.355", 0., 2000.);
-      resolutionfit->FixParameter(0, f0);
-      resolutionfit->FixParameter(1, f1);
-
-      m_ResolutionCalibration[CR.first] = resolutionfit;
-    } else if (CalibratorType == "p2" || CalibratorType == "poly2") {
-      double f0 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
-      double f1 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
-      double f2 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
-      TF1* resolutionfit = new TF1("P2", "([0]+[1]*x+[2]*x*x) / 2.355", 0., 2000.);
-      resolutionfit->FixParameter(0, f0);
-      resolutionfit->FixParameter(1, f1);
-      resolutionfit->FixParameter(2, f2);
-      m_ResolutionCalibration[CR.first] = resolutionfit;
-    } else {
-      if (g_Verbosity >= c_Error) {
-        cout << m_XmlTag << ": Line parser: Unknown resolution calibrator type (" << CalibratorType << ") for strip" << CR.first << endl;
-      }
-      continue;
     }
   }
 
@@ -518,6 +317,238 @@ void MModuleEnergyCalibration::Finalize()
   }
 
   return;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleEnergyCalibration::ReadEnergyCalibrationFile(MString FileName) {
+
+  // Parse the Energy Calibration file
+  MParser Parser;
+  if (Parser.Open(FileName, MFile::c_Read) == false) {
+    if (g_Verbosity >= c_Error) {
+      cout << m_XmlTag << ": Unable to open calibration file " << FileName << endl;
+    }
+    return false;
+  }
+
+  // create other maps
+  map<MReadOutElementDoubleStrip, unsigned int> CP_ROEToLine; //Peak fits
+  map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine; //Energy Calibration Model
+  map<MReadOutElementDoubleStrip, unsigned int> CR_ROEToLine; //Energy Resolution Calibration Model
+
+  //tokenize ecal file
+  for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
+    unsigned int NTokens = Parser.GetTokenizerAt(i)->GetNTokens();
+    if (NTokens < 2) {
+      continue;
+    }
+    if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CP") == true ||
+        Parser.GetTokenizerAt(i)->IsTokenAt(0, "CM") == true || Parser.GetTokenizerAt(i)->IsTokenAt(0, "CR") == true) {
+      if (Parser.GetTokenizerAt(i)->IsTokenAt(1, "dss") == true) {
+
+        // input token values to map
+        MReadOutElementDoubleStrip R;
+        R.SetDetectorID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(2));
+        R.SetStripID(Parser.GetTokenizerAt(i)->GetTokenAtAsUnsignedInt(3));
+        R.IsLowVoltageStrip((Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "p") || (Parser.GetTokenizerAt(i)->GetTokenAtAsString(4) == "l"));
+        if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CP") == true) {
+          CP_ROEToLine[R] = i;
+        } else if (Parser.GetTokenizerAt(i)->IsTokenAt(0, "CM") == true) {
+          CM_ROEToLine[R] = i;
+        } else {
+          CR_ROEToLine[R] = i;
+        }
+      } else {
+        if (g_Verbosity >= c_Error) {
+          cout << m_XmlTag << ": Line parser: Unknown read-out element (" << Parser.GetTokenizerAt(i)->GetTokenAt(1) << ")" << endl;
+        }
+        return false;
+      }
+    }
+  }
+
+  for (auto CM : CM_ROEToLine) {
+    // If we have at least three data points, we store the calibration
+
+    if (CP_ROEToLine.find(CM.first) != CP_ROEToLine.end()) {
+      unsigned int i = CP_ROEToLine[CM.first];
+      if (Parser.GetTokenizerAt(i)->IsTokenAt(5, "pakw") == false) {
+        if (g_Verbosity >= c_Warning) {
+          cout << m_XmlTag << ": Unknown calibration point descriptor found: " << Parser.GetTokenizerAt(i)->GetTokenAt(5) << endl;
+        }
+        continue;
+      }
+    } else {
+      if (g_Verbosity >= c_Warning) {
+        cout << m_XmlTag << ": No good calibration for the following strip found: " << CM.first << endl;
+      }
+      continue;
+    }
+
+    // Read the calibrator, i.e. read the fit function from the .ecal Melinator file.
+
+    unsigned int Pos = 5;
+    MString CalibratorType = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsString(Pos);
+    CalibratorType.ToLower();
+
+    // Below inclusion of poly1zero written by J. Beechert on 2019/11/15
+    if (CalibratorType == "poly1zero") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      //From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly1zero", "0. + [0]*x", 0., 8191.);
+      melinatorfit->FixParameter(0, a0);
+
+      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      m_Calibration[CM.first] = melinatorfit;
+
+    }
+
+    // Below inclusion of poly1 and poly2 written by J. Beechert on 2019/10/24
+    else if (CalibratorType == "poly1") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      //From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., 8191.);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+
+      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      m_Calibration[CM.first] = melinatorfit;
+
+    } else if (CalibratorType == "poly2") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      //From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., 8191.);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+      melinatorfit->FixParameter(2, a2);
+
+      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      m_Calibration[CM.first] = melinatorfit;
+
+    }
+    //Eventually, I'll be including other possible fits, but for now, we've just include poly3 and poly4
+    else if (CalibratorType == "poly3") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      //From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., 8191.);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+      melinatorfit->FixParameter(2, a2);
+      melinatorfit->FixParameter(3, a3);
+
+      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      m_Calibration[CM.first] = melinatorfit;
+
+    } else if (CalibratorType == "poly4") {
+      double a0 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a1 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a2 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a3 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+      double a4 = Parser.GetTokenizerAt(CM.second)->GetTokenAtAsDouble(++Pos);
+
+      //From the fit parameters I just extracted from the .ecal file, I can define a function
+      TF1* melinatorfit = new TF1("poly4", "[0] + [1]*x + [2]*x^2 + [3]*x^3 + [4]*x^4", 0., 8191.);
+      melinatorfit->FixParameter(0, a0);
+      melinatorfit->FixParameter(1, a1);
+      melinatorfit->FixParameter(2, a2);
+      melinatorfit->FixParameter(3, a3);
+      melinatorfit->FixParameter(4, a4);
+
+      //Define the map by saving the fit function I just created as a map to the current ReadOutElement
+      m_Calibration[CM.first] = melinatorfit;
+
+    } else {
+      if (g_Verbosity >= c_Error) {
+        cout << m_XmlTag << ": Line parser: Unknown calibrator type (" << CalibratorType << ") for strip" << CM.first << endl;
+      }
+      continue;
+    }
+  }
+
+  for (auto CR : CR_ROEToLine) {
+
+    unsigned int Pos = 5;
+    MString CalibratorType = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsString(Pos);
+    CalibratorType.ToLower();
+    if (CalibratorType == "p1" || CalibratorType == "poly1") {
+      double f0 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
+      double f1 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
+      TF1* resolutionfit = new TF1("P1", "([0]+[1]*x) / 2.355", 0., 2000.);
+      resolutionfit->FixParameter(0, f0);
+      resolutionfit->FixParameter(1, f1);
+
+      m_ResolutionCalibration[CR.first] = resolutionfit;
+    } else if (CalibratorType == "p2" || CalibratorType == "poly2") {
+      double f0 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
+      double f1 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
+      double f2 = Parser.GetTokenizerAt(CR.second)->GetTokenAtAsDouble(++Pos);
+      TF1* resolutionfit = new TF1("P2", "([0]+[1]*x+[2]*x*x) / 2.355", 0., 2000.);
+      resolutionfit->FixParameter(0, f0);
+      resolutionfit->FixParameter(1, f1);
+      resolutionfit->FixParameter(2, f2);
+      m_ResolutionCalibration[CR.first] = resolutionfit;
+    } else {
+      if (g_Verbosity >= c_Error) {
+        cout << m_XmlTag << ": Line parser: Unknown resolution calibrator type (" << CalibratorType << ") for strip" << CR.first << endl;
+      }
+      continue;
+    }
+  }
+
+  return true;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MModuleEnergyCalibration::ReadSlowThresholdCutFile(MString FileName) {
+
+  MParser Parser;
+  if (Parser.Open(FileName, MFile::c_Read) == false) {
+    if (g_Verbosity >= c_Error) {
+      cout<<m_XmlTag<<": Unable to open Threshold file "<<FileName<<endl;
+    }
+    return false;
+  }
+
+  MString Line; // each line of the threshold csv file
+  while (Parser.ReadLine(Line) == true) {
+    if (Line.BeginsWith("#") == false) {
+      std::vector<MString> Tokens = Line.Tokenize(","); // for each line, Create tokens seperated by commas
+      if (Tokens.size() == 6) {
+        int IndexOffset = Tokens.size() % 6; //index counter
+        int DetID = Tokens[1 + IndexOffset].ToInt(); // Detector ID
+        MString Side = Tokens[2 + IndexOffset].ToString(); // side is a string, either 'l' or 'h'
+        int StripID = Tokens[3 + IndexOffset].ToInt(); // stripID
+        //int ThresholdADC = Tokens[4 + IndexOffset].ToInt(); // energy threshold in ADC
+        double ThresholdKeVFile = Tokens[5 + IndexOffset].ToDouble(); //energy threshold in keV
+
+        MReadOutElementDoubleStrip R;
+        R.SetDetectorID(DetID);
+        R.SetStripID(StripID);
+        R.IsLowVoltageStrip(Side == "l");
+
+        // map detectorID, strip number, and voltage side to the threshold (keV)
+        m_ThresholdMap[R] = ThresholdKeVFile;
+      }
+    }
+  }
+
+  return true;
 }
 
 

--- a/src/MSubModuleStripReadout.cxx
+++ b/src/MSubModuleStripReadout.cxx
@@ -30,10 +30,10 @@
 
 // ROOT libs:
 #include "TRandom.h"
-#include "TMath.h"
 
 // MEGAlib libs:
 #include "MParser.h"
+#include "MModuleEnergyCalibration.h"
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -74,6 +74,10 @@ bool MSubModuleStripReadout::Initialize()
 {
   // Initialize the module
 
+  // Clear the maps before reading
+  m_Calibration.clear();
+  m_ResolutionCalibration.clear();
+
   // Check if we have a file
   if (m_EnergyCalibrationFileName == "") {
     if (g_Verbosity >= c_Error) {
@@ -82,142 +86,16 @@ bool MSubModuleStripReadout::Initialize()
     return false;
   }
 
-  // Open ecal file
-  MParser Parser;
-  if (Parser.Open(m_EnergyCalibrationFileName, MFile::c_Read) == false) {
-    if (g_Verbosity >= c_Error) {
-      cout << m_Name << ": Unable to open calibration file " << m_EnergyCalibrationFileName << endl;
-    }
+  // Read energy calibration file
+  MModuleEnergyCalibration EnergyCalibration;
+  if (EnergyCalibration.ReadEnergyCalibrationFile(m_EnergyCalibrationFileName) == true) {
+    // Copy the energy calibration function maps
+    m_Calibration = EnergyCalibration.GetCalibration();
+    m_ResolutionCalibration = EnergyCalibration.GetResolutionCalibration();
+  } else {
     return false;
   }
-
-  // Create the map to store line numbers
-  map<MReadOutElementDoubleStrip, unsigned int> CM_ROEToLine;
-    
-  // Clear the maps before reading
-  m_ResolutionCalibration.clear();
-  m_Calibration.clear();
-
   
-  for (unsigned int i = 0; i < Parser.GetNLines(); ++i) {
-    MTokenizer* T = Parser.GetTokenizerAt(i);
-    
-    // If user wants it, get the fits to smear the energies based on the FWHM from the ecal
-    if (m_ApplyResolutionCalibration == true) {
-      
-      if (T->GetNTokens() >= 6 && T->IsTokenAt(0, "CR") == true && T->IsTokenAt(1, "dss") == true) {
-        MReadOutElementDoubleStrip R;
-        R.SetDetectorID(T->GetTokenAtAsUnsignedInt(2));
-        R.SetStripID(T->GetTokenAtAsUnsignedInt(3));
-        R.IsLowVoltageStrip((T->GetTokenAtAsString(4) == "p") || (T->GetTokenAtAsString(4) == "l"));
-        
-        MString ResolutionCalibrationType = T->GetTokenAtAsString(5);
-        ResolutionCalibrationType.ToLower();
-        
-        // position of the fwhm and max keV value
-        unsigned int PosResolution = 6;
-        unsigned int HistMaxkeV = 10000;
-        
-        // Look for the CR lines
-        if (ResolutionCalibrationType == "poly1") {
-          double a0 = T->GetTokenAtAsDouble(PosResolution++);
-          double a1 = T->GetTokenAtAsDouble(PosResolution++);
-          
-          TF1* resFit = new TF1("res_poly1", "[0] + [1]*x", 0., HistMaxkeV);
-          resFit->SetParameters(a0, a1);
-          m_ResolutionCalibration[R] = resFit;
-          
-        } else if (ResolutionCalibrationType == "poly2") {
-          double a0 = T->GetTokenAtAsDouble(PosResolution++);
-          double a1 = T->GetTokenAtAsDouble(PosResolution++);
-          double a2 = T->GetTokenAtAsDouble(PosResolution++);
-          
-          TF1* resFit = new TF1("res_poly2", "[0] + [1]*x + [2]*x^2", 0., HistMaxkeV);
-          resFit->SetParameters(a0, a1, a2);
-          m_ResolutionCalibration[R] = resFit;
-          
-        } else if (ResolutionCalibrationType == "poly3") {
-          double a0 = T->GetTokenAtAsDouble(PosResolution++);
-          double a1 = T->GetTokenAtAsDouble(PosResolution++);
-          double a2 = T->GetTokenAtAsDouble(PosResolution++);
-          double a3 = T->GetTokenAtAsDouble(PosResolution++);
-          
-          TF1* resFit = new TF1("res_poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., HistMaxkeV);
-          resFit->SetParameters(a0, a1, a2, a3);
-          m_ResolutionCalibration[R] = resFit;
-          
-        } else {
-          // TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
-          // So far, only added these ones because these are the ones we use for the ecals
-          if (g_Verbosity >= c_Error) {
-            cout << m_Name << ": Unknown FWHM calibrator type: " << ResolutionCalibrationType << endl;
-            return false;
-          }
-        }
-      }
-    }
-    
-    
-    // Get enegry calibration fits second
-    if (T->GetNTokens() >= 2 && T->IsTokenAt(0, "CM") == true && T->IsTokenAt(1, "dss") == true) {
-      
-      MReadOutElementDoubleStrip R;
-      R.SetDetectorID(T->GetTokenAtAsUnsignedInt(2));
-      R.SetStripID(T->GetTokenAtAsUnsignedInt(3));
-      R.IsLowVoltageStrip((T->GetTokenAtAsString(4) == "p") ||
-                          (T->GetTokenAtAsString(4) == "l"));
-      
-      unsigned int Pos = 5;
-      
-      // Get CM token
-      MString CalibratorType = T->GetTokenAtAsString(Pos);
-      CalibratorType.ToLower();
-      
-      
-      if (CalibratorType == "poly1") {
-        double a0 = T->GetTokenAtAsDouble(++Pos);
-        double a1 = T->GetTokenAtAsDouble(++Pos);
-        
-        TF1* melinatorfit = new TF1("poly1", "[0] + [1]*x", 0., m_MaxADCRange);
-        melinatorfit->FixParameter(0, a0);
-        melinatorfit->FixParameter(1, a1);
-        
-        m_Calibration[R] = melinatorfit;
-      } else if (CalibratorType == "poly2") {
-        double a0 = T->GetTokenAtAsDouble(++Pos);
-        double a1 = T->GetTokenAtAsDouble(++Pos);
-        double a2 = T->GetTokenAtAsDouble(++Pos);
-        
-        TF1* melinatorfit = new TF1("poly2", "[0] + [1]*x + [2]*x^2", 0., m_MaxADCRange);
-        melinatorfit->FixParameter(0, a0);
-        melinatorfit->FixParameter(1, a1);
-        melinatorfit->FixParameter(2, a2);
-        
-        m_Calibration[R] = melinatorfit;
-      } else if (CalibratorType == "poly3") {
-        double a0 = T->GetTokenAtAsDouble(++Pos);
-        double a1 = T->GetTokenAtAsDouble(++Pos);
-        double a2 = T->GetTokenAtAsDouble(++Pos);
-        double a3 = T->GetTokenAtAsDouble(++Pos);
-        
-        TF1* melinatorfit = new TF1("poly3", "[0] + [1]*x + [2]*x^2 + [3]*x^3", 0., m_MaxADCRange);
-        melinatorfit->FixParameter(0, a0);
-        melinatorfit->FixParameter(1, a1);
-        melinatorfit->FixParameter(2, a2);
-        melinatorfit->FixParameter(3, a3);
-        
-        m_Calibration[R] = melinatorfit;
-      } else {
-        // TODO: @RobinAnthonyPetersen add all the other types of fits melinator can do
-        // So far, only added these ones because these are the ones we use for the ecals
-        if (g_Verbosity >= c_Error) {
-          cout<<m_Name<<": Unhandled CalibratorType: "<<CalibratorType<<endl<<"Please update this module."<<endl;
-        }
-        return false;
-      }
-    }
-  }
-
   return MSubModule::Initialize();
 }
 
@@ -240,8 +118,6 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
 {
   // Main data analysis routine, which updates the event to a new level
   
-  static const double FWHMtoSigma = 2.0 * TMath::Sqrt(2.0 * TMath::Log(2.0));
-
   // Get low-voltage and high-voltage hits
   for (auto* Hits : { &Event->GetDEEStripHitLVListReference(), &Event->GetDEEStripHitHVListReference() }) {
     
@@ -252,14 +128,10 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
         // Look up the FWHM fit for this strip
         if (m_ResolutionCalibration.count(SH.m_ROE) == 1) {
           
-          // Calculate FWHM (keV) at this energy
-          double fwhm = m_ResolutionCalibration[SH.m_ROE]->Eval(SH.m_Energy);
-          
-          // Convert FWHM to Sigma (FWHM = 2.355 * Sigma)
-          double sigma = fwhm / FWHMtoSigma;
+          double Sigma = m_ResolutionCalibration[SH.m_ROE]->Eval(SH.m_Energy);
           
           // Smear the hit energy using a Gaussian distribution
-          SH.m_Energy = gRandom->Gaus(SH.m_Energy, sigma);
+          SH.m_Energy = gRandom->Gaus(SH.m_Energy, Sigma);
           
           // If energy is lower than zero now, floor it to zero
           if (SH.m_Energy < 0) {
@@ -269,9 +141,9 @@ bool MSubModuleStripReadout::AnalyzeEvent(MReadOutAssembly* Event)
         } else {
           // The fit wasn't found! Handle the error
           if (g_Verbosity >= c_Warning) {
-          cout << m_Name << ": Warning - No resolution calibration fit found for strip ID " << SH.m_ROE.GetStripID() << endl;
+            cout << m_Name << ": Warning - No resolution calibration fit found for strip ID " << SH.m_ROE.GetStripID() << endl;
           }
-          // Note, if there is not calibration found then the energy remains unsmeared
+          // Note, if no resolution calibration is found then the energy remains unsmeared
         }
       }
       


### PR DESCRIPTION
This is my attempt at reducing the code duplication in `MSubModuleStripReadout`.
Currently, we have two implementations of reading an ecal file; in `MModuleEnergyCalibration` and `MSubModuleStripReadout`. The only difference between them seems to be that the energy resolution in `MModuleEnergyCalibration` is parsed in units of `σ` by dividing by 2.355 already in the `TF1` function, whereas in `MSubModuleStripReadout` it is parsed in units of FWHM in the `TF1` function, and then converted to `σ` later in the code.

By exporting the code to read the energy calibration file to a dedicated function, we can avoid the code duplication.

I ran the code twice, with the current `develop/em` branch and the updated code in this PR to cross-check that I obtain the same results and that the energy resolution is handled in the correct units (`σ`/FWHM) :
<img width="580" height="432" alt="image" src="https://github.com/user-attachments/assets/a762bf36-bda7-455a-9157-d9b43f76d0bc" />
