### PR TITLE
Adding the option to save/or not QA-flagged events

### DIFF
--- a/include/MGUIOptionsEventSaver.h
+++ b/include/MGUIOptionsEventSaver.h
@@ -81,6 +81,9 @@ class MGUIOptionsEventSaver : public MGUIOptions
   //! Checkbutton to save or reject bad events
   TGCheckButton* m_SaveBadEvents;
 
+  //! Checkbutton to save or reject quality flag events
+  TGCheckButton* m_SavePoorQualityEvents;
+
   //! Checkbutton to save veto events
   TGCheckButton* m_SaveVetoEvents;
 

--- a/include/MModuleEventSaver.h
+++ b/include/MModuleEventSaver.h
@@ -63,6 +63,11 @@ class MModuleEventSaver : public MModule
   //! Set whether the Bad events should be saved
   void SetSaveBadEvents(bool SaveBadEvents) { m_SaveBadEvents = SaveBadEvents; }
 
+  //! Return true if the Poor Quality events should be saved
+  bool GetSavePoorQualityEvents() const { return m_SavePoorQualityEvents; }
+  //! Set whether the Poor Quality events should be saved
+  void SetSavePoorQualityEvents(bool SavePoorQualityEvents) { m_SavePoorQualityEvents = SavePoorQualityEvents; }
+
   //! Return true if the Veto events should be saved
   bool GetSaveVetoEvents() const { return m_SaveVetoEvents; }
   //! Set whether the Veto events should be saved
@@ -192,6 +197,9 @@ class MModuleEventSaver : public MModule
   
   //! Save bad events
   bool m_SaveBadEvents;
+
+  //! Save poor quality events
+  bool m_SavePoorQualityEvents;
 
   //! Save Veto events
   bool m_SaveVetoEvents;

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -260,6 +260,8 @@ class MReadOutAssembly : public MReadOutSequence
   //! Return true if any error flag is set or the event has been filtered out
   //! Veto and quality flags do not affect this result
   bool IsBad() const;
+  //! Returns true if any of the Quality flags have been set
+  bool IsPoorQuality() const;
 
   //! Set a specific analysis progress
   void SetAnalysisProgress(uint64_t Progress) { m_AnalysisProgress |= Progress; }

--- a/include/MReadOutAssembly.h
+++ b/include/MReadOutAssembly.h
@@ -249,6 +249,8 @@ class MReadOutAssembly : public MReadOutSequence
   bool IsGood() const;
   //! Returns true if any of the "bad" or "Error" flags has been set
   bool IsBad() const;
+  //! Returns true if any of the Quality flags have been set
+  bool IsPoorQuality() const;
 
   //! Set a specific analysis progress
   void SetAnalysisProgress(uint64_t Progress) { m_AnalysisProgress |= Progress; }

--- a/src/MGUIOptionsEventSaver.cxx
+++ b/src/MGUIOptionsEventSaver.cxx
@@ -110,7 +110,7 @@ void MGUIOptionsEventSaver::Create()
 
   m_SavePoorQualityEvents = new TGCheckButton(GeneralFrame, "Save events with quality flag (QA)", 1);
   m_SavePoorQualityEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSavePoorQualityEvents());
-  GeneralFrame->AddFrame(m_SavePoorQualityEvents, FirstLabelLayout);
+  GeneralFrame->AddFrame(m_SavePoorQualityEvents, TightButtonLayout);
 
   m_SaveVetoEvents = new TGCheckButton(GeneralFrame, "Save guard ring and shield veto events (Veto)", 1);
   m_SaveVetoEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSaveVetoEvents());

--- a/src/MGUIOptionsEventSaver.cxx
+++ b/src/MGUIOptionsEventSaver.cxx
@@ -108,6 +108,10 @@ void MGUIOptionsEventSaver::Create()
   m_SaveBadEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSaveBadEvents());
   GeneralFrame->AddFrame(m_SaveBadEvents, FirstLabelLayout);
 
+  m_SavePoorQualityEvents = new TGCheckButton(GeneralFrame, "Save events with quality flag (QA)", 1);
+  m_SavePoorQualityEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSavePoorQualityEvents());
+  GeneralFrame->AddFrame(m_SavePoorQualityEvents, FirstLabelLayout);
+
   m_SaveVetoEvents = new TGCheckButton(GeneralFrame, "Save guard ring and shield veto events (Veto)", 1);
   m_SaveVetoEvents->SetOn(dynamic_cast<MModuleEventSaver*>(m_Module)->GetSaveVetoEvents());
   GeneralFrame->AddFrame(m_SaveVetoEvents, TightButtonLayout);
@@ -229,6 +233,7 @@ bool MGUIOptionsEventSaver::OnApply()
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetFileName(m_FileSelector->GetFileName());
 
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetSaveBadEvents(m_SaveBadEvents->IsOn());
+  dynamic_cast<MModuleEventSaver*>(m_Module)->SetSavePoorQualityEvents(m_SavePoorQualityEvents->IsOn());
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetSaveVetoEvents(m_SaveVetoEvents->IsOn());
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetAddTimeTag(m_AddTimeTag->IsOn());
   dynamic_cast<MModuleEventSaver*>(m_Module)->SetSplitFile(m_SplitFile->IsOn());

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -516,6 +516,8 @@ bool MModuleDepthCalibration::LoadCoeffsFile(MString FileName)
       std::vector<MString> Tokens = Line.Tokenize(",");
       if (Tokens.size() == 5) {
         int PixelCode = Tokens[0].ToInt();
+        double Stretch = Tokens[1].ToDouble();
+        double Offset = Tokens[2].ToDouble();
         double CTD_FWHM = Tokens[3].ToDouble() * 2.355;
         double Chi2 = Tokens[4].ToDouble();
         // Previous iteration of depth calibration read in "Scale" instead of ctd resolution.

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -516,8 +516,6 @@ bool MModuleDepthCalibration::LoadCoeffsFile(MString FileName)
       std::vector<MString> Tokens = Line.Tokenize(",");
       if (Tokens.size() == 5) {
         int PixelCode = Tokens[0].ToInt();
-        double Stretch = Tokens[1].ToDouble();
-        double Offset = Tokens[2].ToDouble();
         double CTD_FWHM = Tokens[3].ToDouble() * 2.355;
         double Chi2 = Tokens[4].ToDouble();
         // Previous iteration of depth calibration read in "Scale" instead of ctd resolution.

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -503,8 +503,6 @@ bool MModuleDepthCalibration::LoadCoeffsFile(MString FileName)
       std::vector<MString> Tokens = Line.Tokenize(",");
       if (Tokens.size() == 5) {
         int PixelCode = Tokens[0].ToInt();
-        double Stretch = Tokens[1].ToDouble();
-        double Offset = Tokens[2].ToDouble();
         double CTD_FWHM = Tokens[3].ToDouble() * 2.355;
         double Chi2 = Tokens[4].ToDouble();
         // Previous iteration of depth calibration read in "Scale" instead of ctd resolution.

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -503,6 +503,8 @@ bool MModuleDepthCalibration::LoadCoeffsFile(MString FileName)
       std::vector<MString> Tokens = Line.Tokenize(",");
       if (Tokens.size() == 5) {
         int PixelCode = Tokens[0].ToInt();
+        double Stretch = Tokens[1].ToDouble();
+        double Offset = Tokens[2].ToDouble();
         double CTD_FWHM = Tokens[3].ToDouble() * 2.355;
         double Chi2 = Tokens[4].ToDouble();
         // Previous iteration of depth calibration read in "Scale" instead of ctd resolution.

--- a/src/MModuleEventSaver.cxx
+++ b/src/MModuleEventSaver.cxx
@@ -75,6 +75,7 @@ MModuleEventSaver::MModuleEventSaver() : MModule()
   m_InternalFileName = "";
   m_Zip = false;
   m_SaveBadEvents = true;
+  m_SavePoorQualityEvents = true;
   m_SaveVetoEvents = true;
   m_AddTimeTag = false;
     
@@ -345,6 +346,10 @@ bool MModuleEventSaver::AnalyzeEvent(MReadOutAssembly* Event)
     if (Event->IsBad() == true) return true;
   }
 
+  if (m_SavePoorQualityEvents == false) {
+    if (Event->IsPoorQuality() == true) return true;
+  }
+
   if (m_SaveVetoEvents == false) {
     if (Event->IsVeto() == true) return true;
   }
@@ -415,6 +420,10 @@ bool MModuleEventSaver::ReadXmlConfiguration(MXmlNode* Node)
   if (SaveBadEventsNode != 0) {
     m_SaveBadEvents = SaveBadEventsNode->GetValueAsBoolean();
   }
+  MXmlNode* SavePoorQualityEventsNode = Node->GetNode("SavePoorQualityEvents");
+  if (SavePoorQualityEventsNode != 0) {
+    m_SavePoorQualityEvents = SavePoorQualityEventsNode->GetValueAsBoolean();
+  }
   MXmlNode* SaveVetoEventsNode = Node->GetNode("SaveVetoEvents");
   if (SaveVetoEventsNode != 0) {
     m_SaveVetoEvents = SaveVetoEventsNode->GetValueAsBoolean();
@@ -480,6 +489,7 @@ MXmlNode* MModuleEventSaver::CreateXmlConfiguration()
   new MXmlNode(Node, "FileName", m_FileName);
   new MXmlNode(Node, "Mode", m_Mode);
   new MXmlNode(Node, "SaveBadEvents", m_SaveBadEvents);
+  new MXmlNode(Node, "SavePoorQualityEvents", m_SavePoorQualityEvents);
   new MXmlNode(Node, "SaveVetoEvents", m_SaveVetoEvents);
   new MXmlNode(Node, "AddTimeTag", m_AddTimeTag);
   new MXmlNode(Node, "SplitFile", m_SplitFile);

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -632,7 +632,14 @@ void MReadOutAssembly::StreamEvta(ostream& S)
   }
 
   for (unsigned int h = 0; h < m_Hits.size(); ++h) {
-    m_Hits[h]->StreamEvta(S);
+
+    // Don't print Guard Ring hits as normal strip hits as they don't have positions defined
+    // the corresponding energy is saved in the StripPairing QA message
+    if (m_Hits[h]->GetGuardRingHitFlag() == true) {
+	continue;
+    } else {
+      m_Hits[h]->StreamEvta(S);  
+    }
   }
 
   S<<"CC NStripHits "<<m_StripHits.size()<<endl;
@@ -818,6 +825,23 @@ bool MReadOutAssembly::IsBad() const
   if (m_StripPairingError == true) return true;
   if (m_DepthCalibrationError == true) return true;
   if (m_EventReconstructionError == true) return true;
+
+  if (m_FilteredOut == true) return true;
+
+  return false;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MReadOutAssembly::IsPoorQuality() const
+{
+  //! Returns true if none of the Quality flag has been set
+
+  // Let's not filter out the strips below threshold events since these aren't less quality
+  //if (m_StripHitBelowThreshold_QualityFlag == true) return true;
+  if (m_StripPairing_QualityFlag == true) return true;
 
   if (m_FilteredOut == true) return true;
 

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -618,7 +618,13 @@ void MReadOutAssembly::StreamEvta(ostream& S)
   }
   
   for (unsigned int h = 0; h < m_Hits.size(); ++h) {
-    m_Hits[h]->StreamEvta(S);  
+    // Don't print Guard Ring hits as normal strip hits as they don't have positions defined
+    // the corresponding energy is saved in the StripPairing QA message
+    if (m_Hits[h]->GetGuardRingHitFlag() == true) {
+	continue;
+    } else {
+      m_Hits[h]->StreamEvta(S);  
+    }
   }
   
   S<<"CC NStripHits "<<m_StripHits.size()<<endl;
@@ -804,7 +810,24 @@ bool MReadOutAssembly::IsBad() const
 
   return false;
 }
- 
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+bool MReadOutAssembly::IsPoorQuality() const
+{
+  //! Returns true if none of the Quality flag has been set
+
+  // Let's not filter out the strips below threshold events since these aren't less quality
+  //if (m_StripHitBelowThreshold_QualityFlag == true) return true;
+  if (m_StripPairing_QualityFlag == true) return true;
+
+  if (m_FilteredOut == true) return true;
+
+  return false;
+}
+
 
 //////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
I cherry-picked this from PR #148 since it's much simpler to have this as it's own PR. 

I checked this with gse_20250709T113820.hdf for detector HP52358-3 and get 9.3 degrees when we allow QA-flagged events through, and 8.2 degrees when we don't. There's also a loss of ~50% of the events when remove QA-flagged hits. It seems like the majority of these hits that are filtered out with the QA flag are events when the best strip pairing leaves at least one grouping of strips unpaired.

@julianmgerber should compare with his ARM numbers to see if this selection recovers the better ARMs he was seeing before we let these lesser quality events through.