### PR TITLE
[DEE] Remove simulated hits with non-positive energies in the DEE intake

### DIFF
--- a/src/MSubModuleDEEIntake.cxx
+++ b/src/MSubModuleDEEIntake.cxx
@@ -99,6 +99,12 @@ bool MSubModuleDEEIntake::AnalyzeEvent(MReadOutAssembly* Event)
 
   for (unsigned int h = 0; h < Event->GetSimulatedEvent()->GetNHTs(); ++h) {
     MSimHT* HT = Event->GetSimulatedEvent()->GetHTAt(h);
+    if (HT->GetEnergy() <= 0) {
+      if (g_Verbosity >= c_Warning) {
+        cout << m_Name << ": Skipping hit with simulated energy of 0." << endl;
+      }
+      continue;
+    }
 
     MDVolumeSequence* VS = HT->GetVolumeSequence();
     MDDetector* Detector = VS->GetDetector();

--- a/src/MSubModuleDEEIntake.cxx
+++ b/src/MSubModuleDEEIntake.cxx
@@ -101,7 +101,7 @@ bool MSubModuleDEEIntake::AnalyzeEvent(MReadOutAssembly* Event)
     MSimHT* HT = Event->GetSimulatedEvent()->GetHTAt(h);
     if (HT->GetEnergy() <= 0) {
       if (g_Verbosity >= c_Warning) {
-        cout << m_Name << ": Skipping hit with simulated energy of 0." << endl;
+        cout << m_Name << ": Skipping simulated hit with non-positive energy." << endl;
       }
       continue;
     }


### PR DESCRIPTION
I ran some cosima simulations with `DiscretizeHits` set to false, resulting in some hits having a simulated energy of 0 (at least within the rounding precision):
<img width="1072" height="368" alt="Screenshot from 2026-05-20 12-30-28" src="https://github.com/user-attachments/assets/dad0ef37-4719-4312-84b9-5bff7e1928f5" />

For the germanium charge transport, this results in a division of 0 by 0 (simulated energy divided by charge cloud size).

Here, I add a guard in the `MSubModuleDEEIntake` to just skip past events with 0 energies, as they shouldn't have an influence on the simulated detector response anyhow.