### PR TITLE
GuardRing Hits and XE in EVTA file

### DIFF
--- a/include/MModuleDepthCalibration.h
+++ b/include/MModuleDepthCalibration.h
@@ -184,6 +184,7 @@ class MModuleDepthCalibration : public MModule
   uint64_t m_ErrorNullSH;
   uint64_t m_ErrorNoE;
   unordered_map<int, MDDetector*> m_Detectors;
+  unordered_map<int, MDDetector*> m_GRDetectors;
   vector<unsigned int> m_DetectorIDs;
   MModuleEnergyCalibration* m_EnergyCalibration;
   MGUIExpoDepthCalibration* m_ExpoDepthCalibration;

--- a/src/MHit.cxx
+++ b/src/MHit.cxx
@@ -244,11 +244,10 @@ void MHit::StreamEvta(ostream& S)
     }
     S<<endl;
 
-  } else if {
-    S<<"GR ;"<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy
-      <<";"<<m_PositionResolution.GetX()<<";"<<m_PositionResolution.GetY()<<";"
-      <<m_PositionResolution.GetZ()<<";"<<m_EnergyResolution; 
+  } else if (m_GuardRingHit == true) {
+    S<<"GR "<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy;   
     S<<endl;
+
   } else if (m_NoDepth == true) {
     S<<"XE "<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy;
     S<<endl;
@@ -260,6 +259,60 @@ void MHit::StreamEvta(ostream& S)
 
 
 bool MHit::Parse(MString& Line, int Version)
+
+  //check that line begins with HT
+  const char* line = Line.Data();
+
+  if( line[0] == 'H' && line[1] == 'T' ) {
+    float X,Y,Z,E;
+    sscanf(&line[3],"%f %f %f %f",&X, &Y, &Z, &E);
+    m_Position.SetX(X);
+    m_Position.SetY(Y);
+    m_Position.SetZ(Z);
+    m_Energy = E;
+    return true;
+
+  } else if (line[0] == 'G' && line[1] == 'R' ) {
+    float X,Y,Z,E;
+    sscanf(&line[2],"%f %f %f %f",&X, &Y, &Z, &E);
+    m_Position.SetX(X);
+    m_Position.SetY(Y);
+    m_Position.SetZ(Z);
+    m_Energy = E;
+    m_GuardRingHit = true;
+    return true;
+
+  } else {
+    return false;
+  }
+
+	
+  /*
+  if( Line.BeginsWith("HT") ){
+    vector<MString> tokens = Line.Tokenize(" ");
+    if( tokens.size() >= 5 ){
+      m_Position.SetX( tokens.at(1).ToDouble() );
+      m_Position.SetY( tokens.at(2).ToDouble() );
+      m_Position.SetZ( tokens.at(3).ToDouble() );
+      m_Energy = tokens.at(4).ToDouble();
+      return true;
+    } else {
+      return false;
+    }
+  } else {
+    return false;
+  }
+  */
+
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+//! Set the origins from the simulations (take care of duplicates)
+void MHit::AddOrigins(vector<int> Origins)
+>>>>>>> 5a54288 (Include GR and XE hits in evta)
 {
   // Parse a hit in Nuclearizer's DAT format
 

--- a/src/MHit.cxx
+++ b/src/MHit.cxx
@@ -193,54 +193,66 @@ void MHit::StreamEvta(ostream& S)
 {
   // Stream the hit in MEGAlib's EVTA format
 
-  // Assemble the origin information
-  vector<int> Origins;
+  if ((m_GuardRingHit == false) && (m_NoDepth == false)) {
 
-  // Only origins existing on both low-voltage and high-voltage strips count
-  vector<int> LVOrigins;
-  vector<int> HVOrigins;
-  for (unsigned int s = 0; s < GetNStripHits(); ++s) {
-    MStripHit* StripHit = m_StripHits[s];
-    vector<int> NewOrigins = StripHit->GetOrigins();
-    if (StripHit->IsLowVoltageStrip() == true) {
-      for (int o: NewOrigins) {
-        LVOrigins.push_back(o);
-      }
-    } else {
-      for (int o: NewOrigins) {
-        HVOrigins.push_back(o);
-      }
-    }
-  }
+    // Assemble the origin information
+    vector<int> Origins;
 
-  sort(LVOrigins.begin(), LVOrigins.end());
-  LVOrigins.erase(unique(LVOrigins.begin(), LVOrigins.end()), LVOrigins.end());
-  sort(HVOrigins.begin(), HVOrigins.end());
-  HVOrigins.erase(unique(HVOrigins.begin(), HVOrigins.end()), HVOrigins.end());
-
-  set_intersection(LVOrigins.begin(), LVOrigins.end(),
-                   HVOrigins.begin(), HVOrigins.end(),
-                   std::back_inserter(Origins));
-
-  if ((LVOrigins.size() != 0 || HVOrigins.size() != 0) && Origins.size() == 0) {
-    // If strip pairing mixed the hits completely, keep the mixed origin information
+    // Only origins existing on both low-voltage and high-voltage strips count
+    vector<int> LVOrigins;
+    vector<int> HVOrigins;
     for (unsigned int s = 0; s < GetNStripHits(); ++s) {
       MStripHit* StripHit = m_StripHits[s];
       vector<int> NewOrigins = StripHit->GetOrigins();
-      for (int o: NewOrigins) {
-        Origins.push_back(o);
+      if (StripHit->IsLowVoltageStrip() == true) {
+        for (int o: NewOrigins) {
+          LVOrigins.push_back(o);
+        }
+      } else {
+        for (int o: NewOrigins) {
+          HVOrigins.push_back(o);
+        }
       }
     }
-    sort(Origins.begin(), Origins.end());
-    Origins.erase(unique(Origins.begin(), Origins.end()), Origins.end());
-  }
 
-  S<<"HT 3;"<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy
-    <<";"<<m_PositionResolution.GetX()<<";"<<m_PositionResolution.GetY()<<";"<<m_PositionResolution.GetZ()<<";"<<m_EnergyResolution;
-  for (unsigned int i = 0; i < Origins.size(); ++i) {
-    S<<";"<<Origins[i];
+    sort(LVOrigins.begin(), LVOrigins.end());
+    LVOrigins.erase(unique(LVOrigins.begin(), LVOrigins.end()), LVOrigins.end());
+    sort(HVOrigins.begin(), HVOrigins.end());
+    HVOrigins.erase(unique(HVOrigins.begin(), HVOrigins.end()), HVOrigins.end());
+
+    set_intersection(LVOrigins.begin(), LVOrigins.end(),
+                    HVOrigins.begin(), HVOrigins.end(),
+                    std::back_inserter(Origins));
+
+    if ((LVOrigins.size() != 0 || HVOrigins.size() != 0) && Origins.size() == 0) {
+      // If strip pairing mixed the hits completely, keep the mixed origin information
+      for (unsigned int s = 0; s < GetNStripHits(); ++s) {
+        MStripHit* StripHit = m_StripHits[s];
+        vector<int> NewOrigins = StripHit->GetOrigins();
+        for (int o: NewOrigins) {
+          Origins.push_back(o);
+        }
+      }
+      sort(Origins.begin(), Origins.end());
+      Origins.erase(unique(Origins.begin(), Origins.end()), Origins.end());
+    }
+
+    S<<"HT 3;"<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy
+      <<";"<<m_PositionResolution.GetX()<<";"<<m_PositionResolution.GetY()<<";"<<m_PositionResolution.GetZ()<<";"<<m_EnergyResolution;
+    for (unsigned int i = 0; i < Origins.size(); ++i) {
+      S<<";"<<Origins[i];
+    }
+    S<<endl;
+
+  } else if {
+    S<<"GR ;"<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy
+      <<";"<<m_PositionResolution.GetX()<<";"<<m_PositionResolution.GetY()<<";"
+      <<m_PositionResolution.GetZ()<<";"<<m_EnergyResolution; 
+    S<<endl;
+  } else if (m_NoDepth == true) {
+    S<<"XE "<<m_Position.GetX()<<";"<<m_Position.GetY()<<";"<<m_Position.GetZ()<<";"<<m_Energy;
+    S<<endl;
   }
-  S<<endl;
 }
 
 

--- a/src/MHit.cxx
+++ b/src/MHit.cxx
@@ -259,60 +259,6 @@ void MHit::StreamEvta(ostream& S)
 
 
 bool MHit::Parse(MString& Line, int Version)
-
-  //check that line begins with HT
-  const char* line = Line.Data();
-
-  if( line[0] == 'H' && line[1] == 'T' ) {
-    float X,Y,Z,E;
-    sscanf(&line[3],"%f %f %f %f",&X, &Y, &Z, &E);
-    m_Position.SetX(X);
-    m_Position.SetY(Y);
-    m_Position.SetZ(Z);
-    m_Energy = E;
-    return true;
-
-  } else if (line[0] == 'G' && line[1] == 'R' ) {
-    float X,Y,Z,E;
-    sscanf(&line[2],"%f %f %f %f",&X, &Y, &Z, &E);
-    m_Position.SetX(X);
-    m_Position.SetY(Y);
-    m_Position.SetZ(Z);
-    m_Energy = E;
-    m_GuardRingHit = true;
-    return true;
-
-  } else {
-    return false;
-  }
-
-	
-  /*
-  if( Line.BeginsWith("HT") ){
-    vector<MString> tokens = Line.Tokenize(" ");
-    if( tokens.size() >= 5 ){
-      m_Position.SetX( tokens.at(1).ToDouble() );
-      m_Position.SetY( tokens.at(2).ToDouble() );
-      m_Position.SetZ( tokens.at(3).ToDouble() );
-      m_Energy = tokens.at(4).ToDouble();
-      return true;
-    } else {
-      return false;
-    }
-  } else {
-    return false;
-  }
-  */
-
-}
-
-
-////////////////////////////////////////////////////////////////////////////////
-
-
-//! Set the origins from the simulations (take care of duplicates)
-void MHit::AddOrigins(vector<int> Origins)
->>>>>>> 5a54288 (Include GR and XE hits in evta)
 {
   // Parse a hit in Nuclearizer's DAT format
 

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -116,7 +116,6 @@ bool MModuleDepthCalibration::Initialize()
     return false;
   }
 
-  // Check for issues with geometry or file loading, and return appropriate errors
   if (m_DetectorIDs.size() == 0) {
     cout<<"No Strip3D detectors were found."<<endl;
     return false; 
@@ -192,21 +191,21 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
     if (H->GetGuardRingHitFlag() == true) {
       // For GR Hit, define position to be anywhere within the GR volume to pass through to revan
 
-      int GRDetID = H->GetStripHit(0)->GetDetectorID();
+//      int GRDetID = H->GetStripHit(0)->GetDetectorID();
       // Find unique/random position within the GR volume to assign as the hit position, as revan expects
-      MVector GRPosition = m_Geometry->GetDetector(m_GRDetectors[GRDetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
+//      MVector GRPosition = m_Geometry->GetDetector(m_GRDetectors[GRDetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
 
-      Xpos = GRPosition[0];
-      Ypos = GRPosition[1];
-      Zpos = GRPosition[2];      
+//      Xpos = GRPosition[0];
+//      Ypos = GRPosition[1];
+//      Zpos = GRPosition[2];      
 
-      if (g_Verbosity >= c_Info) cout << m_XmlTag << "GR Hit :" << GRDetID << ", " << "set hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
+//      if (g_Verbosity >= c_Info) cout << m_XmlTag << "GR Hit :" << GRDetID << ", " << "set hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
 
-      MVector GlobalPositionGR = m_GRDetectors[GRDetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(GRPosition);
-      H->SetPosition(GlobalPositionGR); 
+//      MVector GlobalPositionGR = m_GRDetectors[GRDetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(GRPosition);
+//      H->SetPosition(GlobalPositionGR); 
 
       // Skip past the rest of the calibration and move to next Hit
-      continue;
+ //     continue;
  
     } // If not a GR Hit, perform the depth/position calibration...
 
@@ -536,9 +535,25 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
           cout<<"ERROR in MModuleDepthCalibration::Initialize: Found a Strip3D detector with "<<det->GetNSensitiveVolumes()<<" Sensitive Volumes."<<endl;
         }
       }
+    } else if (det->GetTypeName() == "Simple") {
+//      if (det->GetNSensitiveVolumes() == 1) {
+//        MString DetectorName = det->GetName();
+//        string DetName = DetectorName.GetString();
+        
+        // Check that the DetID agrees with the naming scheme GeD_X
+//        if (DetectorName.BeginsWith("GuardRingDetector_GeD_") == true) {
+//          DetectorName.RemoveAllInPlace("GuardRingDetector_GeD_"); // The number after GeD is the COSI detector ID
+//          if (DetID != (DetectorName.ToUnsignedInt()-1)) { // The GR detector ID is +1 compared to the GeD detector for the same DetID.
+//            if (g_Verbosity >= c_Error) {
+//              cout << "ERROR in MModuleDepthCalibration::Initialize: Non-matching DetID="<<DetID<<" for GR detector "<<DetName<<endl;
+//            }
+//          } else {
+//            m_GRDetectors[DetID-1] = det;
+//          }
+//        }
+//      }
     }
   }
-
   return true;
 }
 

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -117,7 +117,7 @@ bool MModuleDepthCalibration::Initialize()
   }
 
   if (m_DetectorIDs.size() == 0) {
-    cout<<"No Strip3D detectors were found."<<endl;
+    if (g_Verbosity >= c_Error) cout << m_XmlTag << ": No Strip3D detectors were found"<<endl;
     return false; 
   }
 
@@ -134,7 +134,7 @@ bool MModuleDepthCalibration::Initialize()
     if (g_Verbosity >= c_Info) cout << m_XmlTag << ": !!! Mask Metrology Enabled !!!" << endl;
     m_MaskMetrologyFileIsLoaded = LoadMaskMetrologyFile(m_MaskMetrologyFileName);
     if (m_MaskMetrologyFileIsLoaded == false) {
-      if (g_Verbosity >= c_Error) cout << m_XmlTag << "Unable to open Metrology file" << endl;
+      if (g_Verbosity >= c_Error) cout << m_XmlTag << ": Unable to open Metrology file" << endl;
       return false;
     }
   }
@@ -191,21 +191,28 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
     if (H->GetGuardRingHitFlag() == true) {
       // For GR Hit, define position to be anywhere within the GR volume to pass through to revan
 
-//      int GRDetID = H->GetStripHit(0)->GetDetectorID();
+      int GRDetID = H->GetStripHit(0)->GetDetectorID();
+
       // Find unique/random position within the GR volume to assign as the hit position, as revan expects
-//      MVector GRPosition = m_Geometry->GetDetector(m_GRDetectors[GRDetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
+      if (m_GRDetectors[GRDetID]->GetName().BeginsWith("GuardRing") == true) {
+        MVector GRPosition = m_Geometry->GetDetector(m_GRDetectors[GRDetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
+      
+        Xpos = GRPosition[0];
+        Ypos = GRPosition[1];
+        Zpos = GRPosition[2];      
+      
+        if (g_Verbosity >= c_Info) cout << m_XmlTag << ": GR Hit: Det ID " << GRDetID << ", " << "set hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
 
-//      Xpos = GRPosition[0];
-//      Ypos = GRPosition[1];
-//      Zpos = GRPosition[2];      
+        MVector GlobalPositionGR = m_GRDetectors[GRDetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(GRPosition);
+        H->SetPosition(GlobalPositionGR); 
 
-//      if (g_Verbosity >= c_Info) cout << m_XmlTag << "GR Hit :" << GRDetID << ", " << "set hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
-
-//      MVector GlobalPositionGR = m_GRDetectors[GRDetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(GRPosition);
-//      H->SetPosition(GlobalPositionGR); 
+      } else {
+        if (g_Verbosity >= c_Error) cout << m_XmlTag << ": Could not find GuardRing volume for position determination" << endl;
+      }
+      
 
       // Skip past the rest of the calibration and move to next Hit
- //     continue;
+      continue;
  
     } // If not a GR Hit, perform the depth/position calibration...
 
@@ -298,11 +305,11 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
         Event->SetDepthCalibrationError("No calibration coefficients");
         ++m_Error1;
       } else if (CTDVec.size() == 0) {
-          if (g_Verbosity >= c_Error) cout << m_XmlTag << "Empty CTD vector" << endl;
+          if (g_Verbosity >= c_Error) cout << m_XmlTag << ": Empty CTD vector" << endl;
           H->SetNoDepth();
           Event->SetDepthCalibrationError("No calibration coefficients");
       } else if (DepthVec.size() == 0) {
-          if (g_Verbosity >= c_Error) cout << m_XmlTag << "Empty Depth vector" << endl;
+          if (g_Verbosity >= c_Error) cout << m_XmlTag << ": Empty Depth vector" << endl;
           H->SetNoDepth();
           Event->SetDepthCalibrationError("No calibration coefficients");
       } else if ((LVTiming < 1.0E-6) || (HVTiming < 1.0E-6)) {
@@ -378,7 +385,7 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       
       }
     
-      if (g_Verbosity >= c_Info) cout << m_XmlTag << "Strip ID :" << LVStripID << " " << HVStripID << endl << "Hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
+      if (g_Verbosity >= c_Info) cout << m_XmlTag << ": Strip ID: " << LVStripID << " " << HVStripID << endl << "Hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
 
     }
     
@@ -393,8 +400,8 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
     H->SetPosition(GlobalPosition); 
     H->SetPositionResolution(GlobalResolution);
 
-    // For events that have NoDepth, these can be passed through revan with an XE flag and any position within the detector
-    if (H->GetNoDepth() == true) {
+    // For non-GR hits that have NoDepth, these can be passed through revan with an XE flag and any position within the detector
+    if (H->GetNoDepth() == true && H->GetGuardRingHitFlag() == false) {
       DetID = H->GetStripHit(0)->GetDetectorID();
       MVector XEPosition = m_Geometry->GetDetector(m_Detectors[DetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
       
@@ -535,23 +542,24 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
           cout<<"ERROR in MModuleDepthCalibration::Initialize: Found a Strip3D detector with "<<det->GetNSensitiveVolumes()<<" Sensitive Volumes."<<endl;
         }
       }
-    } else if (det->GetTypeName() == "Simple") {
-//      if (det->GetNSensitiveVolumes() == 1) {
-//        MString DetectorName = det->GetName();
-//        string DetName = DetectorName.GetString();
-        
-        // Check that the DetID agrees with the naming scheme GeD_X
-//        if (DetectorName.BeginsWith("GuardRingDetector_GeD_") == true) {
-//          DetectorName.RemoveAllInPlace("GuardRingDetector_GeD_"); // The number after GeD is the COSI detector ID
-//          if (DetID != (DetectorName.ToUnsignedInt()-1)) { // The GR detector ID is +1 compared to the GeD detector for the same DetID.
-//            if (g_Verbosity >= c_Error) {
-//              cout << "ERROR in MModuleDepthCalibration::Initialize: Non-matching DetID="<<DetID<<" for GR detector "<<DetName<<endl;
-//            }
-//          } else {
-//            m_GRDetectors[DetID-1] = det;
-//          }
-//        }
-//      }
+    } else if (det->GetTypeName() == "Simple" || det->GetTypeName() == "Scintillator") {
+      if (det->GetNSensitiveVolumes() == 1) {
+        MString DetectorName = det->GetName();
+        string DetName = DetectorName.GetString();
+        // Check that the DetID agrees with the naming scheme GuardRingDetector_GeD_
+        if (DetectorName.BeginsWith("GuardRingDetector_GeD_") == true) {
+          DetectorName.RemoveAllInPlace("GuardRingDetector_GeD_"); // The number after GeD is the COSI detector ID
+          if (DetID != (DetectorName.ToUnsignedInt()-1)) { // The GR detector ID is +1 compared to the GeD detector for the same DetID.
+            if (g_Verbosity >= c_Error) {
+              cout << "ERROR in MModuleDepthCalibration::Initialize: Non-matching DetID="<<DetID<<" for GR detector "<<DetName<<endl;
+            }
+          } else {
+            m_GRDetectors[DetID-1] = det;
+          }
+        } else if (DetectorName == "GuardRingDetector") {
+          m_GRDetectors[DetID-1] = det;
+        }
+      }
     }
   }
   return true;
@@ -580,7 +588,7 @@ bool MModuleDepthCalibration::LoadCoeffsFile(MString FileName)
       std::vector<MString> Tokens = Line.Tokenize(" ");
       m_Coeffs_Energy = Tokens[5].ToDouble();
       if (g_Verbosity >= c_Info) {
-        cout << m_XmlTag << "The stretch and offset were calculated for " << m_Coeffs_Energy << " keV." << endl;
+        cout << m_XmlTag << ": The stretch and offset were calculated for " << m_Coeffs_Energy << " keV." << endl;
       }
     } else {
       std::vector<MString> Tokens = Line.Tokenize(",");
@@ -807,7 +815,7 @@ int MModuleDepthCalibration::GetHitGrade(MHit* H){
   }
   if (H->GetNStripHits() == 0) {
     // Error if no strip hits listed. Bad grade is returned
-    if (g_Verbosity >= c_Error) cout << m_XmlTag << "ERROR in MModuleDepthCalibration: HIT WITH NO STRIP HITS" << endl;
+    if (g_Verbosity >= c_Error) cout << m_XmlTag << ": ERROR in MModuleDepthCalibration: HIT WITH NO STRIP HITS" << endl;
     return -1;
   }
    
@@ -819,11 +827,11 @@ int MModuleDepthCalibration::GetHitGrade(MHit* H){
   for (unsigned int j = 0; j < H->GetNStripHits(); ++j) {
     MStripHit* SH = H->GetStripHit(j);
     if (SH == nullptr ) { 
-      if (g_Verbosity >= c_Error) cout << m_XmlTag << "ERROR in MModuleDepthCalibration: Depth Calibration: got NULL strip hit :( " << endl;
+      if (g_Verbosity >= c_Error) cout << m_XmlTag << ": ERROR in MModuleDepthCalibration: Depth Calibration: got NULL strip hit :( " << endl;
       return -1;
     }
     if (SH->GetEnergy() == 0 ) { 
-      if (g_Verbosity >= c_Error) cout << m_XmlTag << "ERROR in MModuleDepthCalibration: Depth Calibration: got strip without energy :( " << endl; 
+      if (g_Verbosity >= c_Error) cout << m_XmlTag << ": ERROR in MModuleDepthCalibration: Depth Calibration: got strip without energy :( " << endl; 
       return -1;
     }
     if (SH->IsLowVoltageStrip()) {

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -185,7 +185,6 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
   
     // Skip the depth calibration for Hits that have a GR Strip Hit
     if (H->GetGuardRingHitFlag() == true) {
-      cout<<"Found GR Hit"<<endl;
       continue;
     }
 

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -177,202 +177,196 @@ void MModuleDepthCalibration::CreateExpos()
 
 bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event) 
 {
+
+  for (unsigned int i = 0; i < Event->GetNHits(); ++i ){
+    // H is a pointer to an instance of the MHit class. Each Hit has activated strips, represented by
+    // instances of the MStripHit class.
+    MHit* H = Event->GetHit(i);
   
-  if (Event->GetGuardRingVeto() == true) {
-    //TODO: Handle events with GR vetos    
-    
-    Event->SetDepthCalibrationError("GR Veto");
-    return false;
-  
-  } else {
-    
-    for (unsigned int i = 0; i < Event->GetNHits(); ++i ){
-      // Each event represents one photon. It contains Hits, representing interaction sites.
-      // H is a pointer to an instance of the MHit class. Each Hit has activated strips, represented by
-      // instances of the MStripHit class.
-      MHit* H = Event->GetHit(i);
+    // Skip the depth calibration for Hits that have a GR Strip Hit
+    if (H->GetGuardRingHitFlag() == true) {
+      cout<<"Found GR Hit"<<endl;
+      continue;
+    }
 
-      int Grade = GetHitGrade(H);
+    int Grade = GetHitGrade(H);
 
-      // Handle different grades differently    
-      // GRADE=-1 is an error. Break from the loop and continue.
-      if (Grade < 0){
+    // Handle different grades differently    
+    // GRADE=-1 is an error. Break from the loop and continue.
+    if (Grade < 0){
+      H->SetNoDepth();
+      Event->SetDepthCalibrationError("Error in depth calibration");
+      if (Grade == -1) {
+        ++m_ErrorSH;
+      } else if (Grade == -2) {
+        ++m_ErrorNullSH;
+      } else if (Grade == -3) {
+        ++m_ErrorNoE;
+      }
+    } else if (Grade > 4) { // GRADE=5 is some complicated geometry with multiple hits on a single strip. GRADE=6 means not all strips are adjacent.
+      H->SetNoDepth();
+      Event->SetDepthCalibrationError("Multiple hits on single strip");
+      if (Grade==5) {
+        ++m_Error5;
+      } else if (Grade==6) {
+        ++m_Error6;
+      }
+    } else { // If the Grade is 0-4, we can handle it.
+
+      // Calculate the position. If error is thrown, record and no depth.
+      // Take a Hit and separate its activated X- and Y-strips into separate vectors.
+      vector<MStripHit*> LVStrips;
+      vector<MStripHit*> HVStrips;
+
+      for (unsigned int j = 0; j < H->GetNStripHits(); ++j) {
+        MStripHit* SH = H->GetStripHit(j);
+        if (SH->IsLowVoltageStrip()) LVStrips.push_back(SH); else HVStrips.push_back(SH);
+      }
+
+      double LVEnergyFraction;
+      double HVEnergyFraction;
+      MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
+      MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
+
+      double CTD_s = 0.0;
+
+      //now try and get z position
+      int DetID = LVSH->GetDetectorID();
+      int LVStripID = LVSH->GetStripID();
+      int HVStripID = HVSH->GetStripID();
+      int PixelCode = 10000*DetID + 100*LVStripID + HVStripID;
+
+      //Define the X/Y positions based on the detector pitch and number of strip hits
+      // LV strip 0 is in -ve X direction, HV strip 0 is in -ve Y direction.
+      // Confusingly, the strips parallel to the Y axis determines the X position, and the "X strips" determine the Y position
+      double Xpos = m_YPitches[DetID]*((double)LVStripID - ((m_NYStrips[DetID]-1)/2.0));
+      double Ypos = m_XPitches[DetID]*((double)HVStripID - ((m_NXStrips[DetID]-1)/2.0));
+      double Zpos = 0.0;
+
+      if (m_MaskMetrologyEnabled == true) {
+        // If we are applying the mask metrology correction, first define two new readout elements to help determine the intersection of these two strips
+        MReadOutElementDoubleStrip R_LV = *dynamic_cast<MReadOutElementDoubleStrip*>(LVSH->GetReadOutElement());
+        MReadOutElementDoubleStrip R_HV = *dynamic_cast<MReadOutElementDoubleStrip*>(HVSH->GetReadOutElement());
+
+        // Find the intercept of the two dominate strips based on the mask metrology, and update Xpos and Ypos	  
+        vector<double> inter = GetStripIntersection(R_LV, R_HV);
+        Xpos = inter[0];
+        Ypos = inter[1];
+      }
+
+
+      // TODO: Calculate X and Y positions more rigorously using charge sharing.
+
+      double Xsigma = m_YPitches[DetID]/sqrt(12.0);
+      double Ysigma = m_XPitches[DetID]/sqrt(12.0);
+      double Zsigma = m_Thicknesses[DetID]/sqrt(12.0);
+
+      vector<double>* Coeffs = GetPixelCoeffs(PixelCode);
+
+      vector<double> CTDVec = GetCTD(DetID, Grade);
+      vector<double> DepthVec = GetDepth(DetID);
+
+      double LVTiming = LVSH->GetTiming();
+      double HVTiming = HVSH->GetTiming();
+
+      // If there aren't coefficients loaded, then report a depth calibration error.
+      if( Coeffs == nullptr ){
+        // Set the bad flag for depth
         H->SetNoDepth();
-        Event->SetDepthCalibrationError("Error in depth calibration");
-        if (Grade == -1) {
-          ++m_ErrorSH;
-        } else if (Grade == -2) {
-          ++m_ErrorNullSH;
-        } else if (Grade == -3) {
-          ++m_ErrorNoE;
-        }
-      } else if (Grade > 4) { // GRADE=5 is some complicated geometry with multiple hits on a single strip. GRADE=6 means not all strips are adjacent.
-        H->SetNoDepth();
-        Event->SetDepthCalibrationError("Multiple hits on single strip");
-        if (Grade==5) {
-          ++m_Error5;
-        } else if (Grade==6) {
-          ++m_Error6;
-        }
-      } else { // If the Grade is 0-4, we can handle it.
-
-        // Calculate the position. If error is thrown, record and no depth.
-        // Take a Hit and separate its activated X- and Y-strips into separate vectors.
-        vector<MStripHit*> LVStrips;
-        vector<MStripHit*> HVStrips;
-
-        for (unsigned int j = 0; j < H->GetNStripHits(); ++j) {
-          MStripHit* SH = H->GetStripHit(j);
-          if (SH->IsLowVoltageStrip()) LVStrips.push_back(SH); else HVStrips.push_back(SH);
-        }
-
-        double LVEnergyFraction;
-        double HVEnergyFraction;
-        MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
-        MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
-
-        double CTD_s = 0.0;
-
-        //now try and get z position
-        int DetID = LVSH->GetDetectorID();
-        int LVStripID = LVSH->GetStripID();
-        int HVStripID = HVSH->GetStripID();
-        int PixelCode = 10000*DetID + 100*LVStripID + HVStripID;
-
-       //Define the X/Y positions based on the detector pitch and number of strip hits
-        // LV strip 0 is in -ve X direction, HV strip 0 is in -ve Y direction.
-        // Confusingly, the strips parallel to the Y axis determines the X position, and the "X strips" determine the Y position
-        double Xpos = m_YPitches[DetID]*((double)LVStripID - ((m_NYStrips[DetID]-1)/2.0));
-        double Ypos = m_XPitches[DetID]*((double)HVStripID - ((m_NXStrips[DetID]-1)/2.0));
-        double Zpos = 0.0;
-
-        if (m_MaskMetrologyEnabled == true) {
-          // If we are applying the mask metrology correction, first define two new readout elements to help determine the intersection of these two strips
-          MReadOutElementDoubleStrip R_LV = *dynamic_cast<MReadOutElementDoubleStrip*>(LVSH->GetReadOutElement());
-          MReadOutElementDoubleStrip R_HV = *dynamic_cast<MReadOutElementDoubleStrip*>(HVSH->GetReadOutElement());
-
-          // Find the intercept of the two dominate strips based on the mask metrology, and update Xpos and Ypos	  
-          vector<double> inter = GetStripIntersection(R_LV, R_HV);
-          Xpos = inter[0];
-          Ypos = inter[1];
-
-	}
-
-
-        // TODO: Calculate X and Y positions more rigorously using charge sharing.
-
-        double Xsigma = m_YPitches[DetID]/sqrt(12.0);
-        double Ysigma = m_XPitches[DetID]/sqrt(12.0);
-        double Zsigma = m_Thicknesses[DetID]/sqrt(12.0);
-
-        vector<double>* Coeffs = GetPixelCoeffs(PixelCode);
-
-        vector<double> CTDVec = GetCTD(DetID, Grade);
-        vector<double> DepthVec = GetDepth(DetID);
-
-        // TODO: For Card Cage, may need to add noise
-        double LVTiming = LVSH->GetTiming();
-        double HVTiming = HVSH->GetTiming();
-
-        // If there aren't coefficients loaded, then report a depth calibration error.
-        if( Coeffs == nullptr ){
-          // Set the bad flag for depth
+        Event->SetDepthCalibrationError("No calibration coefficients");
+        ++m_Error1;
+      } else if (CTDVec.size() == 0) {
+          if (g_Verbosity >= c_Error) cout << m_XmlTag << "Empty CTD vector" << endl;
           H->SetNoDepth();
           Event->SetDepthCalibrationError("No calibration coefficients");
-          ++m_Error1;
-        } else if (CTDVec.size() == 0) {
-            if (g_Verbosity >= c_Error) cout << m_XmlTag << "Empty CTD vector" << endl;
-            H->SetNoDepth();
-            Event->SetDepthCalibrationError("No calibration coefficients");
-        } else if (DepthVec.size() == 0) {
-            if (g_Verbosity >= c_Error) cout << m_XmlTag << "Empty Depth vector" << endl;
-            H->SetNoDepth();
-            Event->SetDepthCalibrationError("No calibration coefficients");
-        } else if ((LVTiming < 1.0E-6) || (HVTiming < 1.0E-6)) {
-            ++m_Error3;
-            H->SetNoDepth();
-            Event->SetDepthCalibrationError("No timing");
-        } else {
+      } else if (DepthVec.size() == 0) {
+          if (g_Verbosity >= c_Error) cout << m_XmlTag << "Empty Depth vector" << endl;
+          H->SetNoDepth();
+          Event->SetDepthCalibrationError("No calibration coefficients");
+      } else if ((LVTiming < 1.0E-6) || (HVTiming < 1.0E-6)) {
+          ++m_Error3;
+          H->SetNoDepth();
+          Event->SetDepthCalibrationError("No timing");
+      } else {
           
-          // If there are coefficients and timing information is loaded, try calculating the CTD and depth
-          double CTD = (HVTiming - LVTiming);
+        // If there are coefficients and timing information is loaded, try calculating the CTD and depth
+        double CTD = (HVTiming - LVTiming);
 
-          // Confirmed that this matches SP's python code.
-          CTD_s = (CTD - Coeffs->at(1))/(Coeffs->at(0)); //apply inverse stretch and offset
+        // Confirmed that this matches SP's python code.
+        CTD_s = (CTD - Coeffs->at(1))/(Coeffs->at(0)); //apply inverse stretch and offset
 
-          double Xmin = * std::min_element(CTDVec.begin(), CTDVec.end());
-          double Xmax = * std::max_element(CTDVec.begin(), CTDVec.end());
+        double Xmin = * std::min_element(CTDVec.begin(), CTDVec.end());
+        double Xmax = * std::max_element(CTDVec.begin(), CTDVec.end());
 
-          double noise = GetTimingNoiseFWHM(PixelCode, H->GetEnergy());
+        double noise = GetTimingNoiseFWHM(PixelCode, H->GetEnergy());
 
-          //if the CTD is out of range, check if we should reject the event.
-          if ((CTD_s < (Xmin - 2.0*noise)) || (CTD_s > (Xmax + 2.0*noise))) {
-            H->SetNoDepth();
-            Event->SetDepthCalibrationError("Out of Range");
-            ++m_Error2;
-          }
-
-          // If the CTD is in range, calculate the depth
-          // Rather than plugging CTD into a spline to get depth, use the depth-CTD relation to calculate a probability-weighted depth value.
-          // This way we can avoid problems like non-monotonicity or assigning depth to events "outside" the detector 
-          // Note that this requires that we don't massively overestimate the timing noise
-          else {
-            // Calculate the probability given timing noise of CTD_s corresponding to the values of depth in DepthVec
-            // Utlize symmetry of the normal distribution.
-            vector<double> prob_dist = norm_pdf(CTDVec, CTD_s, noise/2.355);
-            
-            // Weight the depth by probability
-        	  double prob_sum = 0.0;
-        	  for (unsigned int k=0; k < prob_dist.size(); ++k) {
-        	    prob_sum += prob_dist[k];
-        	  }
-            double weighted_depth = 0.0;
-
-            for (unsigned int k = 0; k < DepthVec.size(); ++k) {
-              weighted_depth += prob_dist[k] * DepthVec[k];
-            }
-
-            // Calculate the expectation value of the depth
-            double mean_depth = weighted_depth/prob_sum;
-
-            // Calculate the standard deviation of the depth
-            double depth_var = 0.0;
-
-            for (unsigned int k=0; k < DepthVec.size(); ++k) {
-              depth_var += prob_dist[k] * pow(DepthVec[k] - mean_depth, 2.0);
-            }
-
-            Zsigma =  sqrt(depth_var/prob_sum);
-            Zpos = mean_depth;
-            // Zpos = mean_depth - (m_Thicknesses[DetID]/2.0);
-
-            // Add the depth to the GUI histogram.
-            if (Event->HasStripPairingError()==false) {
-              if (HasExpos() == true) {
-                m_ExpoDepthCalibration->AddDepth(DetID, Zpos);
-              }
-            }
-            m_NoError+=1;
-          }
+        //if the CTD is out of range, check if we should reject the event.
+        if ((CTD_s < (Xmin - 2.0*noise)) || (CTD_s > (Xmax + 2.0*noise))) {
+          H->SetNoDepth();
+          Event->SetDepthCalibrationError("Out of Range");
+          ++m_Error2;
         }
 
-      if (g_Verbosity >= c_Info) cout << m_XmlTag << "Strip ID :" << LVStripID << " " << HVStripID << endl << "Hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
+        // If the CTD is in range, calculate the depth
+        // Rather than plugging CTD into a spline to get depth, use the depth-CTD relation to calculate a probability-weighted depth value.
+        // This way we can avoid problems like non-monotonicity or assigning depth to events "outside" the detector 
+        // Note that this requires that we don't massively overestimate the timing noise
+        else {
+          // Calculate the probability given timing noise of CTD_s corresponding to the values of depth in DepthVec
+          // Utlize symmetry of the normal distribution.
+          vector<double> prob_dist = norm_pdf(CTDVec, CTD_s, noise/2.355);
+            
+          // Weight the depth by probability
+          double prob_sum = 0.0;
+          for (unsigned int k=0; k < prob_dist.size(); ++k) {
+       	    prob_sum += prob_dist[k];
+          }
+          double weighted_depth = 0.0;
 
-      MVector LocalPosition(Xpos, Ypos, Zpos);
-      MVector LocalOrigin(0.0, 0.0, 0.0);
-      MVector GlobalPosition = m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(LocalPosition);
+          for (unsigned int k = 0; k < DepthVec.size(); ++k) {
+            weighted_depth += prob_dist[k] * DepthVec[k];
+          }
 
-      // Make sure XYZ resolution are correctly mapped to the global coord system.
-      MVector PositionResolution(Xsigma, Ysigma, Zsigma);
-      MVector GlobalResolution = ((m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(PositionResolution)) - (m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(LocalOrigin))).Abs();
-      
-      H->SetPosition(GlobalPosition); 
+          // Calculate the expectation value of the depth
+          double mean_depth = weighted_depth/prob_sum;
 
-      H->SetPositionResolution(GlobalResolution);
+          // Calculate the standard deviation of the depth
+          double depth_var = 0.0;
 
+          for (unsigned int k=0; k < DepthVec.size(); ++k) {
+            depth_var += prob_dist[k] * pow(DepthVec[k] - mean_depth, 2.0);
+          }
 
+          Zsigma =  sqrt(depth_var/prob_sum);
+          Zpos = mean_depth;
+          // Zpos = mean_depth - (m_Thicknesses[DetID]/2.0);
 
+          // Add the depth to the GUI histogram.
+          if (Event->HasStripPairingError()==false) {
+            if (HasExpos() == true) {
+              m_ExpoDepthCalibration->AddDepth(DetID, Zpos);
+            }
+          }
+          m_NoError+=1;
+        }
       }
+
+    if (g_Verbosity >= c_Info) cout << m_XmlTag << "Strip ID :" << LVStripID << " " << HVStripID << endl << "Hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
+
+    MVector LocalPosition(Xpos, Ypos, Zpos);
+    MVector LocalOrigin(0.0, 0.0, 0.0);
+    MVector GlobalPosition = m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(LocalPosition);
+
+    // Make sure XYZ resolution are correctly mapped to the global coord system.
+    MVector PositionResolution(Xsigma, Ysigma, Zsigma);
+    MVector GlobalResolution = ((m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(PositionResolution)) - (m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(LocalOrigin))).Abs();
+      
+    H->SetPosition(GlobalPosition); 
+
+    H->SetPositionResolution(GlobalResolution);
+
+
+
     }
   }
 

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -116,6 +116,7 @@ bool MModuleDepthCalibration::Initialize()
     return false;
   }
 
+  // Check for issues with geometry or file loading, and return appropriate errors
   if (m_DetectorIDs.size() == 0) {
     cout<<"No Strip3D detectors were found."<<endl;
     return false; 
@@ -176,24 +177,20 @@ void MModuleDepthCalibration::CreateExpos()
 bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event) 
 {
 
-  for (unsigned int i = 0; i < Event->GetNHits(); ++i ){
+  for (unsigned int i = 0; i < Event->GetNHits(); ++i ) {
     // H is a pointer to an instance of the MHit class. Each Hit has activated strips, represented by
     // instances of the MStripHit class.
     MHit* H = Event->GetHit(i);
+    int DetID = H->GetStripHit(0)->GetDetectorID();
 
     //Initalize position variables:
-    double Xpos = 0;
-    double Ypos = 0;
-    double Zpos = 0;
-    double Xsigma = 0;
-    double Ysigma = 0;
-    double Zsigma = 0;
+    double Xpos = 0.0, Ypos = 0.0, Zpos = 0.0;
+    double Xsigma = 0.0, Ysigma = 0.0, Zsigma = 0.0;
 
 
     // First, check for GR Hits
     if (H->GetGuardRingHitFlag() == true) {
-      // Skip the depth calibration for Hits that have a GR Strip Hit. Define position
-      // to be anywhere within the GR volume to pass through to revan
+      // For GR Hit, define position to be anywhere within the GR volume to pass through to revan
 
       int GRDetID = H->GetStripHit(0)->GetDetectorID();
       // Find unique/random position within the GR volume to assign as the hit position, as revan expects
@@ -206,19 +203,15 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       if (g_Verbosity >= c_Info) cout << m_XmlTag << "GR Hit :" << GRDetID << ", " << "set hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
 
       MVector GlobalPositionGR = m_GRDetectors[GRDetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(GRPosition);
-      MVector GRResolution(0.1, 0.1, 0.1);
-      
       H->SetPosition(GlobalPositionGR); 
-      H->SetPositionResolution(GRResolution);
 
       // Skip past the rest of the calibration and move to next Hit
       continue;
  
-    } 
-    // If not a GR Hit, perform the depth/position calibration...
+    } // If not a GR Hit, perform the depth/position calibration...
 
 
-    //TODO Rename Grade variables
+    //TODO: Rename Grade variables
     // The event "Grade" is the sub-pixel region determined via charge sharing
     int Grade = GetHitGrade(H);
     // GRADE=-1 is an error. Break from the loop and continue.
@@ -234,7 +227,10 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       }
     } else if (Grade > 4) { // GRADE=5 is some complicated geometry with multiple hits on a single strip. GRADE=6 means not all strips are adjacent.
       H->SetNoDepth();
-      Event->SetDepthCalibrationError("Multiple hits on single strip");
+      if (Event->HasDepthCalibrationError() == false) {
+        // Check if the DepthCalibrationError is already define for the Event before duplciating it
+        Event->SetDepthCalibrationError("Multiple hits on single strip");
+      }
       if (Grade==5) {
         ++m_Error5;
       } else if (Grade==6) {
@@ -257,7 +253,6 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
       MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
 
-      int DetID = LVSH->GetDetectorID();
       int LVStripID = LVSH->GetStripID();
       int HVStripID = HVSH->GetStripID();
       int PixelCode = 10000*DetID + 100*LVStripID + HVStripID;
@@ -298,7 +293,7 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       double HVTiming = HVSH->GetTiming();
 
       // If there aren't coefficients loaded, then report a depth calibration error.
-      if( Coeffs == nullptr ){
+      if (Coeffs == nullptr) {
         // Set the bad flag for depth
         H->SetNoDepth();
         Event->SetDepthCalibrationError("No calibration coefficients");
@@ -321,64 +316,73 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
         double CTD = (HVTiming - LVTiming);
         CTD_s = (CTD - Coeffs->at(1))/(Coeffs->at(0)); //apply inverse stretch and offset
 
-        double Xmin = * std::min_element(CTDVec.begin(), CTDVec.end());
-        double Xmax = * std::max_element(CTDVec.begin(), CTDVec.end());
+        double CTDmin = * std::min_element(CTDVec.begin(), CTDVec.end());
+        double CTDmax = * std::max_element(CTDVec.begin(), CTDVec.end());
 
         double noise = GetTimingNoiseFWHM(PixelCode, H->GetEnergy());
 
-        //if the CTD is out of range, check if we should reject the event.
-        if ((CTD_s < (Xmin - 2.0*noise)) || (CTD_s > (Xmax + 2.0*noise))) {
+        // If the CTD is not crazy out of range, stick it on the edge of the detector and report a QA flag:
+        if ((CTD_s < CTDmin) && (CTD_s > (CTDmin - 5.0*noise))) {
+          CTD_s = CTDmin;
+          Event->SetDepthCalibrationError("Forced to edge");
+        } else if ((CTD_s > CTDmax) && (CTD_s < (CTDmax + 5.0*noise))) {
+          CTD_s = CTDmax;
+          Event->SetDepthCalibrationError("Forced to edge");
+        } else if ((CTD_s < (CTDmin - 5.0*noise)) || (CTD_s > (CTDmax + 5.0*noise))) {
+          // If the CTD is >5 sigma away from the max/min CTD, then don't calibrate this hit and return an error
           H->SetNoDepth();
           Event->SetDepthCalibrationError("Out of Range");
           ++m_Error2;
         }
 
-        // If the CTD is in range, calculate the depth
+        // Now, calculate the depth
         // Rather than plugging CTD into a spline to get depth, use the depth-CTD relation to calculate a probability-weighted depth value.
         // This way we can avoid problems like non-monotonicity or assigning depth to events "outside" the detector 
         // Note that this requires that we don't massively overestimate the timing noise
-        else {
-          // Calculate the probability given timing noise of CTD_s corresponding to the values of depth in DepthVec
-          // Utlize symmetry of the normal distribution.
-          vector<double> prob_dist = norm_pdf(CTDVec, CTD_s, noise/2.355);
+        // Calculate the probability given timing noise of CTD_s corresponding to the values of depth in DepthVec
+        // Utlize symmetry of the normal distribution.
+        vector<double> prob_dist = norm_pdf(CTDVec, CTD_s, noise/2.355);
             
-          // Weight the depth by probability
-          double prob_sum = 0.0;
-          for (unsigned int k=0; k < prob_dist.size(); ++k) {
-       	    prob_sum += prob_dist[k];
-          }
-          double weighted_depth = 0.0;
-
-          for (unsigned int k = 0; k < DepthVec.size(); ++k) {
-            weighted_depth += prob_dist[k] * DepthVec[k];
-          }
-
-          // Calculate the expectation value of the depth
-          double mean_depth = weighted_depth/prob_sum;
-
-          // Calculate the standard deviation of the depth
-          double depth_var = 0.0;
-
-          for (unsigned int k=0; k < DepthVec.size(); ++k) {
-            depth_var += prob_dist[k] * pow(DepthVec[k] - mean_depth, 2.0);
-          }
-
-          Zsigma =  sqrt(depth_var/prob_sum);
-          Zpos = mean_depth;
-          // Zpos = mean_depth - (m_Thicknesses[DetID]/2.0);
-
-          // Add the depth to the GUI histogram.
-          if (Event->HasStripPairingError()==false) {
-            if (HasExpos() == true) {
-              m_ExpoDepthCalibration->AddDepth(DetID, Zpos);
-            }
-          }
-          m_NoError+=1;
+        // Weight the depth by probability
+        double prob_sum = 0.0;
+        for (unsigned int k=0; k < prob_dist.size(); ++k) {     
+          prob_sum += prob_dist[k];
         }
+        double weighted_depth = 0.0;
+
+        for (unsigned int k = 0; k < DepthVec.size(); ++k) {
+          weighted_depth += prob_dist[k] * DepthVec[k];
+        }
+
+        // Calculate the expectation value of the depth
+        double mean_depth = weighted_depth/prob_sum;
+
+        // Calculate the standard deviation of the depth
+        double depth_var = 0.0;
+
+        for (unsigned int k=0; k < DepthVec.size(); ++k) {
+          depth_var += prob_dist[k] * pow(DepthVec[k] - mean_depth, 2.0); 
+        }
+
+        Zsigma =  sqrt(depth_var/prob_sum);
+        Zpos = mean_depth;
+        // Zpos = mean_depth - (m_Thicknesses[DetID]/2.0);
+
+        // Add the depth to the GUI histogram.
+        if (Event->HasStripPairingError()==false) {
+          if (HasExpos() == true) {
+            m_ExpoDepthCalibration->AddDepth(DetID, Zpos);
+          }
+        }
+        
+        m_NoError+=1;
+      
       }
+    
+      if (g_Verbosity >= c_Info) cout << m_XmlTag << "Strip ID :" << LVStripID << " " << HVStripID << endl << "Hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
 
-    if (g_Verbosity >= c_Info) cout << m_XmlTag << "Strip ID :" << LVStripID << " " << HVStripID << endl << "Hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
-
+    }
+    
     MVector LocalPosition(Xpos, Ypos, Zpos);
     MVector LocalOrigin(0.0, 0.0, 0.0);
     MVector GlobalPosition = m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(LocalPosition);
@@ -390,14 +394,20 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
     H->SetPosition(GlobalPosition); 
     H->SetPositionResolution(GlobalResolution);
 
-
-
+    // For events that have NoDepth, these can be passed through revan with an XE flag and any position within the detector
+    if (H->GetNoDepth() == true) {
+      DetID = H->GetStripHit(0)->GetDetectorID();
+      MVector XEPosition = m_Geometry->GetDetector(m_Detectors[DetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
+      
+      MVector GlobalPositionXE = m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(XEPosition);
+      H->SetPosition(GlobalPositionXE);
     }
+
   }
-
+    
   Event->SetAnalysisProgress(MAssembly::c_DepthCorrection | MAssembly::c_PositionDetermiation);
-
   return true;
+
 }
 
 

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -1,6 +1,4 @@
-/*
- * MModuleDepthCalibration.cxx
- *
+ /*
  *
  * Copyright (C) 2008-2008 by Andreas Zoglauer, Alex Lowell, 
  * 				Sean Pike, Carolyn Kierans.
@@ -182,15 +180,47 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
     // H is a pointer to an instance of the MHit class. Each Hit has activated strips, represented by
     // instances of the MStripHit class.
     MHit* H = Event->GetHit(i);
-  
-    // Skip the depth calibration for Hits that have a GR Strip Hit
+
+    //Initalize position variables:
+    double Xpos = 0;
+    double Ypos = 0;
+    double Zpos = 0;
+    double Xsigma = 0;
+    double Ysigma = 0;
+    double Zsigma = 0;
+
+
+    // First, check for GR Hits
     if (H->GetGuardRingHitFlag() == true) {
+      // Skip the depth calibration for Hits that have a GR Strip Hit. Define position
+      // to be anywhere within the GR volume to pass through to revan
+
+      int GRDetID = H->GetStripHit(0)->GetDetectorID();
+      // Find unique/random position within the GR volume to assign as the hit position, as revan expects
+      MVector GRPosition = m_Geometry->GetDetector(m_GRDetectors[GRDetID]->GetName())->GetSensitiveVolume(0)->GetRandomPositionExclusivelyInside();
+
+      Xpos = GRPosition[0];
+      Ypos = GRPosition[1];
+      Zpos = GRPosition[2];      
+
+      if (g_Verbosity >= c_Info) cout << m_XmlTag << "GR Hit :" << GRDetID << ", " << "set hit position: "<< Xpos << " " << Ypos << " " << Zpos << endl;
+
+      MVector GlobalPositionGR = m_GRDetectors[GRDetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(GRPosition);
+      MVector GRResolution(0.1, 0.1, 0.1);
+      
+      H->SetPosition(GlobalPositionGR); 
+      H->SetPositionResolution(GRResolution);
+
+      // Skip past the rest of the calibration and move to next Hit
       continue;
-    }
+ 
+    } 
+    // If not a GR Hit, perform the depth/position calibration...
 
+
+    //TODO Rename Grade variables
+    // The event "Grade" is the sub-pixel region determined via charge sharing
     int Grade = GetHitGrade(H);
-
-    // Handle different grades differently    
     // GRADE=-1 is an error. Break from the loop and continue.
     if (Grade < 0){
       H->SetNoDepth();
@@ -212,7 +242,7 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       }
     } else { // If the Grade is 0-4, we can handle it.
 
-      // Calculate the position. If error is thrown, record and no depth.
+
       // Take a Hit and separate its activated X- and Y-strips into separate vectors.
       vector<MStripHit*> LVStrips;
       vector<MStripHit*> HVStrips;
@@ -227,20 +257,19 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
       MStripHit* LVSH = GetDominantStrip(LVStrips, LVEnergyFraction); 
       MStripHit* HVSH = GetDominantStrip(HVStrips, HVEnergyFraction); 
 
-      double CTD_s = 0.0;
-
-      //now try and get z position
       int DetID = LVSH->GetDetectorID();
       int LVStripID = LVSH->GetStripID();
       int HVStripID = HVSH->GetStripID();
       int PixelCode = 10000*DetID + 100*LVStripID + HVStripID;
 
-      //Define the X/Y positions based on the detector pitch and number of strip hits
+
+      // TODO: Calculate X and Y positions more rigorously using charge sharing.
+
+      // Define the X/Y positions based on the detector pitch and number of strip hits
       // LV strip 0 is in -ve X direction, HV strip 0 is in -ve Y direction.
       // Confusingly, the strips parallel to the Y axis determines the X position, and the "X strips" determine the Y position
-      double Xpos = m_YPitches[DetID]*((double)LVStripID - ((m_NYStrips[DetID]-1)/2.0));
-      double Ypos = m_XPitches[DetID]*((double)HVStripID - ((m_NXStrips[DetID]-1)/2.0));
-      double Zpos = 0.0;
+      Xpos = m_YPitches[DetID]*((double)LVStripID - ((m_NYStrips[DetID]-1)/2.0));
+      Ypos = m_XPitches[DetID]*((double)HVStripID - ((m_NXStrips[DetID]-1)/2.0));
 
       if (m_MaskMetrologyEnabled == true) {
         // If we are applying the mask metrology correction, first define two new readout elements to help determine the intersection of these two strips
@@ -253,15 +282,15 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
         Ypos = inter[1];
       }
 
+      Xsigma = m_YPitches[DetID]/sqrt(12.0);
+      Ysigma = m_XPitches[DetID]/sqrt(12.0);
+      Zsigma = m_Thicknesses[DetID]/sqrt(12.0);
 
-      // TODO: Calculate X and Y positions more rigorously using charge sharing.
 
-      double Xsigma = m_YPitches[DetID]/sqrt(12.0);
-      double Ysigma = m_XPitches[DetID]/sqrt(12.0);
-      double Zsigma = m_Thicknesses[DetID]/sqrt(12.0);
+      // Now try and get z position
+      double CTD_s = 0.0;
 
       vector<double>* Coeffs = GetPixelCoeffs(PixelCode);
-
       vector<double> CTDVec = GetCTD(DetID, Grade);
       vector<double> DepthVec = GetDepth(DetID);
 
@@ -290,8 +319,6 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
           
         // If there are coefficients and timing information is loaded, try calculating the CTD and depth
         double CTD = (HVTiming - LVTiming);
-
-        // Confirmed that this matches SP's python code.
         CTD_s = (CTD - Coeffs->at(1))/(Coeffs->at(0)); //apply inverse stretch and offset
 
         double Xmin = * std::min_element(CTDVec.begin(), CTDVec.end());
@@ -361,7 +388,6 @@ bool MModuleDepthCalibration::AnalyzeEvent(MReadOutAssembly* Event)
     MVector GlobalResolution = ((m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(PositionResolution)) - (m_Detectors[DetID]->GetSensitiveVolume(0)->GetPositionInWorldVolume(LocalOrigin))).Abs();
       
     H->SetPosition(GlobalPosition); 
-
     H->SetPositionResolution(GlobalResolution);
 
 
@@ -505,6 +531,9 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
 
   return true;
 }
+
+
+/////////////////////////////////////////////////////////////////////////////////
 
 
 bool MModuleDepthCalibration::LoadCoeffsFile(MString FileName)
@@ -1139,6 +1168,7 @@ void MModuleDepthCalibration::Finalize()
   m_XPitches.clear();
   m_YPitches.clear();
   m_Detectors.clear();
+  m_GRDetectors.clear();
   m_CTDMap.clear();
   m_DepthGrid.clear();
   m_SplineMap.clear();

--- a/src/MModuleStripPairingMultiRoundChiSquare.cxx
+++ b/src/MModuleStripPairingMultiRoundChiSquare.cxx
@@ -833,9 +833,6 @@ bool MModuleStripPairingMultiRoundChiSquare::AnalyzeEvent(MReadOutAssembly* Even
           Event->GetHit(h)->SetGuardRingHitFlag(true);
         }
       }
-      if (Event->GetHit(h)->GetGuardRingHitFlag() == true) {
-        Event->SetStripPairing_QualityFlag("GR Hit: Detector ID " + to_string(d) + " and Energy " + to_string(Event->GetHit(h)->GetEnergy()));
-      }
     }
       
   } // End Detector loop

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -632,13 +632,7 @@ void MReadOutAssembly::StreamEvta(ostream& S)
   }
 
   for (unsigned int h = 0; h < m_Hits.size(); ++h) {
-    // Don't print Guard Ring hits as normal strip hits as they don't have positions defined
-    // the corresponding energy is saved in the StripPairing QA message
-    if (m_Hits[h]->GetGuardRingHitFlag() == true) {
-	continue;
-    } else {
-      m_Hits[h]->StreamEvta(S);  
-    }
+    m_Hits[h]->StreamEvta(S);  
   }
 
   S<<"CC NStripHits "<<m_StripHits.size()<<endl;

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -632,7 +632,6 @@ void MReadOutAssembly::StreamEvta(ostream& S)
   }
 
   for (unsigned int h = 0; h < m_Hits.size(); ++h) {
-
     // Don't print Guard Ring hits as normal strip hits as they don't have positions defined
     // the corresponding energy is saved in the StripPairing QA message
     if (m_Hits[h]->GetGuardRingHitFlag() == true) {


### PR DESCRIPTION
This is a draft PR that addresses issues with the position determination in the Depth Calibration. I presented at the CDEE meeting in April showing examples of these "bad" events in the evta file:

<img width="1292" height="484" alt="Screenshot 2026-05-18 at 11 35 31 PM" src="https://github.com/user-attachments/assets/0cb35ad9-9401-4c32-9bb0-0e37800763bf" />


Andreas's comments for me at the meeting:
<img width="500" height="250" alt="Screenshot 2026-05-18 at 11 37 48 PM" src="https://github.com/user-attachments/assets/82ed2cc8-d598-4618-9c39-dfcf60359311" />
(Julian handed 5 already)

With this PR, I'm saving the GR hits in the evta file with the "GR" keyword and assigning them a random position in the guard ring volume. For events that fail the depth calibration, we're using the "XE" keyword and again just assign the hit a random position within the detector volume. These keywords are streamed to the evta file though the MHit::StreamEvta function, but I haven't yet done the same for the .dat files.

 Now, looking at the same events as above, we now get

> ID 999
> TI 1752086301.590697765
> HT 3;-1.45508;-0.403469;1.32867;365.288;0.0336036;0.0217617;0.0336036;0.961842
> CC NStripHits 3
> QA StripPairing (Best strip pairing leaves at least one grouping of strips unpaired (unpaired energy: 8.611698))
> PQ 1.17823 

Note this is a good event, and now we have the TI information from PR #124 , and better QA details from Strip pairing from PR #121 .

> SE
> ID 1000
> TI 1752086301.590716838
> XE 0.276994;0.3894;-2.94184;137.792
> XE 3.56288;0.753757;-0.862971;12.2433
> XE -2.24436;-0.563929;-1.24495;55.3574
> CC NStripHits 5
> BD DepthCalibrationError (Multiple hits on single strip)
> QA StripPairing (Event contains multiple hits on a single strip)
> PQ 0.386063

This event consisted of multiple hits on a single strip. It's only a QA flag in strip pairing since Julian is able to figure out the most likely ordering, but the depth calibration still fails to find the right position. Here these three hits are given the XE flag to track the extra energy deposit.

> SE
> ID 1092
> TI 1752086301.653759717
> HT 3;0.640234;-0.260901;-1.9307;240.615;0.0336036;0.0231942;0.0336036;0.93588
> XE 3.27438;-0.281045;1.91529;13.421
> GR -1.67307;0.345954;-3.75344;44.4647
> CC NStripHits 6
> BD DepthCalibrationError (Out of Range)
> BD GR Veto
> PQ 3.65235

Previously, this event didn't get any position calibration since there's a GR hit and it got passed over. Now, we have one hit properly calibrated, another hit which was >5 sigma out of the expected CTD range, therefore it's flagged as just an XE event, and there's a GR hit as well. 

I've also cleaned up the MModuleDepthCalibration code quite a bit, and removed white spaces from MHit.

And, against my better judgement, I also included the QA flag button/selection in MEventSaver in this same PR. If you want, I can remove that here and make it a stand-alone PR for that commit.

I'll save the redefinition of the CC NStripHits keyword and the BD VETO keyword for another PR since this one has already become length. 