### PR TITLE
Set default value of `m_Coeffs_Energy` in depth calibration to 59.5keV

### DIFF
--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -84,7 +84,7 @@ MModuleDepthCalibration::MModuleDepthCalibration() : MModule()
   m_AllowMultiThreading = true;
   m_AllowMultipleInstances = false;
 
-  m_Coeffs_Energy = 0;
+  m_Coeffs_Energy = 59.5;
 
   m_NoError = 0;
   m_Error1 = 0;
@@ -465,7 +465,7 @@ double MModuleDepthCalibration::GetTimingNoiseFWHM(int PixelCode, double Energy)
   // Should follow 1/E relation
   // TODO: Determine real energy dependence and implement it here.
   double noiseFWHM = 0.0;
-  if (m_Coeffs_Energy != 0) {
+  if (m_CoeffsFileIsLoaded == true) {
     noiseFWHM = m_Coeffs[PixelCode][2] * m_Coeffs_Energy/Energy;
     if (noiseFWHM < 3.0*2.355) {
       noiseFWHM = 3.0*2.355;


### PR DESCRIPTION
In `MModuleDepthCalibration`, the reference energy at which the depth calibration was performed is stored as `m_Coeffs_Energy` and expected to be read from the header of the depth coefficients file.

https://github.com/cositools/nuclearizer/blob/d153b0fea708f993e514e1b8a204128b992b16ec/src/MModuleDepthCalibration.cxx#L485-L486
https://github.com/cositools/nuclearizer/blob/d153b0fea708f993e514e1b8a204128b992b16ec/src/MModuleDepthCalibration.cxx#L497-L501

However, most (all?) of the depth calibration coefficient files do not have that header, resulting in `m_Coeffs_Energy` to stay zero and resulting a scaled `noiseFWHM` of 0:
https://github.com/cositools/nuclearizer/blob/d153b0fea708f993e514e1b8a204128b992b16ec/src/MModuleDepthCalibration.cxx#L462-L477

While the zero `noiseFWHM` is handled in the forward pipeline by just setting a "standard" FWHM of 3keV, this will result in wrong results in the DEE inverse depth cal in PR #134. And I mean: we have the information on the FWHM in the files.

As we're currently ALWAYS generating the depth calibration coefficients at 59.5keV, I propose to update that default values, such that people can still use the old files that might not have the headers in them.
