### PR TITLE
Stream crystal hits to "UC" instead of "UH" in ROA output

### DIFF
--- a/src/MCrystalHit.cxx
+++ b/src/MCrystalHit.cxx
@@ -160,7 +160,7 @@ void MCrystalHit::StreamRoa(ostream& S, bool WithADC, bool WithEnergy, bool With
 {
   //! Stream the content in MEGAlib's evta format 
 
-  S<<"UH "
+  S<<"UC "
    <<m_ReadOutElement->GetDetectorID()<<" ";
   if (WithADC == true) {
     S<<m_ADCUnits<<" ";


### PR DESCRIPTION
Currently, when running simulations with the EM massmodels, the current implementation of the DEE results in `MStripHits` and `MCrystalHits` both being saved to `UH` to the ROA file. This messes up parsing these ROA files, because the rows for crystal hits have fewer entries:
<img width="295" height="158" alt="Screenshot from 2026-05-27 09-15-01" src="https://github.com/user-attachments/assets/2786bf2b-2a38-41f3-8e36-0709c946e373" />

I was wondering whether `UH` here is actually correct, or whether it should be exclusively reserved for `MStripHits`.
It looks like `MShieldCrystalHits` for example are saved to `UC` instead of `UH`:
https://github.com/cositools/nuclearizer/blob/79ac09121379fdbfab2389c1effd2ebc4232ea1a/src/MShieldCrystalHit.cxx#L159-L163

whereas `MCrystalHits` are saved to `UH`:
https://github.com/cositools/nuclearizer/blob/79ac09121379fdbfab2389c1effd2ebc4232ea1a/src/MCrystalHit.cxx#L159-L163

Writing `MCrystalHits` also to `UC` instead of `UH` would prevent my current scripts from failing in case ACS hits are present in the simulations :innocent: 