### PR TITLE
CHG: Removed old DEE modules from compilation procedure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ NUCLEARIZER              := $(TOPLEVEL)
 NUCLEARIZER_DIR          := $(NUCLEARIZER)
 NUCLEARIZER_PRG          := $(BN)/nuclearizer
 NUCLEARIZER_CXX_MAIN     := $(NUCLEARIZER_DIR)/src/MNuclearizerMain.cxx
-NUCLEARIZER_CXX_FILTERED := $(NUCLEARIZER_CXX_MAIN) $(NUCLEARIZER_DIR)/src/MModuleTemplate.cxx $(NUCLEARIZER_DIR)/src/MDetectorEffectsEngineSingleDet.cxx $(NUCLEARIZER_DIR)/src/MDetectorEffectsEngineSMEX.cxx $(NUCLEARIZER_DIR)/src/MModuleLoaderSimulationsSingleDet.cxx $(NUCLEARIZER_DIR)/src/MModuleLoaderSimulationsSMEX.cxx $(NUCLEARIZER_DIR)/src/MGUIOptionsLoaderSimulations.cxx $(NUCLEARIZER_DIR)/src/MGUIOptionsDEESMEX.cxx
+NUCLEARIZER_CXX_FILTERED := $(NUCLEARIZER_CXX_MAIN) $(NUCLEARIZER_DIR)/src/MModuleTemplate.cxx $(NUCLEARIZER_DIR)/src/MDetectorEffectsEngineSingleDet.cxx $(NUCLEARIZER_DIR)/src/MDetectorEffectsEngineSMEX.cxx $(NUCLEARIZER_DIR)/src/MModuleLoaderSimulationsSingleDet.cxx $(NUCLEARIZER_DIR)/src/MModuleLoaderSimulationsSMEX.cxx $(NUCLEARIZER_DIR)/src/MGUIOptionsLoaderSimulations.cxx
 NUCLEARIZER_CXX_FILES    := $(wildcard $(NUCLEARIZER_DIR)/src/*.cxx)
 NUCLEARIZER_CXX_FILES    := $(filter-out $(NUCLEARIZER_CXX_FILTERED),$(NUCLEARIZER_CXX_FILES))
 NUCLEARIZER_LIBS         := $(addprefix $(LB)/,$(notdir $(NUCLEARIZER_CXX_FILES:.cxx=.o)))

--- a/Makefile
+++ b/Makefile
@@ -83,15 +83,16 @@ FRETALON_LIBS         := $(addprefix $(LB)/,$(notdir $(FRETALON_CXX_FILES:.cxx=.
 FRETALON_DEP_FILES    := $(FRETALON_LIBS:.o=.d)
 
 # Nuclearizer library 
-NUCLEARIZER            := $(TOPLEVEL)
-NUCLEARIZER_DIR        := $(NUCLEARIZER)
-NUCLEARIZER_PRG        := $(BN)/nuclearizer
-NUCLEARIZER_CXX_MAIN   := $(NUCLEARIZER_DIR)/src/MNuclearizerMain.cxx
-NUCLEARIZER_CXX_FILES  := $(wildcard $(NUCLEARIZER_DIR)/src/*.cxx)
-NUCLEARIZER_CXX_FILES  := $(filter-out $(NUCLEARIZER_CXX_MAIN) $(NUCLEARIZER_DIR)/src/MModuleTemplate.cxx,$(NUCLEARIZER_CXX_FILES))
-NUCLEARIZER_LIBS       := $(addprefix $(LB)/,$(notdir $(NUCLEARIZER_CXX_FILES:.cxx=.o)))
-NUCLEARIZER_DEP_FILES  := $(NUCLEARIZER_LIBS:.o=.d)
-NUCLEARIZER_H_FILES    := $(addprefix $(NUCLEARIZER)/include/,$(notdir $(NUCLEARIZER_LIBS:.o=.h)))
+NUCLEARIZER              := $(TOPLEVEL)
+NUCLEARIZER_DIR          := $(NUCLEARIZER)
+NUCLEARIZER_PRG          := $(BN)/nuclearizer
+NUCLEARIZER_CXX_MAIN     := $(NUCLEARIZER_DIR)/src/MNuclearizerMain.cxx
+NUCLEARIZER_CXX_FILTERED := $(NUCLEARIZER_CXX_MAIN) $(NUCLEARIZER_DIR)/src/MModuleTemplate.cxx $(NUCLEARIZER_DIR)/src/MDetectorEffectsEngineSingleDet.cxx $(NUCLEARIZER_DIR)/src/MDetectorEffectsEngineSMEX.cxx $(NUCLEARIZER_DIR)/src/MModuleLoaderSimulationsSingleDet.cxx $(NUCLEARIZER_DIR)/src/MModuleLoaderSimulationsSMEX.cxx $(NUCLEARIZER_DIR)/src/MGUIOptionsLoaderSimulations.cxx $(NUCLEARIZER_DIR)/src/MGUIOptionsDEESMEX.cxx
+NUCLEARIZER_CXX_FILES    := $(wildcard $(NUCLEARIZER_DIR)/src/*.cxx)
+NUCLEARIZER_CXX_FILES    := $(filter-out $(NUCLEARIZER_CXX_FILTERED),$(NUCLEARIZER_CXX_FILES))
+NUCLEARIZER_LIBS         := $(addprefix $(LB)/,$(notdir $(NUCLEARIZER_CXX_FILES:.cxx=.o)))
+NUCLEARIZER_DEP_FILES    := $(NUCLEARIZER_LIBS:.o=.d)
+NUCLEARIZER_H_FILES      := $(addprefix $(NUCLEARIZER)/include/,$(notdir $(NUCLEARIZER_LIBS:.o=.h)))
 
 # Nuclearizer dictionary
 NUCLEARIZER_DICT_NAME=Nuclearizer_Dictionary

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -59,8 +59,6 @@ using namespace std;
 #include "MModule.h"
 #include "MGUIExpoCombinedViewer.h"
 #include "MModuleTransmitterRealta.h"
-#include "MModuleLoaderSimulationsSMEX.h"
-#include "MModuleLoaderSimulationsSingleDet.h"
 #include "MModuleLoaderSimulationsCosima.h"
 #include "MModuleLoaderMeasurementsROA.h"
 #include "MModuleLoaderMeasurementsHDF.h"
@@ -123,8 +121,6 @@ MAssembly::MAssembly()
   
   m_Supervisor->UseMultiThreading(true);
   
-  m_Supervisor->AddAvailableModule(new MModuleLoaderSimulationsSMEX());
-  m_Supervisor->AddAvailableModule(new MModuleLoaderSimulationsSingleDet());
   m_Supervisor->AddAvailableModule(new MModuleLoaderSimulationsCosima());
   m_Supervisor->AddAvailableModule(new MModuleLoaderMeasurementsROA());
   m_Supervisor->AddAvailableModule(new MModuleLoaderMeasurementsHDF());


### PR DESCRIPTION
I removed the old DEE modules from the code and compilation, but kept the files around.

This addresses: 
https://github.com/cositools/nuclearizer/issues/170