### PR TITLE
ADD: Codecov badge to `README.md`

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -139,6 +139,7 @@ jobs:
           set -euo pipefail
           cd $NUCLEARIZER
           export PATH=$MEGALIB/bin:$PATH
+          find $MEGALIB/bin -name "*.gcda" -delete
           make unittests COVERAGE=1 CXX="ccache g++" CC="ccache gcc" LB=${{ github.workspace }}/lib BN=${{ github.workspace }}/bin -j$(nproc)
           ${{ github.workspace }}/bin/UTNRunner
 
@@ -162,6 +163,9 @@ jobs:
             --xml coverage.xml \
             --exclude '$NUCLEARIZER/apps/.*' \
             --exclude '$NUCLEARIZER/unittests/.*' \
+            --exclude-throw-branches --exclude-unreachable-branches \
+            --decisions \
+            --gcov-delete \
             -j $(nproc)
 
       - name: Upload Report to Codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # COSI's calibration tool nuclearizer
 
+[![Codecov](https://codecov.io/gh/cositools/nuclearizer/branch/develop/em/graph/badge.svg)](https://codecov.io/gh/cositools/nuclearizer)
+
 ## What is nuclearizer?
 
 Nuclearizer is the detectior calibration tool of the gamma-ray telescope COSI, the Compton Spectrometer and Imager.

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,6 +5,14 @@ ignore:
   - apps/
   - unittests/
 
+parsers:
+  gcov:
+    branch_detection:
+      conditional: false
+      loop: false
+      method: false
+      macro: false
+
 coverage:
   range: 20..90 # coverage lower than 20 is red, higher than 90 green, between color code
 


### PR DESCRIPTION
Following #186, I added a little icon to the `README.md` that will display the current code coverage percentage and link [the codecov page](https://codecov.io/gh/cositools/nuclearizer) for more information.

<img width="930" height="369" alt="image" src="https://github.com/user-attachments/assets/53b38e7d-8427-4c3e-9151-d8ed1a981702" />
