### PR TITLE
[DEE] Consistenly use `GetTimeUTC` instead of `GetTime`

### DIFF
--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -130,7 +130,7 @@ bool MModuleDEESMEX::AnalyzeEvent(MReadOutAssembly* Event)
   m_Intake.Clear();
   m_Intake.AnalyzeEvent(Event);
 
-  if (Event->GetTime() < m_DeadTimeEnd) {
+  if (Event->GetTimeUTC() < m_DeadTimeEnd) {
     // Flag event for deletion
     return true;
   }

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -518,7 +518,7 @@ bool MReadOutAssembly::GetNextFromDatFile(MFile &F){
 		} else if( Line.BeginsWith("TI") ){
 			MTime T = MTime();
 			T.Set(Line);
-			SetTime( T );
+			SetTimeUTC( T );
 		} else if( Line.BeginsWith("HT") ){
 			MHit* h = new MHit();
 			h->Parse(Line);

--- a/src/MSubModuleDEEIntake.cxx
+++ b/src/MSubModuleDEEIntake.cxx
@@ -95,6 +95,9 @@ bool MSubModuleDEEIntake::AnalyzeEvent(MReadOutAssembly* Event)
   // Main data analysis routine, which updates the event to a new level
 
   Event->SetID(Event->GetSimulatedEvent()->GetID());
+  Event->SetTimeUTC(Event->GetSimulatedEvent()->GetTime());
+
+  // TODO: Check if all instances in the DEE of Get/SetTime are replaced by Get/SetTimeUTC
   Event->SetTime(Event->GetSimulatedEvent()->GetTime());
 
   for (unsigned int h = 0; h < Event->GetSimulatedEvent()->GetNHTs(); ++h) {

--- a/src/MSubModuleShieldTrigger.cxx
+++ b/src/MSubModuleShieldTrigger.cxx
@@ -301,7 +301,7 @@ bool MSubModuleShieldTrigger::AnalyzeEvent(MReadOutAssembly* Event)
   m_HasShieldVeto = false;
   m_IsShieldDead = false;
 
-  m_EventTime = Event->GetTime().GetAsSeconds();
+  m_EventTime = Event->GetTimeUTC().GetAsSeconds();
 
   // First: veto based on shield state from previous events
   for (int group = 0; group < nShieldPanels; ++group) {

--- a/src/MSubModuleStripTrigger.cxx
+++ b/src/MSubModuleStripTrigger.cxx
@@ -295,7 +295,7 @@ bool MSubModuleStripTrigger::ProcessStripHits(MReadOutAssembly* Event)
 {
   // Process strip hits for deadtime calculation and trigger determination
 
-  m_EventTime = Event->GetTime().GetAsSeconds();
+  m_EventTime = Event->GetTimeUTC().GetAsSeconds();
   bool ASICFirstHitAfterDead = false;
   m_IsGeDDead = false;
 


### PR DESCRIPTION
Following up on https://github.com/cositools/nuclearizer/pull/124#discussion_r3196618854, I looked up all occurences of `GetTime` in the DEE and replaced them with `GetTimeUTC`.

In order for this to work, the "biggest" change in this PR is adding the following line to `MSubModuleDEEIntake`:
```
Event->SetTimeUTC(Event->GetSimulatedEvent()->GetTime());
```
Before this PR, all `TI` values in the ROA files created using simulated DEE events were all zero (reason being: cosima `TI` values are read in and stored in `Event->GetSimulatedEvent->m_Time`, but we save `Event->m_EventTimeUTC` to the ROA file).

After this PR, when writing ROA files using simulated DEE events, the `TI` values in the resulting ROA files match the `TI` values in the input cosima file.

