### PR TITLE
[DEE] Allow multithreading and multiple instances in the DEE

### DIFF
--- a/include/MModuleDEESMEX.h
+++ b/include/MModuleDEESMEX.h
@@ -55,7 +55,9 @@ class MModuleDEESMEX : public MModule
   //! Create a new object of this class
   virtual MModuleDEESMEX* Clone()
   {
-    return new MModuleDEESMEX();
+    MModuleDEESMEX* M = new MModuleDEESMEX();
+    M->SetGeometry(m_Geometry);
+    return M;
   }
 
   //! Set the geometry

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -50,6 +50,9 @@ MModuleDEESMEX::MModuleDEESMEX() : MModule()
 {
   // Construct an instance of MModuleDEESMEX
 
+  // Set geometry to nullptr to explicitly check that it was set in Initialize
+  m_Geometry = nullptr;
+
   // Set the module name --- has to be unique
   m_Name = "Detector effects engine for COSI SMEX";
   
@@ -96,6 +99,14 @@ MModuleDEESMEX::~MModuleDEESMEX()
 
 bool MModuleDEESMEX::Initialize()
 {
+
+  if (m_Geometry == nullptr) {
+    if (g_Verbosity >= c_Error) {
+      cout << "ERROR in MModuleDEESMEX::Initialize: m_Geometry is a nullptr" << endl;
+    }
+    return false;
+  }
+
   // Set the geometry to the SubModules using it
   m_ChargeTransport.SetGeometry(m_Geometry);
   m_DepthReadout.SetGeometry(m_Geometry);

--- a/src/MModuleDEESMEX.cxx
+++ b/src/MModuleDEESMEX.cxx
@@ -63,8 +63,8 @@ MModuleDEESMEX::MModuleDEESMEX() : MModule()
   m_IsStartModule = false;
   
   // Allow the use of multiple threads and instances
-  m_AllowMultiThreading = false;
-  m_AllowMultipleInstances = false;
+  m_AllowMultiThreading = true;
+  m_AllowMultipleInstances = true;
 
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EventLoaderSimulation);


### PR DESCRIPTION
So far, setting `m_AllowMultipleInstances` to `true` in `MModuleDEESMEX`,  would cause a segmentation fault.
This was caused by `m_Geometry` not being set and containing uninitialized garbage.

The root cause for this is how megalib handles creating multiple instances (find the code [here](https://github.com/zoglauer/megalib/blob/31298310d572e23a348c731eda0b8637abebde7a/src/fretalon/framework/src/MSupervisor.cxx#L982-L999)):

- It creates a new instance by cloning the module via `Clone()`
- It then checks if the module can be initialized using `Initialize()`

In the case of `MModuleDEESMEX`, when cloning the module, we don't pass `m_Geometry` down to the clone, and then get weird behavior when calling on uninitialized garbage. 

To avoid this, in this PR:
- we set `m_Geometry` in the constructor of `MModuleDEESMEX` to `nullptr`
- check in `Initialize` if it is `nullptr`, or whether it was actually set
- pass the geometry to clones of `MModuleDEESMEX` in `Clone()`
- enable running the DEE with multiple instances

It seems to work (and be significantly faster than before) on my laptop, but feedback on this is very much appreciated!