### PR TITLE
ADD: Automatically track code coverage of unit tests and upload to codecov

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
           create-args: >-
             root=6.32 geant4=11.2 healpix_cxx
             pkg-config make cmake cxx-compiler ccache
-            ccfits=2.6 cfitsio=4.3 hdf5=1.14
+            ccfits=2.6 cfitsio=4.3 hdf5=1.14 gcovr
           cache-environment: true
           cache-environment-key: micromamba-${{ runner.os }}-root6.32-geant4.11.2-ccfits2.6-cfitsio4.3-hdf5.1.14
 
@@ -122,7 +122,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/lib ${{ github.workspace }}/bin
           ln -sf $MEGALIB/bin/generatelinkdef ${{ github.workspace }}/bin/generatelinkdef
           cd ${{ github.workspace }}
-          make CXX="ccache g++" CC="ccache gcc" LB=${{ github.workspace }}/lib BN=${{ github.workspace }}/bin -j$(nproc)
+          make COVERAGE=1 CXX="ccache g++" CC="ccache gcc" LB=${{ github.workspace }}/lib BN=${{ github.workspace }}/bin -j$(nproc)
 
       - name: Copy Nuclearizer outputs into MEGAlib tree
         shell: micromamba-shell {0}
@@ -139,7 +139,7 @@ jobs:
           set -euo pipefail
           cd $NUCLEARIZER
           export PATH=$MEGALIB/bin:$PATH
-          make unittests CXX="ccache g++" CC="ccache gcc" LB=${{ github.workspace }}/lib BN=${{ github.workspace }}/bin -j$(nproc)
+          make unittests COVERAGE=1 CXX="ccache g++" CC="ccache gcc" LB=${{ github.workspace }}/lib BN=${{ github.workspace }}/bin -j$(nproc)
           ${{ github.workspace }}/bin/UTNRunner
 
       - name: ccache stats
@@ -153,3 +153,20 @@ jobs:
         with:
           name: failure-logs
           path: /tmp/*.log
+
+      - name: Generate Coverage Report
+        shell: micromamba-shell {0}
+        run: |
+          set -euo pipefail
+          gcovr -r . $MEGALIB/lib/ $MEGALIB/bin/ \
+            --xml coverage.xml \
+            --exclude '$NUCLEARIZER/apps/.*' \
+            --exclude '$NUCLEARIZER/unittests/.*' \
+            -j $(nproc)
+
+      - name: Upload Report to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: true

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,12 @@ NUCLEARIZER_UT_PRGS := $(patsubst $(NUCLEARIZER_DIR)/unittests/%,$(BN)/%,$(NUCLE
 ALLLIBS = -L$(LB) -lResponseCreator -lFretalonBase -lSivan -lRevanGui -lRevan -lMimrec -lGeomega -lSpectralyzeGui -lSpectralyze -lCommonMisc -lCommonGui -L$(MEGALIB)/lib -L$(LB) 
 
 
+# Coverage-specific flags (added when standard COVERAGE=1 is passed)
+ifeq ($(COVERAGE), 1)
+    CXXFLAGS += -O0 -g --coverage
+    LDFLAGS  += --coverage
+endif
+
 #----------------------------------------------------------------
 # Command rules
 #

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+# configuration related to pull request comments
+comment: false # do not comment PR with the result
+
+ignore:
+  - apps/
+  - unittests/
+
+coverage:
+  range: 20..90 # coverage lower than 20 is red, higher than 90 green, between color code
+
+  status:
+    project: # settings affecting project coverage
+      default:
+        target: auto # auto % coverage target
+        threshold: 5%  # allow for 5% reduction of coverage without failing


### PR DESCRIPTION
In this PR, I am adding the possibility to determine the code coverage of the nuclearizer unit tests, and uploading the results to codecov.

I tried this out on my fork of nuclearizer and it seems to work:
https://app.codecov.io/gh/fhagemann/nuclearizer

<img width="797" height="429" alt="image" src="https://github.com/user-attachments/assets/c1103516-ca47-419a-967b-f458275b646a" />

The changes required to achieve this are:
- adding an environmental variable `COVERAGE` in the `Makefile` that compiles nuclearizer with the `--coverage` flag.
- Running GitHub actions with `COVERAGE=1` , generating the codecov XML report via `gcovr` and uploading the result to codecov
- Adding `codecov.yml` to exclude the `apps` and `unittests` directories from the overall code coverage.

In order for this to work on `cositools/nuclearizer`, someone with admin rights would need to add a `CODECOV_TOKEN` to the secrets of the repository.