### PR TITLE
FIX: Assign correct DetIDs to strip detectors when loading detector dimensions

### DIFF
--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -455,9 +455,30 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
     if (det->GetTypeName() == "Strip3D") {
       if (det->GetNSensitiveVolumes() == 1) {
         MDVolume* vol = det->GetSensitiveVolume(0);
-        string det_name = vol->GetName().GetString();
-        if (find(DetectorNames.begin(), DetectorNames.end(), det_name) == DetectorNames.end()) {
-          DetectorNames.push_back(det_name);
+        MString DetectorName = det->GetName();
+        string DetName = DetectorName.GetString();
+        
+        // Check that the DetID agrees with the naming scheme GeD_X
+        if (DetectorName.BeginsWith("GeD_") == true) {
+          DetectorName.RemoveAllInPlace("GeD_"); // The number after GeD is the COSI detector ID
+          if (DetID != DetectorName.ToUnsignedInt()) {
+            if (g_Verbosity >= c_Error) {
+              cout << "ERROR in MModuleDepthCalibration::Initialize: Non-matching DetID="<<DetID<<" for detector "<<DetName<<endl;
+            }
+            // Return false if this is running with the COSI SMEX payload mass model
+            if (Geometry->GetName() == "COSI-SMEX-Payload"){
+              return false;
+            }
+          }
+        } else if (Geometry->GetName() == "COSI-SMEX-Payload") {
+          if (g_Verbosity >= c_Error) {
+            cout << "ERROR in MModuleDepthCalibration::Initialize: COSI-SMEX-Payload expects all Strip3D detectors to follow the name scheme GeD_X"<<endl;
+          }
+          return false;
+        }
+
+        if (find(DetectorNames.begin(), DetectorNames.end(), DetName) == DetectorNames.end()) {
+          DetectorNames.push_back(DetName);
           m_Thicknesses[DetID] = 2 * (det->GetStructuralSize().GetZ());
           MDStrip3D* strip = dynamic_cast<MDStrip3D*>(det);
           m_XPitches[DetID] = strip->GetPitchX();
@@ -466,7 +487,7 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
           m_NYStrips[DetID] = strip->GetNStripsY();
 
           if (g_Verbosity >= c_Info) {
-            cout << "Found detector " << det_name << " corresponding to DetID=" << DetID << "." << endl;
+            cout << "Found detector " << DetName << " corresponding to DetID=" << DetID << "." << endl;
             cout << "Detector thickness: " << m_Thicknesses[DetID] << endl;
             cout << "Number of X strips: " << m_NXStrips[DetID] << endl;
             cout << "Number of Y strips: " << m_NYStrips[DetID] << endl;
@@ -478,7 +499,7 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
           DetID += 1;
         } else {
           if (g_Verbosity >= c_Error) {
-            cout<<"ERROR in MModuleDepthCalibration::Initialize: Found a duplicate detector: "<<det_name<<endl;
+            cout<<"ERROR in MModuleDepthCalibration::Initialize: Found a duplicate detector: "<<DetName<<endl;
           }
         }
       } else {

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -441,10 +441,11 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
   vector<MDDetector*> DetList = Geometry->GetDetectorList();
 
   // Look through the Geometry and get the names and thicknesses of all the detectors.
+  unsigned int DetID = -1;
   for (unsigned int i = 0; i < DetList.size(); ++i) {
     // For now, DetID is in order of detectors, which puts contraints on how the geometry file should be written.
     // If using the card cage at UCSD, default to DetID=11.
-    unsigned int DetID = i;
+    
     if (m_UCSDOverride == true) {
       DetID = 11;
     }
@@ -456,6 +457,9 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
         MDVolume* vol = det->GetSensitiveVolume(0);
         string det_name = vol->GetName().GetString();
         if (find(DetectorNames.begin(), DetectorNames.end(), det_name) == DetectorNames.end()) {
+          if (m_UCSDOverride == false){
+            DetID += 1;
+          }
           DetectorNames.push_back(det_name);
           m_Thicknesses[DetID] = 2 * (det->GetStructuralSize().GetZ());
           MDStrip3D* strip = dynamic_cast<MDStrip3D*>(det);

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -440,26 +440,23 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
   // ie DetID=0 should be the 0th detector in m_Detectors, DetID=1 should the 1st, etc.
   vector<MDDetector*> DetList = Geometry->GetDetectorList();
 
-  // Look through the Geometry and get the names and thicknesses of all the detectors.
-  unsigned int DetID = -1;
+  // Look through the Geometry and get the names and thicknesses of all Strip3D detectors.
+  vector<string> DetectorNames;
+  unsigned int DetID = 0;
+
   for (unsigned int i = 0; i < DetList.size(); ++i) {
     // For now, DetID is in order of detectors, which puts contraints on how the geometry file should be written.
     // If using the card cage at UCSD, default to DetID=11.
-    
     if (m_UCSDOverride == true) {
       DetID = 11;
     }
 
     MDDetector* det = DetList[i];
-    vector<string> DetectorNames;
     if (det->GetTypeName() == "Strip3D") {
       if (det->GetNSensitiveVolumes() == 1) {
         MDVolume* vol = det->GetSensitiveVolume(0);
         string det_name = vol->GetName().GetString();
         if (find(DetectorNames.begin(), DetectorNames.end(), det_name) == DetectorNames.end()) {
-          if (m_UCSDOverride == false){
-            DetID += 1;
-          }
           DetectorNames.push_back(det_name);
           m_Thicknesses[DetID] = 2 * (det->GetStructuralSize().GetZ());
           MDStrip3D* strip = dynamic_cast<MDStrip3D*>(det);
@@ -478,6 +475,7 @@ bool MModuleDepthCalibration::LoadDetectorDimensions(MDGeometryQuest* Geometry)
           }
           m_DetectorIDs.push_back(DetID);
           m_Detectors[DetID] = det;
+          DetID += 1;
         } else {
           if (g_Verbosity >= c_Error) {
             cout<<"ERROR in MModuleDepthCalibration::Initialize: Found a duplicate detector: "<<det_name<<endl;

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -79,18 +79,17 @@ bool MSubModuleChargeTransport::Initialize()
   // ie DetID=0 should be the 0th detector in m_Detectors, DetID=1 should the 1st, etc.
   vector<MDDetector*> DetList = m_Geometry->GetDetectorList();
 
-  // Look through the Geometry and get the names and thicknesses of all the detectors.
-  unsigned int DetID = -1;
+  // Look through the Geometry and get the names and thicknesses of all Strip3D detectors.
+  vector<string> DetectorNames;
+  unsigned int DetID = 0;
+  
   for(unsigned int i = 0; i < DetList.size(); ++i){
-
     MDDetector* det = DetList[i];
-    vector<string> DetectorNames;
     if (det->GetTypeName() == "Strip3D") {
       if (det->GetNSensitiveVolumes() == 1) {
         MDVolume* vol = det->GetSensitiveVolume(0);
         string det_name = vol->GetName().GetString();
         if (find(DetectorNames.begin(), DetectorNames.end(), det_name) == DetectorNames.end()) {
-          DetID += 1;
           DetectorNames.push_back(det_name);
           m_Thicknesses[DetID] = 2*(det->GetStructuralSize().GetZ());
           MDStrip3D* strip = dynamic_cast<MDStrip3D*>(det);
@@ -125,6 +124,7 @@ bool MSubModuleChargeTransport::Initialize()
           }
           m_DetectorIDs.push_back(DetID);
           m_Detectors[DetID] = det;
+          DetID += 1;
         } else {
           cout << "ERROR in MSubModuleChargeTransport::Initialize: Found a duplicate detector: " << det_name << endl;
         }

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -80,9 +80,8 @@ bool MSubModuleChargeTransport::Initialize()
   vector<MDDetector*> DetList = m_Geometry->GetDetectorList();
 
   // Look through the Geometry and get the names and thicknesses of all the detectors.
+  unsigned int DetID = -1;
   for(unsigned int i = 0; i < DetList.size(); ++i){
-
-    unsigned int DetID = i;
 
     MDDetector* det = DetList[i];
     vector<string> DetectorNames;
@@ -91,6 +90,7 @@ bool MSubModuleChargeTransport::Initialize()
         MDVolume* vol = det->GetSensitiveVolume(0);
         string det_name = vol->GetName().GetString();
         if (find(DetectorNames.begin(), DetectorNames.end(), det_name) == DetectorNames.end()) {
+          DetID += 1;
           DetectorNames.push_back(det_name);
           m_Thicknesses[DetID] = 2*(det->GetStructuralSize().GetZ());
           MDStrip3D* strip = dynamic_cast<MDStrip3D*>(det);

--- a/src/MSubModuleChargeTransport.cxx
+++ b/src/MSubModuleChargeTransport.cxx
@@ -88,9 +88,30 @@ bool MSubModuleChargeTransport::Initialize()
     if (det->GetTypeName() == "Strip3D") {
       if (det->GetNSensitiveVolumes() == 1) {
         MDVolume* vol = det->GetSensitiveVolume(0);
-        string det_name = vol->GetName().GetString();
-        if (find(DetectorNames.begin(), DetectorNames.end(), det_name) == DetectorNames.end()) {
-          DetectorNames.push_back(det_name);
+        MString DetectorName = det->GetName();
+        string DetName = DetectorName.GetString();
+        
+        // Check that the DetID agrees with the naming scheme GeD_X
+        if (DetectorName.BeginsWith("GeD_") == true) {
+          DetectorName.RemoveAllInPlace("GeD_"); // The number after GeD is the COSI detector ID
+          if (DetID != DetectorName.ToUnsignedInt()) {
+            if (g_Verbosity >= c_Error) {
+              cout << "ERROR in MModuleDepthCalibration::Initialize: Non-matching DetID="<<DetID<<" for detector "<<DetName<<endl;
+            }
+            // Return false if this is running with the COSI SMEX payload mass model
+            if (m_Geometry->GetName() == "COSI-SMEX-Payload"){
+              return false;
+            }
+          }
+        } else if (m_Geometry->GetName() == "COSI-SMEX-Payload") {
+          if (g_Verbosity >= c_Error) {
+            cout << "ERROR in MModuleDepthCalibration::Initialize: COSI-SMEX-Payload expects all Strip3D detectors to follow the name scheme GeD_X"<<endl;
+          }
+          return false;
+        }
+
+        if (find(DetectorNames.begin(), DetectorNames.end(), DetName) == DetectorNames.end()) {
+          DetectorNames.push_back(DetName);
           m_Thicknesses[DetID] = 2*(det->GetStructuralSize().GetZ());
           MDStrip3D* strip = dynamic_cast<MDStrip3D*>(det);
           m_XPitches[DetID] = strip->GetPitchX();
@@ -112,7 +133,7 @@ bool MSubModuleChargeTransport::Initialize()
           }
           
           if (g_Verbosity >= c_Info) {
-            cout << "Found detector " << det_name << " corresponding to DetID=" << DetID << "." << endl;
+            cout << "Found detector " << DetName << " corresponding to DetID=" << DetID << "." << endl;
             cout << "Detector width (X): " << m_XWidths[DetID] << endl;
             cout << "Detector width (Y): " << m_YWidths[DetID] << endl;
             cout << "Detector radius (R): " << m_Radii[DetID] << endl;
@@ -126,7 +147,7 @@ bool MSubModuleChargeTransport::Initialize()
           m_Detectors[DetID] = det;
           DetID += 1;
         } else {
-          cout << "ERROR in MSubModuleChargeTransport::Initialize: Found a duplicate detector: " << det_name << endl;
+          cout << "ERROR in MSubModuleChargeTransport::Initialize: Found a duplicate detector: " << DetName << endl;
         }
       } else {
         cout << "ERROR in MSubModuleChargeTransport::Initialize: Found a Strip3D detector with " << det->GetNSensitiveVolumes() << " Sensitive Volumes." << endl;


### PR DESCRIPTION
Currently, with the [massmodel-cosi-payload](https://github.com/cositools/massmodel-cosi-payload) (and probably every other massmodel using more than just 1 detector), when loading the detector dimensions for the `MModuleDepthCalibration` and `MSubModuleChargeTransport`, we assign `DetIDs` to all detectors in the `DetectorList`.
However, this `DetectorList` also includes the guard ring detectors.
Thus, the germanium strip detectors are only assigned even `DetIDs` in increments of 2:
```
Found detector GeWafer_Q0_L0 corresponding to DetID=0.
Detector thickness: 1.583
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
Found detector GeWafer_Q0_L1 corresponding to DetID=2.
Detector thickness: 1.55
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
Found detector GeWafer_Q0_L2 corresponding to DetID=4.
Detector thickness: 1.583
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
Found detector GeWafer_Q0_L3 corresponding to DetID=6.
Detector thickness: 1.568
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
...
```

In this PR, we only increment the `DetID` once we actually have found a `"Strip3D"` detector, to avoid incrementing the `DetID` also for the `Simple` guard ring detectors.

```
Found detector GeWafer_Q0_L0 corresponding to DetID=0.
Detector thickness: 1.583
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
Found detector GeWafer_Q0_L1 corresponding to DetID=1.
Detector thickness: 1.55
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
Found detector GeWafer_Q0_L2 corresponding to DetID=2.
Detector thickness: 1.583
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
Found detector GeWafer_Q0_L3 corresponding to DetID=3.
Detector thickness: 1.568
Number of X strips: 64
Number of Y strips: 64
X strip pitch: 0.1162
Y strip pitch: 0.1162
...
```

I'm also keeping the `m_UCSDOverwrite` to assign a `DetID` of `11`