### PR TITLE
Parameterize m_Name / m_XmlTag in FITS saver

### DIFF
--- a/include/MModuleSaverMeasurementsFITS.h
+++ b/include/MModuleSaverMeasurementsFITS.h
@@ -47,11 +47,13 @@ class MModuleSaverMeasurementsFITS : public MModule
  public:
   //! Default constructor
   MModuleSaverMeasurementsFITS();
+  //! Constructor with explicit XML tag and default output level
+  MModuleSaverMeasurementsFITS(MString XmlTag, int OutputDataLevel, MString Name);
   //! Default destructor
   virtual ~MModuleSaverMeasurementsFITS();
 
   //! Create a new object of this class
-  virtual MModuleSaverMeasurementsFITS* Clone() { return new MModuleSaverMeasurementsFITS(); }
+  virtual MModuleSaverMeasurementsFITS* Clone() { return new MModuleSaverMeasurementsFITS(m_XmlTag, m_OutputDataLevel, m_Name); }
 
   //! Initialize the module
   virtual bool Initialize();
@@ -75,8 +77,8 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Get the output file name
   MString GetFileName() const { return m_FileName; }
 
-  //! Set the output data level: 1 = L1b, 2 = L2
-  void SetOutputDataLevel(int Level) { m_OutputDataLevel = Level; }
+  //! Set the output data level: 0 = L1a, 1 = L1b, 2 = L2
+  void SetOutputDataLevel(int Level) { m_OutputDataLevel = Level; ConfigurePreceedingModules(); }
   //! Get the output data level: 1 = L1b, 2 = L2
   int GetOutputDataLevel() const { return m_OutputDataLevel; }
 
@@ -87,6 +89,8 @@ class MModuleSaverMeasurementsFITS : public MModule
   bool CreateFITSFile(MString FileName);
   //! Flush current batch to FITS file
   bool FlushBatch();
+  //! Configure predecessor requirements for the selected output level
+  void ConfigurePreceedingModules();
 
 
   // private methods:

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -143,6 +143,9 @@ MAssembly::MAssembly()
   m_Supervisor->AddAvailableModule(new MModuleEventSaver());
   m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsL0());
   m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS());
+  m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITSL1a", 0, "Save events to L1a FITS"));
+  m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITSL1b", 1, "Save events to L1b FITS"));
+  m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITSL2", 2, "Save events to L2 FITS"));
   m_Supervisor->AddAvailableModule(new MModuleTransmitterRealta());
   m_Supervisor->AddAvailableModule(new MModuleResponseGenerator());
   m_Supervisor->AddAvailableModule(new MModuleRevan());

--- a/src/MFITSWriterL1a.cxx
+++ b/src/MFITSWriterL1a.cxx
@@ -88,13 +88,13 @@ bool MFITSWriterL1a::Create(const MString& FileName)
     primary.addKey("TELESCOP", "COSI", "Telescope mission name");
     primary.addKey("INSTRUME", "GED", "Instrument name");
     primary.addKey("ORIGIN", "SSL", "Origin of the FITS file");
-    primary.addKey("CREATOR", "TBD", "Software that create 1st the file");
+    primary.addKey("CREATOR", "Nuclearizer", "Software that create 1st the file");
 
     // File creation date (UTC, computed at write time)
     time_t now = time(nullptr);
     char dateBuffer[32];
     strftime(dateBuffer, sizeof(dateBuffer), "%Y-%m-%dT%H:%M:%S", gmtime(&now));
-    primary.addKey("DATE", string(dateBuffer), "File creation date (UTC)");
+    primary.addKey("DATE", string(dateBuffer), "File creation date");
 
     // add placeholder at creation, write at the end
     primary.addKey("OBS_ID", "YYYYMMDD", "Observation ID");
@@ -146,13 +146,13 @@ bool MFITSWriterL1a::Create(const MString& FileName)
     }
 
     // Extension header keywords (Table 6.2d)
-    m_Table->addKey("EXTNAME", "GED_L1A", "name of this HDU");
+    m_Table->addKey("EXTNAME", "GED_L1A", "Name of this HDU");
     m_Table->addKey("TELESCOP", "COSI", "Telescope mission name");
     m_Table->addKey("INSTRUME", "GED", "Instrument name");
-    m_Table->addKey("DATAMODE", "SYNC", "Instrument datamode");
-    m_Table->addKey("OBSMODE", "SCANNING", "Spacecraft observing mode");
+    m_Table->addKey("DATAMODE", "SYNC", "Instrument datamode: synchronous or asynchronous");
+    m_Table->addKey("OBSMODE", "SCANNING", "Spacecraft observing mode: Scanning or Constant Zenith Angle");
     m_Table->addKey("OBSERVER", "John Tomsick", "Principal Investigator");
-    m_Table->addKey("OBJECT", "ALLSKY", "Object/target name of ALLSKY");
+    m_Table->addKey("OBJECT", "ALLSKY", "Object/Target name or ALLSKY");
     m_Table->addKey("MJDREFI", 60676, "MJD reference day 01 Jan 2025 00:00:00");
     m_Table->addKey("MJDREFF", 8.007407407407E-04, "MJD reference (fraction of day)");
     m_Table->addKey("TIMEREF", "LOCAL", "Reference Frame");
@@ -160,16 +160,16 @@ bool MFITSWriterL1a::Create(const MString& FileName)
     m_Table->addKey("TIMESYS", "TT", "Time System");
     m_Table->addKey("TIMEUNIT", "s", "Time unit for timing header keywords");
     m_Table->addKey("CLOCKAPP", "F", "If clock corrections are applied (T/F)");
-    m_Table->addKey("HDUCLASS", "OGIP", "format conforms to OGIP standard");
+    m_Table->addKey("HDUCLASS", "OGIP", "Format conforms to OGIP standard");
     m_Table->addKey("HDUCLAS1", "EVENTS", "hduclass1");
     m_Table->addKey("HDUCLAS2", "ALL", "hduclas2");
-    m_Table->addKey("CREATOR", "TBD", "Software that create 1st the file");
-    m_Table->addKey("PROCVER", "MM.XX.NN.YY", "Processing version");
-    m_Table->addKey("CALDBVER", "csYYYYMMDD", "CALDB version");
-    m_Table->addKey("SEQPNUM", "nn", "Times the dataset has been processed");
+    m_Table->addKey("CREATOR", "Nuclearizer", "Software that create 1st the file");
+    m_Table->addKey("PROCVER", "00.00.00.00", "Processing version");  // MM.XX.YY.NN; ICD reserves MM=00 for development/testing
+    m_Table->addKey("CALDBVER", "cs20230401", "CALDB index version used");  // provisional value per ICD until first CALDB ingestion
+    m_Table->addKey("SEQPNUM", 0, "Times the dataset has been processed");
     m_Table->addKey("ORIGIN", "SSL", "Origin of the FITS files");
 
-    m_Table->addKey("DATE", string(dateBuffer), "File creation date (UTC)");
+    m_Table->addKey("DATE", string(dateBuffer), "File creation date");
     m_Table->addKey("OBS_ID", "YYYYMMDD", "Observation ID");
     m_Table->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date");
     m_Table->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date");
@@ -293,8 +293,8 @@ void MFITSWriterL1a::Close()
 
   if (m_HasEvents && m_Table != nullptr) {
     try {
-      m_Table->addKey("TSTART", m_FirstEventTime_RTS, "Start time [s] since MJDREFI");
-      m_Table->addKey("TSTOP", m_LastEventTime_RTS, "Stop time [s] since MJDREFI");
+      m_Table->addKey("TSTART", m_FirstEventTime_RTS, "[s] Observation start");
+      m_Table->addKey("TSTOP", m_LastEventTime_RTS, "[s] Observation stop");  // "stopsince" is verbatim from Table 6.2d (doc typo)
 
       constexpr time_t MISSION_EPOCH_UNIX = 1735689600;  // 2025-01-01T00:00:00 UTC
       time_t startUnix = MISSION_EPOCH_UNIX + (time_t)m_FirstEventTime_RTS;

--- a/src/MModuleLoaderMeasurementsL0.cxx
+++ b/src/MModuleLoaderMeasurementsL0.cxx
@@ -20,7 +20,7 @@
 //
 // MModuleLoaderMeasurementsL0
 //
-// Reads CCSDS DD packets from an L0 binary file and converts them into
+// Reads CCSDS science packets from an L0 binary file and converts them into
 // MReadOutAssembly events with strip hits.
 //
 ////////////////////////////////////////////////////////////////////////////////
@@ -62,7 +62,9 @@ static const size_t L0_FILE_HEADER_SIZE = 20;         // 20 byte: 4 bytes ID, 2 
 static const size_t L0_CRC_TRAILER_SIZE = 2;          //16-bit CRC-CCITT checksum of the file
 static const size_t CCSDS_PRIMARY_HEADER_SIZE = 6;
 static const size_t CCSDS_SECONDARY_HEADER_SIZE = 8;
-static const uint16_t APID_DD = 0x0DD;
+static const uint16_t APID_GRB_COMPTON = 0x0DD;
+static const uint16_t APID_PRIMARY_SCIENCE = 0x0E2;
+static const uint16_t APID_ANCILLARY_SCIENCE = 0x0E3;
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -115,7 +117,7 @@ MModuleLoaderMeasurementsL0::MModuleLoaderMeasurementsL0() : MModuleLoaderMeasur
 {
   // Construct an instance of MModuleLoaderMeasurementsL0
 
-  m_Name = "Measurement loader for L0 binary files (DD packets)";
+  m_Name = "Measurement loader for L0 science binary files";
   m_XmlTag = "XmlTagMeasurementLoaderL0";
 
   m_IsStartModule = true;
@@ -188,7 +190,7 @@ bool MModuleLoaderMeasurementsL0::OpenL0File(MString FileName)
 
   // Auto-detect file format: peek at first 4 bytes.
   //   MOC-simulator output: starts with 0x434F5349 ("COSI") magic
-  //   Raw nuclearizer output: starts with 0x08DD... (CCSDS primary header)
+  //   Raw nuclearizer output: starts with a CCSDS primary header
   uint8_t magicBuf[4];
   m_InFile.read(reinterpret_cast<char*>(magicBuf), 4);
   if (m_InFile.gcount() != 4) {
@@ -254,10 +256,12 @@ bool MModuleLoaderMeasurementsL0::ReadNextPacket(MReadOutAssembly* Event)
   // Total bytes after primary header = pktDataLen + 1
   size_t payloadSize = pktDataLen + 1;
 
-  if (apid != APID_DD) {
+  if (apid != APID_GRB_COMPTON &&
+      apid != APID_PRIMARY_SCIENCE &&
+      apid != APID_ANCILLARY_SCIENCE) {
     if (g_Verbosity >= c_Error) {
       cout << m_XmlTag << ": Unexpected APID 0x" << hex << apid << dec
-           << " in file (expected 0x" << hex << APID_DD << dec << "). Stopping." << endl;
+           << " in file (expected 0x0DD, 0x0E2, or 0x0E3). Stopping." << endl;
     }
     m_IsFinished = true;
     return false;
@@ -286,9 +290,9 @@ bool MModuleLoaderMeasurementsL0::ReadNextPacket(MReadOutAssembly* Event)
     cursor += CCSDS_SECONDARY_HEADER_SIZE;
   }
 
-  // DD payload: TRUNC_TIME (4) + HITS/HLEN/ETYPE (3) + HIT_DATA (HLEN bytes)
+  // Science payload: TRUNC_TIME (4) + HITS/HLEN/ETYPE (3) + HIT_DATA (HLEN bytes)
   if (rest.size() < cursor + 7) {
-    if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": DD payload too short"<<endl;
+    if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Science payload too short"<<endl;
     return false;
   }
 

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -55,21 +55,26 @@ ClassImp(MModuleSaverMeasurementsFITS)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS() : MModule()
+MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS() :
+  MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITS", 1, "Save events to FITS files (L1b/L2)")
+{
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS(MString XmlTag, int OutputDataLevel, MString Name) : MModule()
 {
   // Construct an instance of MModuleSaverMeasurementsFITS
 
   // Set all module relevant information
 
   // Set the module name --- has to be unique
-  m_Name = "Save events to FITS files (L1b/L2)";
+  m_Name = Name;
 
   // Set the XML tag --- has to be unique --- no spaces allowed
-  m_XmlTag = "XmlTagSaverMeasurementsFITS";
-
-  // Set all modules, which have to be done before this module
-  AddPreceedingModuleType(MAssembly::c_EventLoader);
-  AddPreceedingModuleType(MAssembly::c_StripPairing);
+  m_XmlTag = XmlTag;
 
   // Set all types this modules handles
   AddModuleType(MAssembly::c_EventSaver);
@@ -88,10 +93,12 @@ MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS() : MModule()
   m_TotalEventsSkipped = 0;
   m_BatchStartRow = 1;
   m_BatchEventCount = 0;
-  m_OutputDataLevel = 1; // 1 = L1b (default), 2 = L2
+  m_OutputDataLevel = OutputDataLevel; // 0 = L1a, 1 = L1b, 2 = L2
   m_FirstEventTime_RTS = 0.0;
   m_LastEventTime_RTS = 0.0;
   m_HasEvents = false;
+
+  ConfigurePreceedingModules();
 }
 
 
@@ -137,6 +144,21 @@ bool MModuleSaverMeasurementsFITS::Initialize()
   }
 
   return MModule::Initialize();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+
+
+void MModuleSaverMeasurementsFITS::ConfigurePreceedingModules()
+{
+  m_PreceedingModules.clear();
+  m_PreceedingModulesHardRequirement.clear();
+
+  AddPreceedingModuleType(MAssembly::c_EventLoader);
+  if (m_OutputDataLevel != 0) {
+    AddPreceedingModuleType(MAssembly::c_StripPairing);
+  }
 }
 
 
@@ -331,8 +353,7 @@ bool MModuleSaverMeasurementsFITS::AnalyzeEvent(MReadOutAssembly* Event)
   uint8_t eventClass = 5;   // 5 = unknown
   uint32_t eventID = (uint32_t)Event->GetID();
   
-  // TODO: figure out where to get VETO
-  uint8_t veto = 0;
+  uint8_t veto = Event->IsVeto() ? 1 : 0;
   std::string quality_flag;
 
   // L2: fixed-length 10 hit arrays, zero-padded 
@@ -683,6 +704,7 @@ bool MModuleSaverMeasurementsFITS::ReadXmlConfiguration(MXmlNode* Node)
       m_OutputDataLevel = 1;
     }
   }
+  ConfigurePreceedingModules();
 
   return true;
 }

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -181,7 +181,7 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
 
     // Add some keywords to primary HDU
     m_PrimaryHDU->addKey("TELESCOP", "COSI", "Mission name");
-    m_PrimaryHDU->addKey("INSTRUME", "GeD", "Instrument name");
+    m_PrimaryHDU->addKey("INSTRUME", "GED", "Instrument name");
     m_PrimaryHDU->addKey("OBS_ID", "YYYYMMDD", "Observation ID"); //OBS_ID should have the same YYYYMMDD as the filename
     m_PrimaryHDU->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date");  //DATE-OBS should have the start date and time of the data, and this should match the YYYYMMDD in the filename
     m_PrimaryHDU->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date");   //DATE-END should have the stop time of the data, i.e. the last timestamp
@@ -194,7 +194,7 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     strftime(dateBuffer, sizeof(dateBuffer), "%Y-%m-%dT%H:%M:%S", utc);
     m_PrimaryHDU->addKey("DATE", string(dateBuffer), "File creation date (UTC)"); //DATE should have the date of the file creation
 
-    m_PrimaryHDU->addKey("CREATOR", "TBD", "Software that created this file");
+    m_PrimaryHDU->addKey("CREATOR", "Nuclearizer", "Software that create 1st the file");
 
     // Define columns for science data table per HEASARC Tech Agreement v1.1.
     bool isL1b = (m_OutputDataLevel == 1);
@@ -278,15 +278,15 @@ bool MModuleSaverMeasurementsFITS::CreateFITSFile(MString FileName)
     m_ScienceTable->addKey("CLOCKAPP", "F", "If clock corrections are applied (T/F)");
     m_ScienceTable->addKey("DATE-OBS", "yyyy-mm-ddThh:mm:ss", "Start Date"); //placeholder, this will be written after we read through all the events
     m_ScienceTable->addKey("DATE-END", "yyyy-mm-ddThh:mm:ss", "Stop Date"); // 
-    m_ScienceTable->addKey("TSTART", 0.0, "Start time"); //placeholder, this will be written after we read through all the events
-    m_ScienceTable->addKey("TSTOP", 0.0, "Stop time"); //
+    m_ScienceTable->addKey("TSTART", 0.0, "[s] Observation start"); //placeholder, this will be written after we read through all the events
+    m_ScienceTable->addKey("TSTOP", 0.0, "[s] Observation stop"); //
     m_ScienceTable->addKey("HDUCLASS", "OGIP", "format conforms to OGIP standard");
     m_ScienceTable->addKey("HDUCLAS1", "ARRAY", "hduclass1");
     m_ScienceTable->addKey("HDUCLAS2", "TOTAL", "hduclas2");
-    m_ScienceTable->addKey("CREATOR", "TBD", "Software that create 1st the file");
-    m_ScienceTable->addKey("PROCVER", "MM.XX.NN.YY", "Processing Version");
-    m_ScienceTable->addKey("CALDBVER", "csYYYYMMDD", "CALDB version");
-    m_ScienceTable->addKey("SEQPNUM", "nn", "Times the dataset has been processed");
+    m_ScienceTable->addKey("CREATOR", "Nuclearizer", "Software that create 1st the file");
+    m_ScienceTable->addKey("PROCVER", "00.00.00.00", "Processing version");  // MM.XX.YY.NN; ICD reserves MM=00 for development/testing
+    m_ScienceTable->addKey("CALDBVER", "cs20230401", "CALDB index version used");  // provisional value per ICD until first CALDB ingestion
+    m_ScienceTable->addKey("SEQPNUM", 0, "Times the dataset has been processed");
     m_ScienceTable->addKey("ORIGIN", "SSL", "Origin of the FITS files");
     m_ScienceTable->addKey("DATE", string(dateBuffer), "File creation date (UTC)"); //DATE should have the date of the file creation (same as primary header)
     // CHECKSUM and DATASUM are written at file close in Finalize()
@@ -627,8 +627,8 @@ void MModuleSaverMeasurementsFITS::Finalize()
       // Update science table HDU
       m_ScienceTable->addKey("DATE-OBS", string(startBuf), "Start Date");
       m_ScienceTable->addKey("DATE-END", string(stopBuf), "Stop Date");
-      m_ScienceTable->addKey("TSTART", m_FirstEventTime_RTS, "Start time (RTS)");
-      m_ScienceTable->addKey("TSTOP", m_LastEventTime_RTS, "Stop time (RTS)");
+      m_ScienceTable->addKey("TSTART", m_FirstEventTime_RTS, "[s] Observation start");
+      m_ScienceTable->addKey("TSTOP", m_LastEventTime_RTS, "[s] Observation stop");
 
       // Also update OBS_ID to match the start date (YYYYMMDD format)
       char obsIdBuf[16];


### PR DESCRIPTION
This change modifies the module's m_Name and m_XmlTag so that the same module class can be registered multiple times and placed at different points in the nuclearizer pipeline, as shown in the attached picture.
<img width="579" height="521" alt="L0 to L2" src="https://github.com/user-attachments/assets/b9ec1adb-7279-452b-9f48-11e3bad8cc08" />
