### PR TITLE
CHG: MStripHit cleanup

### DIFF
--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -83,7 +83,7 @@ class MStripHit
   //! TODO: Switch to unsigned int: Issue #176
   //! Set the measured ADC units of the strip
   void SetADCUnits(double ADCUnits) { m_ADCUnits = ADCUnits; }
-  //! Return the measured the ADC units of the strip
+  //! Return the measured ADC units of the strip
   double GetADCUnits() const { return m_ADCUnits; }
 
   //! Set the calibrated energy (= calibrated ADC's) in keV

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -107,7 +107,7 @@ class MStripHit
 
   //! Set the timing (= calibrated TAC) in nanoseconds
   void SetTiming(double Timing) { m_Timing = Timing; }
-  //! Return the timing (= calibrated TAC)in nanoseconds
+  //! Return the timing (= calibrated TAC) in nanoseconds
   double GetTiming() const { return m_Timing; }
 
   //! Set the timing resolution
@@ -139,7 +139,7 @@ class MStripHit
   //! Return whether the strip has triggered (ADC values above slow threshold)
   bool HasTriggered() const { return m_HasTriggered; }
 
-  //! REVIEW: Should this be just HasTiming() - timing is calibrated TAC?
+  //! TODO: Rename to HasTiming()
   //! Set the calibrated-timing flag
   void HasCalibratedTiming(bool CalibratedTiming) { m_HasCalibratedTiming = CalibratedTiming; }
   //! Return whether the strip timing has been calibrated

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -40,15 +40,18 @@ class MStripHit
  public:
   //! Default constructor
   MStripHit();
+  //! Copy constructor is disabled because this class owns a m_ReadOutElement pointer
+  MStripHit(const MStripHit&) = delete;
+  //! Assignment is disabled because this class owns a m_ReadOutElement pointer
+  MStripHit& operator=(const MStripHit&) = delete;
   //! Default destructor
   virtual ~MStripHit();
-  //! Copy constructor is disabled because this class owns m_ReadOutElement
-  MStripHit(const MStripHit&) = delete;
-  //! Assignment is disabled because this class owns m_ReadOutElement
-  MStripHit& operator=(const MStripHit&) = delete;
 
   //! Reset all data
   void Clear();
+
+
+  // The read-out element
 
   //! Return the read-out element
   //! Ownership stays with this object
@@ -64,46 +67,52 @@ class MStripHit
   //! Return the strip ID
   unsigned int GetStripID() const { return m_ReadOutElement->GetStripID(); }
 
-  //! DEPRECATED: Set whether the strip is on the low voltage side using IsLowVoltageStrip instead
+  //! DEPRECATED: Set whether the strip is on the low-voltage side using IsLowVoltageStrip instead
   void IsXStrip(bool LowVoltageSide) { m_ReadOutElement->IsLowVoltageStrip(LowVoltageSide); }
-  //! DEPRECATED: Return whether the strip is on the low voltage side using IsLowVoltageStrip instead
+  //! DEPRECATED: Return whether the strip is on the low-voltage side using IsLowVoltageStrip instead
   bool IsXStrip() const { return m_ReadOutElement->IsLowVoltageStrip(); }
 
-  //! Set whether the strip is on the low voltage side
+  //! Set whether the strip is on the low-voltage side
   void IsLowVoltageStrip(bool LowVoltageSide) { m_ReadOutElement->IsLowVoltageStrip(LowVoltageSide); }
-  //! Return whether the strip is on the low voltage side
+  //! Return whether the strip is on the low-voltage side
   bool IsLowVoltageStrip() const { return m_ReadOutElement->IsLowVoltageStrip(); }
 
-  //! Set whether the strip has triggered
-  void HasTriggered(bool HasTriggered) { m_HasTriggered = HasTriggered; }
-  //! Return whether the strip has triggered
-  bool HasTriggered() const { return m_HasTriggered; }
 
+  // Energy section:
+
+  //! REVIEW: Why is this not unsigned int - that is what we measure?
+  //! Set the measured ADC units of the strip
+  void SetADCUnits(double ADCUnits) { m_ADCUnits = ADCUnits; }
+  //! Return measured the ADC units of the strip
+  double GetADCUnits() const { return m_ADCUnits; }
+
+  //! REVIEW: What are we using those for - they are not used anywhere - I would always correct the energy not the raw data
+  //!           We might use it for temperature correction - or not
   //! Set the uncorrected ADC units of the strip (before common-mode correction)
   void SetUncorrectedADCUnits(double UncorrectedADCUnits) { m_UncorrectedADCUnits = UncorrectedADCUnits; }
   //! Return the uncorrected ADC units of the strip (before common-mode correction)
   double GetUncorrectedADCUnits() const { return m_UncorrectedADCUnits; }
-
-  //! Set the ADC units of the strip
-  void SetADCUnits(double ADCUnits) { m_ADCUnits = ADCUnits; }
-  //! Return the ADC units of the strip
-  double GetADCUnits() const { return m_ADCUnits; }
 
   //! Set the calibrated energy
   void SetEnergy(double Energy) { m_Energy = Energy; }
   //! Return the calibrated energy
   double GetEnergy() const { return m_Energy; }
 
-  //! Set the energy resolution (sigma)
+  //! Set the energy resolution (1 sigma)
   void SetEnergyResolution(double EnergyResolution) { m_EnergyResolution = EnergyResolution; }
-  //! Return the energy resolution
+  //! Return the energy resolution (1 sigma)
   double GetEnergyResolution() const { return m_EnergyResolution; }
 
-  //! Set the TAC
+
+  // Timing:
+
+  //! REVIEW: Why is TAC double, when we measure unsigned ints?
+  //! Set the measured TAC value of the strip (arrival timing)
   void SetTAC(double TAC) { m_TAC = TAC; }
-  //! Return the TAC
+  //! Return the measured TAC value of the strip (arrival timing)
   double GetTAC() const { return m_TAC; }
 
+  //! REVIEW: This is not used - timing should have a resolution
   //! Set the TAC resolution
   void SetTACResolution(double TACResolution) { m_TACResolution = TACResolution; }
   //! Return the TAC resolution
@@ -119,23 +128,26 @@ class MStripHit
   //! Return the timing resolution
   double GetTimingResolution() const { return m_TimingResolution; }
 
+
+  // Temperature:
+
+  //! REVIEW: Hold-over from balloon and balloon temperature calibration
   //! Set the temperature of the relevant preamp (in degrees C)
   void SetPreampTemp(double PreampTemp) { m_PreampTemp = PreampTemp; }
   //! Return the temperature of the relevant preamp (in degrees C)
   double GetPreampTemp() const { return m_PreampTemp; }
 
-  //! Add origins from the simulation and remove duplicates
-  void AddOrigins(const vector<int>& Origins);
-  //! Return the origins from the simulation
-  vector<int> GetOrigins() const { return m_Origins; }
+
+  // Flags:
 
   //! Set the guard ring flag
   void IsGuardRing(bool GuardRing) { m_IsGuardRing = GuardRing; }
-  //! Return whether the strip is a guard ring
+  //! Return whether the strip is a guard-ring hit
   bool IsGuardRing() const { return m_IsGuardRing; }
+
   //! Set the nearest-neighbor flag
   void IsNearestNeighbor(bool NearestNeighbor) { m_IsNearestNeighbor = NearestNeighbor; }
-  //! Return whether the strip is a nearest neighbor
+  //! Return whether the strip is a nearest-neighbor hit
   bool IsNearestNeighbor() const { return m_IsNearestNeighbor; }
 
   //! Set the fast-timing flag
@@ -143,22 +155,40 @@ class MStripHit
   //! Return whether the strip timing is fast
   bool HasFastTiming() const { return m_HasFastTiming; }
 
+  //! REVIEW: What kind of trigger is this: above slow or above fast?
+  //! Set whether the strip has triggered
+  void HasTriggered(bool HasTriggered) { m_HasTriggered = HasTriggered; }
+  //! Return whether the strip has triggered
+  bool HasTriggered() const { return m_HasTriggered; }
+
+  //! REVIEW: Should this be just HasTiming() - timing is calibrated TAC?
   //! Set the calibrated-timing flag
   void HasCalibratedTiming(bool CalibratedTiming) { m_HasCalibratedTiming = CalibratedTiming; }
   //! Return whether the strip timing has been calibrated
   bool HasCalibratedTiming() const { return m_HasCalibratedTiming; }
+
+
+  // Parsing:
 
   //! Return the bitwise strip-hit flags
   unsigned int MakeFlags();
   //! Update the strip-hit flags from a bit mask
   void ParseFlags(unsigned int Flags);
 
-  //! Parse a strip hit from a line
+  //! Parse a strip hit from a line in DAT format
   bool Parse(const MString& Line, int Version = 1);
-  //! Write the strip hit to a file stream
+  //! Stream the strip hit in Nuclearizer's DAT format
   bool StreamDat(ostream& S, int Version = 1);
   //! Stream the strip hit in MEGAlib's ROA format
   void StreamRoa(ostream& S, bool WithADC = true, bool WithTAC = true, bool WithEnergy = false, bool WithTiming = false, bool WithTemperature = false, bool WithFlags = false, bool WithOrigins = false);
+
+
+  // Simulation:
+
+  //! Add origins from the simulation and remove duplicates
+  void AddOrigins(const vector<int>& Origins);
+  //! Return the origins from the simulation
+  vector<int> GetOrigins() const { return m_Origins; }
 
 
   // protected methods:
@@ -177,8 +207,7 @@ class MStripHit
  private:
   //! Read-out element
   MReadOutElementDoubleStrip* m_ReadOutElement;
-  //! True if the strip has triggered
-  bool m_HasTriggered;
+
   //! ADC units before all corrections
   double m_UncorrectedADCUnits;
   //! ADC units after any correction
@@ -187,7 +216,8 @@ class MStripHit
   double m_Energy;
   //! Energy resolution
   double m_EnergyResolution;
-  //! TAC timing
+
+  //! The measured TAC timing values
   double m_TAC;
   //! TAC timing resolution
   double m_TACResolution;
@@ -195,14 +225,16 @@ class MStripHit
   double m_Timing;
   //! Timing resolution in nanoseconds
   double m_TimingResolution;
+
   //! Temperature of the preamp
   double m_PreampTemp;
 
-  //! True if the hit is a guard ring
+  //! True if the hit is a guard ring hit
   bool m_IsGuardRing;
-  //! True if the hit is a nearest neighbor
+  //! True if the hit is a nearest neighbor hit
   bool m_IsNearestNeighbor;
-
+  //! True if the strip has triggered
+  bool m_HasTriggered;
   //! True if the hit has fast timing
   bool m_HasFastTiming;
   //! True if the hit has calibrated timing
@@ -210,6 +242,7 @@ class MStripHit
 
   //! Origin interaction IDs from the simulation
   vector<int> m_Origins;
+
 
 #ifdef ___CLING___
  public:

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -86,9 +86,9 @@ class MStripHit
   //! Return measured the ADC units of the strip
   double GetADCUnits() const { return m_ADCUnits; }
 
-  //! Set the calibrated energy
+  //! Set the calibrated energy (= calibrated ADC's) in keV
   void SetEnergy(double Energy) { m_Energy = Energy; }
-  //! Return the calibrated energy
+  //! Return the calibrated energy (= calibrated ADC's) in keV
   double GetEnergy() const { return m_Energy; }
 
   //! Set the energy resolution (1 sigma)
@@ -105,9 +105,9 @@ class MStripHit
   //! Return the measured TAC value of the strip (arrival timing)
   double GetTAC() const { return m_TAC; }
 
-  //! Set the timing in nanoseconds
+  //! Set the timing (= calibrated TAC) in nanoseconds
   void SetTiming(double Timing) { m_Timing = Timing; }
-  //! Return the timing in nanoseconds
+  //! Return the timing (= calibrated TAC)in nanoseconds
   double GetTiming() const { return m_Timing; }
 
   //! Set the timing resolution
@@ -186,16 +186,16 @@ class MStripHit
   //! Read-out element
   MReadOutElementDoubleStrip* m_ReadOutElement;
 
-  //! ADC units after any correction
+  //! Measured ADC units
   double m_ADCUnits;
-  //! Calibrated energy
+  //! Calibrated energy (= calibrated ADC's) in keV
   double m_Energy;
-  //! Energy resolution
+  //! Energy resolution in keV (1 sigma)
   double m_EnergyResolution;
 
   //! The measured TAC timing values
   double m_TAC;
-  //! Timing in nanoseconds
+  //! Timing (= calibrated TAC) in nanoseconds
   double m_Timing;
   //! Timing resolution in nanoseconds
   double m_TimingResolution;

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -67,9 +67,9 @@ class MStripHit
   //! Return the strip ID
   unsigned int GetStripID() const { return m_ReadOutElement->GetStripID(); }
 
-  //! DEPRECATED: Set whether the strip is on the low-voltage side using IsLowVoltageStrip instead
+  //! DEPRECATED: Remove, but we need to remove it from remaining classes that use it first: Issue #172
   void IsXStrip(bool LowVoltageSide) { m_ReadOutElement->IsLowVoltageStrip(LowVoltageSide); }
-  //! DEPRECATED: Return whether the strip is on the low-voltage side using IsLowVoltageStrip instead
+  //! DEPRECATED: Remove, but we need to remove it from remaining classes that use it first: Issue #172
   bool IsXStrip() const { return m_ReadOutElement->IsLowVoltageStrip(); }
 
   //! Set whether the strip is on the low-voltage side
@@ -80,18 +80,11 @@ class MStripHit
 
   // Energy section:
 
-  //! REVIEW: Why is this not unsigned int - that is what we measure?
+  //! TODO: Switch to unsigned int: Issue #176
   //! Set the measured ADC units of the strip
   void SetADCUnits(double ADCUnits) { m_ADCUnits = ADCUnits; }
   //! Return measured the ADC units of the strip
   double GetADCUnits() const { return m_ADCUnits; }
-
-  //! REVIEW: What are we using those for - they are not used anywhere - I would always correct the energy not the raw data
-  //!           We might use it for temperature correction - or not
-  //! Set the uncorrected ADC units of the strip (before common-mode correction)
-  void SetUncorrectedADCUnits(double UncorrectedADCUnits) { m_UncorrectedADCUnits = UncorrectedADCUnits; }
-  //! Return the uncorrected ADC units of the strip (before common-mode correction)
-  double GetUncorrectedADCUnits() const { return m_UncorrectedADCUnits; }
 
   //! Set the calibrated energy
   void SetEnergy(double Energy) { m_Energy = Energy; }
@@ -106,17 +99,11 @@ class MStripHit
 
   // Timing:
 
-  //! REVIEW: Why is TAC double, when we measure unsigned ints?
+  //! TODO: Switch to unsigned int: Issue #176
   //! Set the measured TAC value of the strip (arrival timing)
   void SetTAC(double TAC) { m_TAC = TAC; }
   //! Return the measured TAC value of the strip (arrival timing)
   double GetTAC() const { return m_TAC; }
-
-  //! REVIEW: This is not used - timing should have a resolution
-  //! Set the TAC resolution
-  void SetTACResolution(double TACResolution) { m_TACResolution = TACResolution; }
-  //! Return the TAC resolution
-  double GetTACResolution() const { return m_TACResolution; }
 
   //! Set the timing in nanoseconds
   void SetTiming(double Timing) { m_Timing = Timing; }
@@ -128,14 +115,6 @@ class MStripHit
   //! Return the timing resolution
   double GetTimingResolution() const { return m_TimingResolution; }
 
-
-  // Temperature:
-
-  //! REVIEW: Hold-over from balloon and balloon temperature calibration
-  //! Set the temperature of the relevant preamp (in degrees C)
-  void SetPreampTemp(double PreampTemp) { m_PreampTemp = PreampTemp; }
-  //! Return the temperature of the relevant preamp (in degrees C)
-  double GetPreampTemp() const { return m_PreampTemp; }
 
 
   // Flags:
@@ -152,13 +131,12 @@ class MStripHit
 
   //! Set the fast-timing flag
   void HasFastTiming(bool FastTiming) { m_HasFastTiming = FastTiming; }
-  //! Return whether the strip timing is fast
+  //! Return whether the strip has passed the fast threshold
   bool HasFastTiming() const { return m_HasFastTiming; }
 
-  //! REVIEW: What kind of trigger is this: above slow or above fast?
-  //! Set whether the strip has triggered
+  //! Set whether the strip has triggered (ADC values above slow threshold)
   void HasTriggered(bool HasTriggered) { m_HasTriggered = HasTriggered; }
-  //! Return whether the strip has triggered
+  //! Return whether the strip has triggered (ADC values above slow threshold)
   bool HasTriggered() const { return m_HasTriggered; }
 
   //! REVIEW: Should this be just HasTiming() - timing is calibrated TAC?
@@ -180,7 +158,7 @@ class MStripHit
   //! Stream the strip hit in Nuclearizer's DAT format
   bool StreamDat(ostream& S, int Version = 1);
   //! Stream the strip hit in MEGAlib's ROA format
-  void StreamRoa(ostream& S, bool WithADC = true, bool WithTAC = true, bool WithEnergy = false, bool WithTiming = false, bool WithTemperature = false, bool WithFlags = false, bool WithOrigins = false);
+  void StreamRoa(ostream& S, bool WithADC = true, bool WithTAC = true, bool WithEnergy = false, bool WithTiming = false, bool WithFlags = false, bool WithOrigins = false);
 
 
   // Simulation:
@@ -208,8 +186,6 @@ class MStripHit
   //! Read-out element
   MReadOutElementDoubleStrip* m_ReadOutElement;
 
-  //! ADC units before all corrections
-  double m_UncorrectedADCUnits;
   //! ADC units after any correction
   double m_ADCUnits;
   //! Calibrated energy
@@ -219,15 +195,11 @@ class MStripHit
 
   //! The measured TAC timing values
   double m_TAC;
-  //! TAC timing resolution
-  double m_TACResolution;
   //! Timing in nanoseconds
   double m_Timing;
   //! Timing resolution in nanoseconds
   double m_TimingResolution;
 
-  //! Temperature of the preamp
-  double m_PreampTemp;
 
   //! True if the hit is a guard ring hit
   bool m_IsGuardRing;

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -33,6 +33,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 
+//! This class represents a hit in a strip
 class MStripHit
 {
   // public interface:
@@ -41,31 +42,36 @@ class MStripHit
   MStripHit();
   //! Default destructor
   virtual ~MStripHit();
+  //! Copy constructor is disabled because this class owns m_ReadOutElement
+  MStripHit(const MStripHit&) = delete;
+  //! Assignment is disabled because this class owns m_ReadOutElement
+  MStripHit& operator=(const MStripHit&) = delete;
 
   //! Reset all data
   void Clear();
 
-  //! Get the read-out element
+  //! Return the read-out element
+  //! Ownership stays with this object
   MReadOutElement* GetReadOutElement() const { return m_ReadOutElement; }
-  
-  //! Set the Detector ID
+
+  //! Set the detector ID
   void SetDetectorID(unsigned int DetectorID) { m_ReadOutElement->SetDetectorID(DetectorID); }
-  //! Return the Detector ID
+  //! Return the detector ID
   unsigned int GetDetectorID() const { return m_ReadOutElement->GetDetectorID(); }
 
-  //! Set the Strip ID
+  //! Set the strip ID
   void SetStripID(unsigned int StripID) { m_ReadOutElement->SetStripID(StripID); }
-  //! Return the Strip ID
+  //! Return the strip ID
   unsigned int GetStripID() const { return m_ReadOutElement->GetStripID(); }
 
-  //! Set the strip type (x/y)
-  void IsXStrip(bool PositiveStrip) { m_ReadOutElement->IsLowVoltageStrip(PositiveStrip); }
-  //! Return the strip type (x/y)
+  //! DEPRECATED: Set whether the strip is on the low voltage side using IsLowVoltageStrip instead
+  void IsXStrip(bool LowVoltageSide) { m_ReadOutElement->IsLowVoltageStrip(LowVoltageSide); }
+  //! DEPRECATED: Return whether the strip is on the low voltage side using IsLowVoltageStrip instead
   bool IsXStrip() const { return m_ReadOutElement->IsLowVoltageStrip(); }
 
-  //! Set the strip type (positive or negative)
-  void IsLowVoltageStrip(bool PositiveStrip) { m_ReadOutElement->IsLowVoltageStrip(PositiveStrip); }
-  //! Return the strip type (positive or negative)
+  //! Set whether the strip is on the low voltage side
+  void IsLowVoltageStrip(bool LowVoltageSide) { m_ReadOutElement->IsLowVoltageStrip(LowVoltageSide); }
+  //! Return whether the strip is on the low voltage side
   bool IsLowVoltageStrip() const { return m_ReadOutElement->IsLowVoltageStrip(); }
 
   //! Set whether the strip has triggered
@@ -73,14 +79,14 @@ class MStripHit
   //! Return whether the strip has triggered
   bool HasTriggered() const { return m_HasTriggered; }
 
-  //! Set the uncorrected ADCUnits of the strip (before common-mode correction)
+  //! Set the uncorrected ADC units of the strip (before common-mode correction)
   void SetUncorrectedADCUnits(double UncorrectedADCUnits) { m_UncorrectedADCUnits = UncorrectedADCUnits; }
-  //! Return the uncorrected ADCUnits of the strip (before common-mode correction)
+  //! Return the uncorrected ADC units of the strip (before common-mode correction)
   double GetUncorrectedADCUnits() const { return m_UncorrectedADCUnits; }
 
-  //! Set the ADCUnits of the strip
+  //! Set the ADC units of the strip
   void SetADCUnits(double ADCUnits) { m_ADCUnits = ADCUnits; }
-  //! Return the ADCUnits of the strip
+  //! Return the ADC units of the strip
   double GetADCUnits() const { return m_ADCUnits; }
 
   //! Set the calibrated energy
@@ -90,7 +96,7 @@ class MStripHit
 
   //! Set the energy resolution (sigma)
   void SetEnergyResolution(double EnergyResolution) { m_EnergyResolution = EnergyResolution; }
-  //! Return the calibrated energy
+  //! Return the energy resolution
   double GetEnergyResolution() const { return m_EnergyResolution; }
 
   //! Set the TAC
@@ -103,58 +109,58 @@ class MStripHit
   //! Return the TAC resolution
   double GetTACResolution() const { return m_TACResolution; }
 
-  //! Set the Timing in nanoseconds
+  //! Set the timing in nanoseconds
   void SetTiming(double Timing) { m_Timing = Timing; }
-  //! Return the Timing in nanoseconds
+  //! Return the timing in nanoseconds
   double GetTiming() const { return m_Timing; }
 
-  //! Set the Timing resolution
+  //! Set the timing resolution
   void SetTimingResolution(double TimingResolution) { m_TimingResolution = TimingResolution; }
-  //! Return the Timing resolution
+  //! Return the timing resolution
   double GetTimingResolution() const { return m_TimingResolution; }
 
-  //! Set the Temperature of the relavent preamp (in degrees C)
+  //! Set the temperature of the relevant preamp (in degrees C)
   void SetPreampTemp(double PreampTemp) { m_PreampTemp = PreampTemp; }
-  //! Return the Temperature of the relavent preamp (in degrees C)
+  //! Return the temperature of the relevant preamp (in degrees C)
   double GetPreampTemp() const { return m_PreampTemp; }
 
-  //! Set the origins from the simulations (take care of duplicates)
-  void AddOrigins(vector<int> Origins);
-  //! Get the origins from the simulation
+  //! Add origins from the simulation and remove duplicates
+  void AddOrigins(const vector<int>& Origins);
+  //! Return the origins from the simulation
   vector<int> GetOrigins() const { return m_Origins; }
 
-  //! Set the Guard Ring flag
+  //! Set the guard ring flag
   void IsGuardRing(bool GuardRing) { m_IsGuardRing = GuardRing; }
-  //! Return a boolean indicating whether the strip is a Guard Ring
-  bool IsGuardRing() const { return m_IsGuardRing; }  
-  //! Set the Nearest Neighbor flag
+  //! Return whether the strip is a guard ring
+  bool IsGuardRing() const { return m_IsGuardRing; }
+  //! Set the nearest-neighbor flag
   void IsNearestNeighbor(bool NearestNeighbor) { m_IsNearestNeighbor = NearestNeighbor; }
-  //! Return a boolean indicating whether the strip is a Nearest Neighbor
+  //! Return whether the strip is a nearest neighbor
   bool IsNearestNeighbor() const { return m_IsNearestNeighbor; }
-    
-  //! Set the Fast Timing flag
+
+  //! Set the fast-timing flag
   void HasFastTiming(bool FastTiming) { m_HasFastTiming = FastTiming; }
-  //! Return a boolean indicating whether the strip timing is fast;
+  //! Return whether the strip timing is fast
   bool HasFastTiming() const { return m_HasFastTiming; }
 
-  //! Set the Calibrated Timing flag
+  //! Set the calibrated-timing flag
   void HasCalibratedTiming(bool CalibratedTiming) { m_HasCalibratedTiming = CalibratedTiming; }
-  //! Return a boolean indicating whether the strip timing has been calibrated;
+  //! Return whether the strip timing has been calibrated
   bool HasCalibratedTiming() const { return m_HasCalibratedTiming; }
 
-  //! Produce an unsigned int with bitwise values representing flags
+  //! Return the bitwise strip-hit flags
   unsigned int MakeFlags();
-  //! Read in unsigned int with bitwise values representing flags and update boolean flags
+  //! Update the strip-hit flags from a bit mask
   void ParseFlags(unsigned int Flags);
 
-  //! Parse some content from a line
-  bool Parse(MString& Line, int Version = 1);
-  //! Dump the content into a file stream
+  //! Parse a strip hit from a line
+  bool Parse(const MString& Line, int Version = 1);
+  //! Write the strip hit to a file stream
   bool StreamDat(ostream& S, int Version = 1);
-  //! Stream the content in MEGAlib's roa format 
+  //! Stream the strip hit in MEGAlib's ROA format
   void StreamRoa(ostream& S, bool WithADC = true, bool WithTAC = true, bool WithEnergy = false, bool WithTiming = false, bool WithTemperature = false, bool WithFlags = false, bool WithOrigins = false);
-  
-  
+
+
   // protected methods:
  protected:
 
@@ -169,44 +175,45 @@ class MStripHit
 
   // private members:
  private:
-  //! The read-out element
+  //! Read-out element
   MReadOutElementDoubleStrip* m_ReadOutElement;
-  //! Strp has triggered
+  //! True if the strip has triggered
   bool m_HasTriggered;
-  //! ADCUnits before all corrections
+  //! ADC units before all corrections
   double m_UncorrectedADCUnits;
-  //! ADCUnits after any correction
+  //! ADC units after any correction
   double m_ADCUnits;
-  //! The calibrated energy
+  //! Calibrated energy
   double m_Energy;
-  //! The energy resolution
+  //! Energy resolution
   double m_EnergyResolution;
   //! TAC timing
   double m_TAC;
   //! TAC timing resolution
   double m_TACResolution;
-  //! Timing in ns
+  //! Timing in nanoseconds
   double m_Timing;
-  //! Timing resolution in ns
+  //! Timing resolution in nanoseconds
   double m_TimingResolution;
-  //! Temperature of Preamp
+  //! Temperature of the preamp
   double m_PreampTemp;
 
-  //! Flags denoting the type of strip hit
+  //! True if the hit is a guard ring
   bool m_IsGuardRing;
+  //! True if the hit is a nearest neighbor
   bool m_IsNearestNeighbor;
 
-  //! Flag indicating whether the hit has fast timing
+  //! True if the hit has fast timing
   bool m_HasFastTiming;
-  //! Flag indicating whether the hit has calibrated timing
+  //! True if the hit has calibrated timing
   bool m_HasCalibratedTiming;
 
-  //! Origin IAs from simulations
+  //! Origin interaction IDs from the simulation
   vector<int> m_Origins;
 
 #ifdef ___CLING___
  public:
-  ClassDef(MStripHit, 0) // no description
+  ClassDef(MStripHit, 0) // A strip hit
 #endif
 
 };

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -83,7 +83,7 @@ class MStripHit
   //! TODO: Switch to unsigned int: Issue #176
   //! Set the measured ADC units of the strip
   void SetADCUnits(double ADCUnits) { m_ADCUnits = ADCUnits; }
-  //! Return measured the ADC units of the strip
+  //! Return the measured the ADC units of the strip
   double GetADCUnits() const { return m_ADCUnits; }
 
   //! Set the calibrated energy (= calibrated ADC's) in keV
@@ -129,7 +129,7 @@ class MStripHit
   //! Return whether the strip is a nearest-neighbor hit
   bool IsNearestNeighbor() const { return m_IsNearestNeighbor; }
 
-  //! Set the fast-timing flag
+  //! Set whether the strip has passed the fast threshold
   void HasFastTiming(bool FastTiming) { m_HasFastTiming = FastTiming; }
   //! Return whether the strip has passed the fast threshold
   bool HasFastTiming() const { return m_HasFastTiming; }

--- a/src/MReadOutAssembly.cxx
+++ b/src/MReadOutAssembly.cxx
@@ -647,6 +647,8 @@ void MReadOutAssembly::StreamEvta(ostream& S)
 void MReadOutAssembly::StreamRoa(ostream& S, bool WithADCs, bool WithTACs, bool WithEnergies, bool WithTimings, bool WithTemperatures, bool WithFlags, bool WithOrigins, bool WithNearestNeighbors)
 {
   // Stream the read-out assembly in MEGAlib's ROA format
+  //
+  // WithTemperatures is currently not used, since we don't have that housekeeping info at the moment
 
   S<<"SE"<<endl;
   S<<"ID "<<m_ID<<endl;
@@ -666,7 +668,7 @@ void MReadOutAssembly::StreamRoa(ostream& S, bool WithADCs, bool WithTACs, bool 
     if (WithNearestNeighbors == false && m_StripHits[h]->IsNearestNeighbor() == true) {
       continue;
     }
-    m_StripHits[h]->StreamRoa(S, WithADCs, WithTACs, WithEnergies, WithTimings, WithTemperatures, WithFlags, WithOrigins);
+    m_StripHits[h]->StreamRoa(S, WithADCs, WithTACs, WithEnergies, WithTimings, WithFlags, WithOrigins);
     ++Counter;
   }
   for (unsigned int h = 0; h < m_CrystalHits.size(); ++h) {

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -36,6 +36,7 @@ using namespace std;
 // MEGAlib libs:
 #include "MStreams.h"
 
+
 ////////////////////////////////////////////////////////////////////////////////
 
 
@@ -52,7 +53,7 @@ MStripHit::MStripHit()
   // Construct an instance of MStripHit
 
   m_ReadOutElement = new MReadOutElementDoubleStrip();
-  
+
   Clear();
 }
 
@@ -63,7 +64,7 @@ MStripHit::MStripHit()
 MStripHit::~MStripHit()
 {
   // Delete this instance of MStripHit
-  
+
   delete m_ReadOutElement;
 }
 
@@ -100,11 +101,13 @@ void MStripHit::Clear()
 ////////////////////////////////////////////////////////////////////////////////
 
 
-bool MStripHit::Parse(MString& Line, int Version)
+bool MStripHit::Parse(const MString& Line, int Version)
 {
+  // Parse the hit from a string starting with SH
+
   const char* line = Line.Data();
   if (Line.Length() < 3) {
-    if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: line too short"<<endl;
+    if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: line too short with length "<<Line.Length()<<endl;
     return false;
   }
 
@@ -119,13 +122,16 @@ bool MStripHit::Parse(MString& Line, int Version)
                    &det_id, &pos_strip, &strip_id, &has_triggered,
                    &timing, &un_adc, &adc, &energy, &energy_res, &flags);
     if (N != 10) {
-      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: malformed SH line"<<endl;
+      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: malformed SH line with "<<N<<" fields instead of 10"<<endl;
       return false;
     }
     if (pos_strip != 'l' && pos_strip != 'h') {
-      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: unknown detector face: "<<pos_strip<<endl;
+      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: unknown detector face '"<<pos_strip<<"' (expected 'l' or 'h')"<<endl;
       return false;
     }
+
+    Clear();
+
     SetDetectorID(det_id);
     IsLowVoltageStrip(pos_strip == 'l');
     SetStripID(strip_id);
@@ -138,7 +144,7 @@ bool MStripHit::Parse(MString& Line, int Version)
     ParseFlags(flags);
     return true;
   } else {
-    if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: line does not start with SH"<<endl;
+    if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: line starts with '"<<line[0]<<line[1]<<"' instead of 'SH'"<<endl;
     return false;
   }
 }
@@ -147,22 +153,23 @@ bool MStripHit::Parse(MString& Line, int Version)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-//! Set the origins from the simulations (take care of duplicates)
-void MStripHit::AddOrigins(vector<int> Origins)
+void MStripHit::AddOrigins(const vector<int>& Origins)
 {
+  // Add origins from the simulation and remove duplicates
+
   m_Origins.insert(m_Origins.end(), Origins.begin(), Origins.end());
   sort(m_Origins.begin(), m_Origins.end());
   m_Origins.erase(unique(m_Origins.begin(), m_Origins.end()), m_Origins.end());
 }
 
-  
+
 ////////////////////////////////////////////////////////////////////////////////
 
 
 bool MStripHit::StreamDat(ostream& S, int Version)
 {
-  //! Stream the content to an ASCII file 
-  
+  // Write the strip hit to an ASCII file
+
   S<<"SH "
    <<m_ReadOutElement->GetDetectorID()<<" "
    <<((m_ReadOutElement->IsLowVoltageStrip() == true) ? "l" : "h")<<" "
@@ -174,7 +181,7 @@ bool MStripHit::StreamDat(ostream& S, int Version)
    <<m_Energy<<" "
    <<m_EnergyResolution<<" "
    <<MakeFlags()<<endl;
- 
+
   return true;
 }
 
@@ -186,9 +193,9 @@ bool MStripHit::StreamDat(ostream& S, int Version)
 
 void MStripHit::StreamRoa(ostream& S, bool WithADC, bool WithTAC, bool WithEnergy, bool WithTiming, bool WithTemperature, bool WithFlags, bool WithOrigins)
 {
-  //! Stream the content in MEGAlib's evta format 
+  // Stream the strip hit in MEGAlib's ROA format
 
-  S<<"UH " 
+  S<<"UH "
    <<m_ReadOutElement->GetDetectorID()<<" "
    <<m_ReadOutElement->GetStripID()<<" "
    <<((m_ReadOutElement->IsLowVoltageStrip() == true) ? "l" : "h")<<" ";
@@ -229,12 +236,12 @@ void MStripHit::StreamRoa(ostream& S, bool WithADC, bool WithTAC, bool WithEnerg
 
 unsigned int MStripHit::MakeFlags()
 {
-  //! Return flags to indicate the type of strip hit
-  //! Currently, 3 bits:
-  //!   v = Has fast timing
-  //!    v = Is a nearest neighbor
-  //!     v = Is a guard ring
-  //! 0b111u
+  // Return the bitwise strip-hit flags
+  // Currently, 3 bits:
+  //   v = Has fast timing
+  //    v = Is a nearest neighbor
+  //     v = Is a guard ring
+  // 0b111u
 
   unsigned int Flags = 0b000u;
   if (m_IsGuardRing == true) {
@@ -256,14 +263,14 @@ unsigned int MStripHit::MakeFlags()
 
 void MStripHit::ParseFlags(unsigned int Flags)
 {
-  //! Set internal booleans according to flag
-  //! Currently, 3 bits:
-  //!   v = Has fast timing
-  //!    v = Is a nearest neighbor
-  //!     v = Is a guard ring
-  //! 0b111u
+  // Update the strip-hit flags from a bit mask
+  // Currently, 3 bits:
+  //   v = Has fast timing
+  //    v = Is a nearest neighbor
+  //     v = Is a guard ring
+  // 0b111u
 
-  // "Flags & 0b001u" extracts bit 0, "!= 0u" turns it into an explicit bool.
+  // "Flags & 0b001u" extracts bit 0, "!= 0u" turns it into an explicit bool
   IsGuardRing((Flags & 0b001u) != 0u);
   IsNearestNeighbor((Flags & 0b010u) != 0u);
   HasFastTiming((Flags & 0b100u) != 0u);

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -78,15 +78,12 @@ void MStripHit::Clear()
 
   m_ReadOutElement->Clear();
   m_HasTriggered = false;
-  m_UncorrectedADCUnits = 0;
   m_ADCUnits = 0;
   m_Energy = 0;
   m_EnergyResolution = 0;
   m_TAC = 0;
-  m_TACResolution = 0;
   m_Timing = 0;
   m_TimingResolution = 0;
-  m_PreampTemp = 0;
 
   m_IsGuardRing = false;
   m_IsNearestNeighbor = false;
@@ -116,15 +113,15 @@ bool MStripHit::Parse(const MString& Line, int Version)
   if (line[0] == 'S' && line[1] == 'H') {
     unsigned int det_id, strip_id;
     int has_triggered;
-    double timing, un_adc, adc;
+    double timing, adc;
     double energy, energy_res;
     char pos_strip;
     unsigned int flags;
-    int N = sscanf(&line[3], "%u %c %u %d %lf %lf %lf %lf %lf %u",
+    int N = sscanf(&line[3], "%u %c %u %d %lf %lf %lf %lf %u",
                    &det_id, &pos_strip, &strip_id, &has_triggered,
-                   &timing, &un_adc, &adc, &energy, &energy_res, &flags);
-    if (N != 10) {
-      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: malformed SH line with "<<N<<" fields instead of 10"<<endl;
+                   &timing, &adc, &energy, &energy_res, &flags);
+    if (N != 9) {
+      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: malformed SH line with "<<N<<" fields instead of 9"<<endl;
       return false;
     }
     if (pos_strip != 'l' && pos_strip != 'h') {
@@ -137,7 +134,6 @@ bool MStripHit::Parse(const MString& Line, int Version)
     SetStripID(strip_id);
     HasTriggered(has_triggered != 0);
     SetTiming(timing);
-    SetUncorrectedADCUnits(un_adc);
     SetADCUnits(adc);
     SetEnergy(energy);
     SetEnergyResolution(energy_res);
@@ -176,7 +172,6 @@ bool MStripHit::StreamDat(ostream& S, int Version)
    <<m_ReadOutElement->GetStripID()<<" "
    <<m_HasTriggered<<" "
    <<setprecision(9)<<m_Timing<<" "
-   <<m_UncorrectedADCUnits<<" "
    <<m_ADCUnits<<" "
    <<m_Energy<<" "
    <<m_EnergyResolution<<" "
@@ -186,12 +181,10 @@ bool MStripHit::StreamDat(ostream& S, int Version)
 }
 
 
-
-
 ////////////////////////////////////////////////////////////////////////////////
 
 
-void MStripHit::StreamRoa(ostream& S, bool WithADC, bool WithTAC, bool WithEnergy, bool WithTiming, bool WithTemperature, bool WithFlags, bool WithOrigins)
+void MStripHit::StreamRoa(ostream& S, bool WithADC, bool WithTAC, bool WithEnergy, bool WithTiming, bool WithFlags, bool WithOrigins)
 {
   // Stream the strip hit in MEGAlib's ROA format
 
@@ -204,9 +197,6 @@ void MStripHit::StreamRoa(ostream& S, bool WithADC, bool WithTAC, bool WithEnerg
   }
   if (WithTAC == true) {
     S<<m_TAC<<" ";
-  }
-  if (WithTemperature == true) {
-    S<<m_PreampTemp<<" ";
   }
   if (WithEnergy == true) {
     S<<m_Energy<<" ";

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -125,7 +125,7 @@ bool MStripHit::Parse(const MString& Line, int Version)
       return false;
     }
     if (pos_strip != 'l' && pos_strip != 'h') {
-      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: unknown detector face '"<<pos_strip<<"' (expected 'l' or 'h')"<<endl;
+      if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: unknown detector side '"<<pos_strip<<"' (expected 'l' or 'h')"<<endl;
       return false;
     }
 
@@ -229,8 +229,8 @@ unsigned int MStripHit::MakeFlags()
   // Return the bitwise strip-hit flags
   // Currently, 3 bits:
   //   v = Has fast timing
-  //    v = Is a nearest neighbor
-  //     v = Is a guard ring
+  //    v = Is a nearest neighbor strip hit
+  //     v = Is a guard ring strip hit
   // 0b111u
 
   unsigned int Flags = 0b000u;

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -105,6 +105,8 @@ bool MStripHit::Parse(const MString& Line, int Version)
 {
   // Parse the hit from a string starting with SH
 
+  Clear();
+
   const char* line = Line.Data();
   if (Line.Length() < 3) {
     if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: line too short with length "<<Line.Length()<<endl;
@@ -129,8 +131,6 @@ bool MStripHit::Parse(const MString& Line, int Version)
       if (g_Verbosity >= c_Error) cout<<"Error in MStripHit::Parse: unknown detector face '"<<pos_strip<<"' (expected 'l' or 'h')"<<endl;
       return false;
     }
-
-    Clear();
 
     SetDetectorID(det_id);
     IsLowVoltageStrip(pos_strip == 'l');
@@ -168,7 +168,7 @@ void MStripHit::AddOrigins(const vector<int>& Origins)
 
 bool MStripHit::StreamDat(ostream& S, int Version)
 {
-  // Write the strip hit to an ASCII file
+  // Stream the strip hit in Nuclearizer's DAT format
 
   S<<"SH "
    <<m_ReadOutElement->GetDetectorID()<<" "

--- a/unittests/UTNStripHit.cxx
+++ b/unittests/UTNStripHit.cxx
@@ -79,7 +79,7 @@ bool UTNStripHit::TestDefaultConstruction()
   Passed = EvaluateTrue("GetReadOutElement()", "non-null", "GetReadOutElement() returns a non-null pointer after construction", H.GetReadOutElement() != nullptr) && Passed;
   Passed = Evaluate("GetDetectorID()", "default", "Default DetectorID is undefined", H.GetDetectorID(), g_UnsignedIntNotDefined) && Passed;
   Passed = Evaluate("GetStripID()", "default", "Default StripID is undefined", H.GetStripID(), g_UnsignedIntNotDefined) && Passed;
-  Passed = EvaluateTrue("IsLowVoltageStrip()", "default", "Default strip type is low-voltage", H.IsLowVoltageStrip()) && Passed;
+  Passed = EvaluateTrue("IsLowVoltageStrip()", "default", "Default strip is on the low voltage side", H.IsLowVoltageStrip()) && Passed;
   Passed = EvaluateFalse("HasTriggered()", "default", "Default HasTriggered is false", H.HasTriggered()) && Passed;
   Passed = EvaluateNear("GetUncorrectedADCUnits()", "default", "Default UncorrectedADCUnits is 0", H.GetUncorrectedADCUnits(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetADCUnits()", "default", "Default ADCUnits is 0", H.GetADCUnits(), 0.0, 1e-12) && Passed;
@@ -154,12 +154,12 @@ bool UTNStripHit::TestGettersSetters()
   H.IsLowVoltageStrip(false);
   Passed = EvaluateFalse("IsLowVoltageStrip(bool)/IsLowVoltageStrip()", "representative false", "IsLowVoltageStrip() returns false after IsLowVoltageStrip(false)", H.IsLowVoltageStrip()) && Passed;
 
-  // IsXStrip is an alias for IsLowVoltageStrip
+  // Deprecated IsXStrip forwards to IsLowVoltageStrip
   H.IsXStrip(true);
-  Passed = EvaluateTrue("IsXStrip(bool)/IsXStrip()", "alias true", "IsXStrip() returns true after IsXStrip(true)", H.IsXStrip()) && Passed;
-  Passed = EvaluateTrue("IsXStrip(bool)/IsLowVoltageStrip()", "alias true", "IsLowVoltageStrip() returns true after IsXStrip(true)", H.IsLowVoltageStrip()) && Passed;
+  Passed = EvaluateTrue("IsXStrip(bool)/IsXStrip()", "deprecated true", "IsXStrip() returns true after IsXStrip(true)", H.IsXStrip()) && Passed;
+  Passed = EvaluateTrue("IsXStrip(bool)/IsLowVoltageStrip()", "deprecated true", "IsLowVoltageStrip() returns true after IsXStrip(true)", H.IsLowVoltageStrip()) && Passed;
   H.IsXStrip(false);
-  Passed = EvaluateFalse("IsXStrip(bool)/IsXStrip()", "alias false", "IsXStrip() returns false after IsXStrip(false)", H.IsXStrip()) && Passed;
+  Passed = EvaluateFalse("IsXStrip(bool)/IsXStrip()", "deprecated false", "IsXStrip() returns false after IsXStrip(false)", H.IsXStrip()) && Passed;
 
   // HasTriggered
   H.HasTriggered(true);
@@ -245,35 +245,35 @@ bool UTNStripHit::TestMakeParseFlags()
 
   MStripHit H;
 
-  // All flags off → 0
+  // All flags off -> 0
   H.IsGuardRing(false);
   H.IsNearestNeighbor(false);
   H.HasFastTiming(false);
   Passed = Evaluate("MakeFlags()", "all off", "MakeFlags() returns 0 when no flag is set",
                     H.MakeFlags(), (unsigned int) 0b000) && Passed;
 
-  // Only IsGuardRing → bit 0 = 1
+  // Only IsGuardRing -> bit 0 = 1
   H.IsGuardRing(true);
   H.IsNearestNeighbor(false);
   H.HasFastTiming(false);
   Passed = Evaluate("MakeFlags()", "guard ring only", "MakeFlags() returns 1 when only IsGuardRing is set",
                     H.MakeFlags(), (unsigned int) 0b001) && Passed;
 
-  // Only IsNearestNeighbor → bit 1 = 2
+  // Only IsNearestNeighbor -> bit 1 = 2
   H.IsGuardRing(false);
   H.IsNearestNeighbor(true);
   H.HasFastTiming(false);
   Passed = Evaluate("MakeFlags()", "nearest neighbor only", "MakeFlags() returns 2 when only IsNearestNeighbor is set",
                     H.MakeFlags(), (unsigned int) 0b010) && Passed;
 
-  // Only HasFastTiming → bit 2 = 4
+  // Only HasFastTiming -> bit 2 = 4
   H.IsGuardRing(false);
   H.IsNearestNeighbor(false);
   H.HasFastTiming(true);
   Passed = Evaluate("MakeFlags()", "fast timing only", "MakeFlags() returns 4 when only HasFastTiming is set",
                     H.MakeFlags(), (unsigned int) 0b100) && Passed;
 
-  // All three flags → 7
+  // All three flags -> 7
   H.IsGuardRing(true);
   H.IsNearestNeighbor(true);
   H.HasFastTiming(true);
@@ -345,7 +345,7 @@ bool UTNStripHit::TestAddOrigins()
                       Origins[3], 8) && Passed;
   }
 
-  // Add again with duplicates: {3, 7, 8} — 3 and 8 are already present
+  // Add again with duplicates: {3, 7, 8} - 3 and 8 are already present
   H.AddOrigins({3, 7, 8});
   Origins = H.GetOrigins();
   Passed = Evaluate("AddOrigins()", "deduplicated count", "Origins list has 5 unique entries after adding {3,7,8} to {1,3,5,8}",
@@ -364,7 +364,7 @@ bool UTNStripHit::TestAddOrigins()
                       Origins[4], 8) && Passed;
   }
 
-  // Add an empty list — count unchanged
+  // Add an empty list - count unchanged
   H.AddOrigins({});
   Passed = Evaluate("AddOrigins()", "empty add", "Origins count is unchanged after adding an empty list",
                     (unsigned int) H.GetOrigins().size(), (unsigned int) 5) && Passed;
@@ -380,7 +380,7 @@ bool UTNStripHit::TestStreamDatParse()
 {
   bool Passed = true;
 
-  // Set up a representative strip hit with representative values.
+  // Set up a representative strip hit with representative values
   MStripHit Writer;
   Writer.SetDetectorID(2);
   Writer.IsLowVoltageStrip(true);
@@ -414,7 +414,7 @@ bool UTNStripHit::TestStreamDatParse()
                     Reader.GetDetectorID(), 2u) && Passed;
   Passed = Evaluate("Parse()", "StripID", "Parse() restores the representative StripID 37",
                     Reader.GetStripID(), 37u) && Passed;
-  Passed = EvaluateTrue("Parse()", "IsLowVoltageStrip", "Parse() restores the representative low-voltage strip flag",
+  Passed = EvaluateTrue("Parse()", "IsLowVoltageStrip", "Parse() restores the low-voltage-side flag",
                         Reader.IsLowVoltageStrip() == true) && Passed;
   Passed = EvaluateTrue("Parse()", "HasTriggered", "Parse() restores the representative HasTriggered flag",
                         Reader.HasTriggered() == true) && Passed;
@@ -438,7 +438,35 @@ bool UTNStripHit::TestStreamDatParse()
   Passed = EvaluateTrue("Parse()", "IsNearestNeighbor", "Parse() restores IsNearestNeighbor true via flags", Reader.IsNearestNeighbor()) && Passed;
   Passed = EvaluateTrue("Parse()", "HasFastTiming", "Parse() restores HasFastTiming true via flags", Reader.HasFastTiming()) && Passed;
 
-  // High-voltage strip round-trip: verify 'h' marker and HasTriggered(false) survive StreamDat/Parse
+  // Parse into a reused object: fields not present in the SH line must not
+  // retain stale values from the previous object state
+  {
+    MStripHit Reused;
+    Reused.SetTAC(1234.0);
+    Reused.SetTACResolution(5.0);
+    Reused.SetTimingResolution(6.0);
+    Reused.SetPreampTemp(27.5);
+    Reused.HasCalibratedTiming(true);
+    Reused.AddOrigins({9, 10});
+
+    MString ReusedLine(Out.str().c_str());
+    Passed = EvaluateTrue("Parse()", "reused object", "Parse() returns true when parsing into a reused object",
+                          Reused.Parse(ReusedLine)) && Passed;
+    Passed = EvaluateNear("Parse()", "reused TAC reset", "Parse() resets TAC before applying fields from the line",
+                          Reused.GetTAC(), 0.0, 1e-12) && Passed;
+    Passed = EvaluateNear("Parse()", "reused TACResolution reset", "Parse() resets TACResolution before applying fields from the line",
+                          Reused.GetTACResolution(), 0.0, 1e-12) && Passed;
+    Passed = EvaluateNear("Parse()", "reused TimingResolution reset", "Parse() resets TimingResolution before applying fields from the line",
+                          Reused.GetTimingResolution(), 0.0, 1e-12) && Passed;
+    Passed = EvaluateNear("Parse()", "reused PreampTemp reset", "Parse() resets PreampTemp before applying fields from the line",
+                          Reused.GetPreampTemp(), 0.0, 1e-12) && Passed;
+    Passed = EvaluateFalse("Parse()", "reused HasCalibratedTiming reset", "Parse() resets HasCalibratedTiming before applying fields from the line",
+                           Reused.HasCalibratedTiming()) && Passed;
+    Passed = Evaluate("Parse()", "reused origins reset", "Parse() clears origins before applying fields from the line",
+                      (unsigned int) Reused.GetOrigins().size(), (unsigned int) 0) && Passed;
+  }
+
+  // High voltage side round-trip: verify 'h' marker and HasTriggered(false) survive StreamDat/Parse
   {
     MStripHit WriterHV;
     WriterHV.SetDetectorID(5);
@@ -454,19 +482,19 @@ bool UTNStripHit::TestStreamDatParse()
     WriterHV.StreamDat(OutHV);
     MString LineHV(OutHV.str().c_str());
     MStripHit ReaderHV;
-    Passed = EvaluateTrue("Parse()", "HV line", "Parse() returns true for a high-voltage strip line",
+    Passed = EvaluateTrue("Parse()", "HV line", "Parse() returns true for a strip on the high voltage side",
                           ReaderHV.Parse(LineHV)) && Passed;
-    Passed = EvaluateFalse("Parse()", "HV IsLowVoltageStrip", "Parse() restores IsLowVoltageStrip false for a high-voltage strip",
+    Passed = EvaluateFalse("Parse()", "HV IsLowVoltageStrip", "Parse() restores IsLowVoltageStrip false for a strip on the high voltage side",
                            ReaderHV.IsLowVoltageStrip()) && Passed;
-    Passed = EvaluateFalse("Parse()", "HV HasTriggered false", "Parse() restores HasTriggered false for the high-voltage strip",
+    Passed = EvaluateFalse("Parse()", "HV HasTriggered false", "Parse() restores HasTriggered false for the strip on the high voltage side",
                            ReaderHV.HasTriggered()) && Passed;
-    Passed = EvaluateNear("Parse()", "HV Timing", "Parse() restores Timing 99.5 for the high-voltage strip",
+    Passed = EvaluateNear("Parse()", "HV Timing", "Parse() restores Timing 99.5 for the strip on the high voltage side",
                           ReaderHV.GetTiming(), 99.5, 1e-6) && Passed;
   }
 
   // The malformed-line cases below exercise MStripHit::Parse() error paths that
   // print via "if (g_Verbosity >= c_Error)". Lower g_Verbosity to c_Quiet to
-  // silence the expected diagnostics, and restore it afterwards.
+  // silence the expected diagnostics, and restore it afterwards
   int OldVerbosity = g_Verbosity;
   g_Verbosity = c_Quiet;
 
@@ -480,6 +508,29 @@ bool UTNStripHit::TestStreamDatParse()
   MString InvalidFaceLine("SH 2 x 37 1 500 3000 2950 662.0 2.5 4");
   Passed = EvaluateFalse("Parse()", "invalid face", "Parse() returns false for a line with an unknown detector face",
                          Dummy.Parse(InvalidFaceLine)) && Passed;
+
+  // Failed Parse() calls must not clear existing state
+  MStripHit Preserved;
+  Preserved.SetDetectorID(7);
+  Preserved.SetStripID(22);
+  Preserved.SetTAC(1234.0);
+  Preserved.SetPreampTemp(27.5);
+  Preserved.IsGuardRing(true);
+  Preserved.AddOrigins({4, 5});
+  Passed = EvaluateFalse("Parse()", "failed parse preserves object", "Parse() returns false for invalid input without clearing existing state",
+                         Preserved.Parse(InvalidFaceLine)) && Passed;
+  Passed = Evaluate("Parse()", "preserved DetectorID", "Failed Parse() leaves DetectorID unchanged",
+                    Preserved.GetDetectorID(), 7u) && Passed;
+  Passed = Evaluate("Parse()", "preserved StripID", "Failed Parse() leaves StripID unchanged",
+                    Preserved.GetStripID(), 22u) && Passed;
+  Passed = EvaluateNear("Parse()", "preserved TAC", "Failed Parse() leaves TAC unchanged",
+                        Preserved.GetTAC(), 1234.0, 1e-12) && Passed;
+  Passed = EvaluateNear("Parse()", "preserved PreampTemp", "Failed Parse() leaves PreampTemp unchanged",
+                        Preserved.GetPreampTemp(), 27.5, 1e-12) && Passed;
+  Passed = EvaluateTrue("Parse()", "preserved guard ring flag", "Failed Parse() leaves IsGuardRing unchanged",
+                        Preserved.IsGuardRing()) && Passed;
+  Passed = Evaluate("Parse()", "preserved origins", "Failed Parse() leaves origins unchanged",
+                    (unsigned int) Preserved.GetOrigins().size(), (unsigned int) 2) && Passed;
 
   // Parse() returns false for a line shorter than 3 characters
   MString ShortLine("SH");
@@ -524,11 +575,13 @@ bool UTNStripHit::TestStreamRoa()
     ostringstream Out;
     H.StreamRoa(Out, true, true, true, true, true, true, true);
     MString S(Out.str().c_str());
+    Passed = Evaluate("StreamRoa()", "full exact output", "Full StreamRoa() output matches the expected field order",
+                      S, MString("UH 0 41 l 4053 10452 22.1 661.7 123 4 2;5\n")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "starts with UH", "Full StreamRoa() output starts with 'UH'",
                           S.BeginsWith("UH")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "contains strip 41", "Full StreamRoa() output contains strip ID 41",
                           S.Contains("41")) && Passed;
-    Passed = EvaluateTrue("StreamRoa()", "contains lv marker", "Full StreamRoa() output contains low-voltage marker 'l'",
+    Passed = EvaluateTrue("StreamRoa()", "contains lv marker", "Full StreamRoa() output contains low-voltage-side marker 'l'",
                           S.Contains(" l ")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "contains ADC", "Full StreamRoa() output contains ADC value 4053",
                           S.Contains("4053")) && Passed;
@@ -599,7 +652,7 @@ bool UTNStripHit::TestStreamRoa()
                           S.Contains("4053") == false) && Passed;
   }
 
-  // Flags only — MakeFlags() = 4 (HasFastTiming only); check as " 4 " to distinguish from strip ID 41
+  // Flags only - MakeFlags() = 4 (HasFastTiming only); check as " 4 " to distinguish from strip ID 41
   {
     ostringstream Out;
     H.StreamRoa(Out, false, false, false, false, false, true, false);
@@ -615,6 +668,8 @@ bool UTNStripHit::TestStreamRoa()
     ostringstream Out;
     H.StreamRoa(Out, false, false, false, false, false, false, false);
     MString S(Out.str().c_str());
+    Passed = Evaluate("StreamRoa()", "bare exact output", "Bare StreamRoa() output matches the fixed UH prefix fields",
+                      S, MString("UH 0 41 l \n")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "bare prefix", "Bare StreamRoa() output starts with the UH prefix",
                           S.BeginsWith("UH")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "bare no ADC", "Bare StreamRoa() output does not contain ADC value 4053",
@@ -623,7 +678,7 @@ bool UTNStripHit::TestStreamRoa()
                           S.Contains("10452") == false) && Passed;
   }
 
-  // High-voltage strip → 'h' marker
+  // High voltage side -> 'h' marker
   {
     MStripHit HV;
     HV.SetDetectorID(1);
@@ -632,9 +687,9 @@ bool UTNStripHit::TestStreamRoa()
     ostringstream Out;
     HV.StreamRoa(Out, false, false, false, false, false, false, false);
     MString S(Out.str().c_str());
-    Passed = EvaluateTrue("StreamRoa()", "HV marker 'h'", "StreamRoa() emits ' h ' for a high-voltage strip",
+    Passed = EvaluateTrue("StreamRoa()", "HV marker 'h'", "StreamRoa() emits ' h ' for a strip on the high voltage side",
                           S.Contains(" h ")) && Passed;
-    Passed = EvaluateTrue("StreamRoa()", "HV no LV marker", "StreamRoa() does not emit ' l ' for a high-voltage strip",
+    Passed = EvaluateTrue("StreamRoa()", "HV no LV marker", "StreamRoa() does not emit ' l ' for a strip on the high voltage side",
                           S.Contains(" l ") == false) && Passed;
   }
 

--- a/unittests/UTNStripHit.cxx
+++ b/unittests/UTNStripHit.cxx
@@ -509,7 +509,7 @@ bool UTNStripHit::TestStreamDatParse()
   Passed = EvaluateFalse("Parse()", "invalid face", "Parse() returns false for a line with an unknown detector face",
                          Dummy.Parse(InvalidFaceLine)) && Passed;
 
-  // Failed Parse() calls must not clear existing state
+  // Failed Parse() calls leave the object in a clean default state
   MStripHit Preserved;
   Preserved.SetDetectorID(7);
   Preserved.SetStripID(22);
@@ -517,20 +517,20 @@ bool UTNStripHit::TestStreamDatParse()
   Preserved.SetPreampTemp(27.5);
   Preserved.IsGuardRing(true);
   Preserved.AddOrigins({4, 5});
-  Passed = EvaluateFalse("Parse()", "failed parse preserves object", "Parse() returns false for invalid input without clearing existing state",
+  Passed = EvaluateFalse("Parse()", "failed parse clears object", "Parse() returns false for invalid input after clearing existing state",
                          Preserved.Parse(InvalidFaceLine)) && Passed;
-  Passed = Evaluate("Parse()", "preserved DetectorID", "Failed Parse() leaves DetectorID unchanged",
-                    Preserved.GetDetectorID(), 7u) && Passed;
-  Passed = Evaluate("Parse()", "preserved StripID", "Failed Parse() leaves StripID unchanged",
-                    Preserved.GetStripID(), 22u) && Passed;
-  Passed = EvaluateNear("Parse()", "preserved TAC", "Failed Parse() leaves TAC unchanged",
-                        Preserved.GetTAC(), 1234.0, 1e-12) && Passed;
-  Passed = EvaluateNear("Parse()", "preserved PreampTemp", "Failed Parse() leaves PreampTemp unchanged",
-                        Preserved.GetPreampTemp(), 27.5, 1e-12) && Passed;
-  Passed = EvaluateTrue("Parse()", "preserved guard ring flag", "Failed Parse() leaves IsGuardRing unchanged",
-                        Preserved.IsGuardRing()) && Passed;
-  Passed = Evaluate("Parse()", "preserved origins", "Failed Parse() leaves origins unchanged",
-                    (unsigned int) Preserved.GetOrigins().size(), (unsigned int) 2) && Passed;
+  Passed = Evaluate("Parse()", "cleared DetectorID", "Failed Parse() resets DetectorID to undefined",
+                    Preserved.GetDetectorID(), g_UnsignedIntNotDefined) && Passed;
+  Passed = Evaluate("Parse()", "cleared StripID", "Failed Parse() resets StripID to undefined",
+                    Preserved.GetStripID(), g_UnsignedIntNotDefined) && Passed;
+  Passed = EvaluateNear("Parse()", "cleared TAC", "Failed Parse() resets TAC to 0",
+                        Preserved.GetTAC(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateNear("Parse()", "cleared PreampTemp", "Failed Parse() resets PreampTemp to 0",
+                        Preserved.GetPreampTemp(), 0.0, 1e-12) && Passed;
+  Passed = EvaluateFalse("Parse()", "cleared guard ring flag", "Failed Parse() resets IsGuardRing to false",
+                         Preserved.IsGuardRing()) && Passed;
+  Passed = Evaluate("Parse()", "cleared origins", "Failed Parse() clears origins",
+                    (unsigned int) Preserved.GetOrigins().size(), (unsigned int) 0) && Passed;
 
   // Parse() returns false for a line shorter than 3 characters
   MString ShortLine("SH");

--- a/unittests/UTNStripHit.cxx
+++ b/unittests/UTNStripHit.cxx
@@ -81,15 +81,12 @@ bool UTNStripHit::TestDefaultConstruction()
   Passed = Evaluate("GetStripID()", "default", "Default StripID is undefined", H.GetStripID(), g_UnsignedIntNotDefined) && Passed;
   Passed = EvaluateTrue("IsLowVoltageStrip()", "default", "Default strip is on the low voltage side", H.IsLowVoltageStrip()) && Passed;
   Passed = EvaluateFalse("HasTriggered()", "default", "Default HasTriggered is false", H.HasTriggered()) && Passed;
-  Passed = EvaluateNear("GetUncorrectedADCUnits()", "default", "Default UncorrectedADCUnits is 0", H.GetUncorrectedADCUnits(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetADCUnits()", "default", "Default ADCUnits is 0", H.GetADCUnits(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetEnergy()", "default", "Default Energy is 0", H.GetEnergy(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetEnergyResolution()", "default", "Default EnergyResolution is 0", H.GetEnergyResolution(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetTAC()", "default", "Default TAC is 0", H.GetTAC(), 0.0, 1e-12) && Passed;
-  Passed = EvaluateNear("GetTACResolution()", "default", "Default TACResolution is 0", H.GetTACResolution(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetTiming()", "default", "Default Timing is 0", H.GetTiming(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetTimingResolution()", "default", "Default TimingResolution is 0", H.GetTimingResolution(), 0.0, 1e-12) && Passed;
-  Passed = EvaluateNear("GetPreampTemp()", "default", "Default PreampTemp is 0", H.GetPreampTemp(), 0.0, 1e-12) && Passed;
   Passed = EvaluateFalse("IsGuardRing()", "default", "Default IsGuardRing is false", H.IsGuardRing()) && Passed;
   Passed = EvaluateFalse("IsNearestNeighbor()", "default", "Default IsNearestNeighbor is false", H.IsNearestNeighbor()) && Passed;
   Passed = EvaluateFalse("HasFastTiming()", "default", "Default HasFastTiming is false", H.HasFastTiming()) && Passed;
@@ -167,10 +164,6 @@ bool UTNStripHit::TestGettersSetters()
   H.HasTriggered(false);
   Passed = EvaluateFalse("HasTriggered(bool)/HasTriggered()", "representative false", "HasTriggered() returns false after HasTriggered(false)", H.HasTriggered()) && Passed;
 
-  // UncorrectedADCUnits
-  H.SetUncorrectedADCUnits(2048.5);
-  Passed = EvaluateNear("SetUncorrectedADCUnits/GetUncorrectedADCUnits", "representative value", "GetUncorrectedADCUnits returns the representative value 2048.5", H.GetUncorrectedADCUnits(), 2048.5, 1e-9) && Passed;
-
   // ADCUnits
   H.SetADCUnits(4095.0);
   Passed = EvaluateNear("SetADCUnits/GetADCUnits", "representative value", "GetADCUnits returns the representative value 4095.0", H.GetADCUnits(), 4095.0, 1e-9) && Passed;
@@ -187,10 +180,6 @@ bool UTNStripHit::TestGettersSetters()
   H.SetTAC(10452.0);
   Passed = EvaluateNear("SetTAC/GetTAC", "representative value", "GetTAC returns the representative value 10452.0", H.GetTAC(), 10452.0, 1e-9) && Passed;
 
-  // TACResolution
-  H.SetTACResolution(3.0);
-  Passed = EvaluateNear("SetTACResolution/GetTACResolution", "representative value", "GetTACResolution returns the representative value 3.0", H.GetTACResolution(), 3.0, 1e-9) && Passed;
-
   // Timing
   H.SetTiming(123.456);
   Passed = EvaluateNear("SetTiming/GetTiming", "representative value", "GetTiming returns the representative value 123.456 ns", H.GetTiming(), 123.456, 1e-9) && Passed;
@@ -198,10 +187,6 @@ bool UTNStripHit::TestGettersSetters()
   // TimingResolution
   H.SetTimingResolution(0.5);
   Passed = EvaluateNear("SetTimingResolution/GetTimingResolution", "representative value", "GetTimingResolution returns the representative value 0.5 ns", H.GetTimingResolution(), 0.5, 1e-9) && Passed;
-
-  // PreampTemp
-  H.SetPreampTemp(25.3);
-  Passed = EvaluateNear("SetPreampTemp/GetPreampTemp", "representative value", "GetPreampTemp returns the representative value 25.3 degrees C", H.GetPreampTemp(), 25.3, 1e-9) && Passed;
 
   // IsGuardRing
   H.IsGuardRing(true);
@@ -387,7 +372,6 @@ bool UTNStripHit::TestStreamDatParse()
   Writer.SetStripID(37);
   Writer.HasTriggered(true);
   Writer.SetTiming(500.123);
-  Writer.SetUncorrectedADCUnits(3000.25);
   Writer.SetADCUnits(2950.75);
   Writer.SetEnergy(662.0);
   Writer.SetEnergyResolution(2.5);
@@ -420,8 +404,6 @@ bool UTNStripHit::TestStreamDatParse()
                         Reader.HasTriggered() == true) && Passed;
   Passed = EvaluateNear("Parse()", "Timing", "Parse() restores the representative Timing value 500.123",
                         Reader.GetTiming(), 500.123, 1e-6) && Passed;
-  Passed = EvaluateNear("Parse()", "UncorrectedADCUnits", "Parse() restores the representative UncorrectedADCUnits value 3000.25",
-                        Reader.GetUncorrectedADCUnits(), 3000.25, 1e-6) && Passed;
   Passed = EvaluateNear("Parse()", "ADCUnits", "Parse() restores the representative ADCUnits value 2950.75",
                         Reader.GetADCUnits(), 2950.75, 1e-6) && Passed;
   Passed = EvaluateNear("Parse()", "Energy", "Parse() restores the representative Energy value 662.0",
@@ -430,8 +412,6 @@ bool UTNStripHit::TestStreamDatParse()
                         Reader.GetEnergyResolution(), 2.5, 1e-4) && Passed;
   Passed = EvaluateNear("Parse()", "TAC", "Parse() leaves TAC at its default value because StreamDat() does not persist it",
                         Reader.GetTAC(), 0.0, 1e-12) && Passed;
-  Passed = EvaluateNear("Parse()", "PreampTemp", "Parse() leaves PreampTemp at its default value because StreamDat() does not persist it",
-                        Reader.GetPreampTemp(), 0.0, 1e-12) && Passed;
   Passed = EvaluateFalse("Parse()", "HasCalibratedTiming", "Parse() leaves HasCalibratedTiming false because StreamDat() does not persist it",
                          Reader.HasCalibratedTiming()) && Passed;
   Passed = EvaluateFalse("Parse()", "IsGuardRing", "Parse() restores IsGuardRing false via flags", Reader.IsGuardRing()) && Passed;
@@ -443,9 +423,7 @@ bool UTNStripHit::TestStreamDatParse()
   {
     MStripHit Reused;
     Reused.SetTAC(1234.0);
-    Reused.SetTACResolution(5.0);
     Reused.SetTimingResolution(6.0);
-    Reused.SetPreampTemp(27.5);
     Reused.HasCalibratedTiming(true);
     Reused.AddOrigins({9, 10});
 
@@ -454,12 +432,8 @@ bool UTNStripHit::TestStreamDatParse()
                           Reused.Parse(ReusedLine)) && Passed;
     Passed = EvaluateNear("Parse()", "reused TAC reset", "Parse() resets TAC before applying fields from the line",
                           Reused.GetTAC(), 0.0, 1e-12) && Passed;
-    Passed = EvaluateNear("Parse()", "reused TACResolution reset", "Parse() resets TACResolution before applying fields from the line",
-                          Reused.GetTACResolution(), 0.0, 1e-12) && Passed;
     Passed = EvaluateNear("Parse()", "reused TimingResolution reset", "Parse() resets TimingResolution before applying fields from the line",
                           Reused.GetTimingResolution(), 0.0, 1e-12) && Passed;
-    Passed = EvaluateNear("Parse()", "reused PreampTemp reset", "Parse() resets PreampTemp before applying fields from the line",
-                          Reused.GetPreampTemp(), 0.0, 1e-12) && Passed;
     Passed = EvaluateFalse("Parse()", "reused HasCalibratedTiming reset", "Parse() resets HasCalibratedTiming before applying fields from the line",
                            Reused.HasCalibratedTiming()) && Passed;
     Passed = Evaluate("Parse()", "reused origins reset", "Parse() clears origins before applying fields from the line",
@@ -474,7 +448,6 @@ bool UTNStripHit::TestStreamDatParse()
     WriterHV.SetStripID(18);
     WriterHV.HasTriggered(false);
     WriterHV.SetTiming(99.5);
-    WriterHV.SetUncorrectedADCUnits(1024.0);
     WriterHV.SetADCUnits(1000.0);
     WriterHV.SetEnergy(356.0);
     WriterHV.SetEnergyResolution(1.2);
@@ -514,7 +487,6 @@ bool UTNStripHit::TestStreamDatParse()
   Preserved.SetDetectorID(7);
   Preserved.SetStripID(22);
   Preserved.SetTAC(1234.0);
-  Preserved.SetPreampTemp(27.5);
   Preserved.IsGuardRing(true);
   Preserved.AddOrigins({4, 5});
   Passed = EvaluateFalse("Parse()", "failed parse clears object", "Parse() returns false for invalid input after clearing existing state",
@@ -525,8 +497,6 @@ bool UTNStripHit::TestStreamDatParse()
                     Preserved.GetStripID(), g_UnsignedIntNotDefined) && Passed;
   Passed = EvaluateNear("Parse()", "cleared TAC", "Failed Parse() resets TAC to 0",
                         Preserved.GetTAC(), 0.0, 1e-12) && Passed;
-  Passed = EvaluateNear("Parse()", "cleared PreampTemp", "Failed Parse() resets PreampTemp to 0",
-                        Preserved.GetPreampTemp(), 0.0, 1e-12) && Passed;
   Passed = EvaluateFalse("Parse()", "cleared guard ring flag", "Failed Parse() resets IsGuardRing to false",
                          Preserved.IsGuardRing()) && Passed;
   Passed = Evaluate("Parse()", "cleared origins", "Failed Parse() clears origins",
@@ -539,7 +509,7 @@ bool UTNStripHit::TestStreamDatParse()
 
   // Parse() returns false for a line with too few fields
   MString TooFewFieldsLine("SH 2 l 37 1 500");
-  Passed = EvaluateFalse("Parse()", "too few fields", "Parse() returns false for a line with fewer than 10 fields",
+  Passed = EvaluateFalse("Parse()", "too few fields", "Parse() returns false for a line with fewer than 9 fields",
                          Dummy.Parse(TooFewFieldsLine)) && Passed;
 
   g_Verbosity = OldVerbosity;
@@ -561,7 +531,6 @@ bool UTNStripHit::TestStreamRoa()
   H.IsLowVoltageStrip(true);
   H.SetADCUnits(4053.0);
   H.SetTAC(10452.0);
-  H.SetPreampTemp(22.1);
   H.SetEnergy(661.7);
   H.SetTiming(123.0);
   H.IsGuardRing(false);
@@ -570,13 +539,13 @@ bool UTNStripHit::TestStreamRoa()
   // MakeFlags() = 0b100 = 4
   H.AddOrigins({2, 5});
 
-  // Full output: ADC + TAC + temperature + energy + timing + flags + origins
+  // Full output: ADC + TAC + energy + timing + flags + origins
   {
     ostringstream Out;
-    H.StreamRoa(Out, true, true, true, true, true, true, true);
+    H.StreamRoa(Out, true, true, true, true, true, true);
     MString S(Out.str().c_str());
     Passed = Evaluate("StreamRoa()", "full exact output", "Full StreamRoa() output matches the expected field order",
-                      S, MString("UH 0 41 l 4053 10452 22.1 661.7 123 4 2;5\n")) && Passed;
+                      S, MString("UH 0 41 l 4053 10452 661.7 123 4 2;5\n")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "starts with UH", "Full StreamRoa() output starts with 'UH'",
                           S.BeginsWith("UH")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "contains strip 41", "Full StreamRoa() output contains strip ID 41",
@@ -593,14 +562,12 @@ bool UTNStripHit::TestStreamRoa()
                           S.Contains("661.7")) && Passed;
     Passed = EvaluateTrue("StreamRoa()", "contains timing", "Full StreamRoa() output contains timing value 123",
                           S.Contains("123")) && Passed;
-    Passed = EvaluateTrue("StreamRoa()", "contains temperature", "Full StreamRoa() output contains temperature value 22.1",
-                          S.Contains("22.1")) && Passed;
   }
 
   // ADC only
   {
     ostringstream Out;
-    H.StreamRoa(Out, true, false, false, false, false, false, false);
+    H.StreamRoa(Out, true, false, false, false, false, false);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "ADC only contains 4053", "ADC-only StreamRoa() output contains ADC value 4053",
                           S.Contains("4053")) && Passed;
@@ -611,7 +578,7 @@ bool UTNStripHit::TestStreamRoa()
   // TAC only
   {
     ostringstream Out;
-    H.StreamRoa(Out, false, true, false, false, false, false, false);
+    H.StreamRoa(Out, false, true, false, false, false, false);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "TAC only contains 10452", "TAC-only StreamRoa() output contains TAC value 10452",
                           S.Contains("10452")) && Passed;
@@ -622,7 +589,7 @@ bool UTNStripHit::TestStreamRoa()
   // Energy only
   {
     ostringstream Out;
-    H.StreamRoa(Out, false, false, true, false, false, false, false);
+    H.StreamRoa(Out, false, false, true, false, false, false);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "energy only contains 661.7", "Energy-only StreamRoa() output contains energy value 661.7",
                           S.Contains("661.7")) && Passed;
@@ -633,7 +600,7 @@ bool UTNStripHit::TestStreamRoa()
   // Timing only
   {
     ostringstream Out;
-    H.StreamRoa(Out, false, false, false, true, false, false, false);
+    H.StreamRoa(Out, false, false, false, true, false, false);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "timing only contains 123", "Timing-only StreamRoa() output contains timing value 123",
                           S.Contains("123")) && Passed;
@@ -641,21 +608,10 @@ bool UTNStripHit::TestStreamRoa()
                           S.Contains("4053") == false) && Passed;
   }
 
-  // Temperature only
-  {
-    ostringstream Out;
-    H.StreamRoa(Out, false, false, false, false, true, false, false);
-    MString S(Out.str().c_str());
-    Passed = EvaluateTrue("StreamRoa()", "temperature only contains 22.1", "Temperature-only StreamRoa() output contains temperature value 22.1",
-                          S.Contains("22.1")) && Passed;
-    Passed = EvaluateTrue("StreamRoa()", "temperature only no ADC", "Temperature-only StreamRoa() output does not contain ADC value 4053",
-                          S.Contains("4053") == false) && Passed;
-  }
-
   // Flags only - MakeFlags() = 4 (HasFastTiming only); check as " 4 " to distinguish from strip ID 41
   {
     ostringstream Out;
-    H.StreamRoa(Out, false, false, false, false, false, true, false);
+    H.StreamRoa(Out, false, false, false, false, true, false);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "flags only contains 4", "Flags-only StreamRoa() output contains flags value 4",
                           S.Contains(" 4 ")) && Passed;
@@ -666,7 +622,7 @@ bool UTNStripHit::TestStreamRoa()
   // No optional fields: output contains only the fixed UH prefix fields
   {
     ostringstream Out;
-    H.StreamRoa(Out, false, false, false, false, false, false, false);
+    H.StreamRoa(Out, false, false, false, false, false, false);
     MString S(Out.str().c_str());
     Passed = Evaluate("StreamRoa()", "bare exact output", "Bare StreamRoa() output matches the fixed UH prefix fields",
                       S, MString("UH 0 41 l \n")) && Passed;
@@ -685,7 +641,7 @@ bool UTNStripHit::TestStreamRoa()
     HV.SetStripID(12);
     HV.IsLowVoltageStrip(false);
     ostringstream Out;
-    HV.StreamRoa(Out, false, false, false, false, false, false, false);
+    HV.StreamRoa(Out, false, false, false, false, false, false);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "HV marker 'h'", "StreamRoa() emits ' h ' for a strip on the high voltage side",
                           S.Contains(" h ")) && Passed;
@@ -700,7 +656,7 @@ bool UTNStripHit::TestStreamRoa()
     NoOrigins.SetStripID(1);
     NoOrigins.IsLowVoltageStrip(true);
     ostringstream Out;
-    NoOrigins.StreamRoa(Out, false, false, false, false, false, false, true);
+    NoOrigins.StreamRoa(Out, false, false, false, false, false, true);
     MString S(Out.str().c_str());
     Passed = EvaluateTrue("StreamRoa()", "no origins emits dash", "StreamRoa() emits '- ' when the origins list is empty",
                           S.Contains("- ")) && Passed;


### PR DESCRIPTION
I did the same cleanup for MStripHit.

But here are a few more old member functions around.

I would like to remove:
  //! DEPRECATED: Set whether the strip is on the low voltage side using IsLowVoltageStrip instead
  void IsXStrip(bool LowVoltageSide) { m_ReadOutElement->IsLowVoltageStrip(LowVoltageSide); }
  //! DEPRECATED: Return whether the strip is on the low voltage side using IsLowVoltageStrip instead
  bool IsXStrip() const { return m_ReadOutElement->IsLowVoltageStrip(); }
--> That is now IsLowVoltageStrip(..) REMOVE?

  //! Set the timing in nanoseconds
  void SetTiming(double Timing) { m_Timing = Timing; }
  //! Return the timing in nanoseconds
  double GetTiming() const { return m_Timing; }

  //! Set the timing resolution
  void SetTimingResolution(double TimingResolution) { m_TimingResolution = TimingResolution; }
  //! Return the timing resolution
  double GetTimingResolution() const { return m_TimingResolution; }
--> Has been replaced by the same function with name TAC instead of timing. REMOVE?


  //! Set the temperature of the relevant preamp (in degrees C)
  void SetPreampTemp(double PreampTemp) { m_PreampTemp = PreampTemp; }
  //! Return the temperature of the relevant preamp (in degrees C)
  double GetPreampTemp() const { return m_PreampTemp; }
--> What about that - we definitely have no preamps, but maybe some temperature dependence? But do we plan to store the temperature here?



