### PR TITLE
CHG: Update XML tags of `EnergyCalibration` and `DepthCalibration`

### DIFF
--- a/CodingConventions.md
+++ b/CodingConventions.md
@@ -37,14 +37,14 @@ To format a file do the following:
 
 ## New classes
 
-For new classes, copy and modify an existing one, or use the MModuleTemplate class as tempplate.
+For new classes, copy and modify an existing one, or use the MModuleTemplate class as template.
 
 ## Naming
 
 ### Classes
 
 * Due to historic reasons, all classes start with M.
-* Modules start with MModule
+* Modules start with MModule, with XML tags starting with XmlTag
 * Option GUI's start with MGUIOptions
 * Expo (= data display) GUI's start with MGUIExpo
 

--- a/Config/Nuclearizer_EM_DEE.cfg
+++ b/Config/Nuclearizer_EM_DEE.cfg
@@ -73,23 +73,16 @@
       <MinimumStripPairingReducedChiSquare>-1</MinimumStripPairingReducedChiSquare>
       <MaximumStripPairingReducedChiSquare>inf</MaximumStripPairingReducedChiSquare>
     </XmlTagEventFilter>
-    <EnergyCalibration>
+    <XmlTagEnergyCalibration>
       <FileName />
       <SlowThresholdCutMode>0</SlowThresholdCutMode>
       <SlowThresholdCutFixedValue>15</SlowThresholdCutFixedValue>
       <SlowThresholdCutThresholdFileName />
       <NearestNeighborCutMode>100</NearestNeighborCutMode>
       <NearestNeighborThreshold>-1000</NearestNeighborThreshold>
-    </EnergyCalibration>
+    </XmlTagEnergyCalibration>
     <XmlTagStripPairingMultiRoundChiSquare />
     <XmlTagStripPairingChiSquare />
-    <DepthCalibration>
-      <CoeffsFileName />
-      <SplinesFileName />
-      <MaskMetrology>true</MaskMetrology>
-      <MaskMetrologyFileName />
-      <UCSDOverride>true</UCSDOverride>
-    </DepthCalibration>
     <XmlTagEventSaver>
       <FileName>/Users/parshadkp/Library/CloudStorage/OneDrive-ClemsonUniversity/COSI/nuclearizer_files/nuclearizer_outputs/STTC/STTC_DEE_Cs137.evta</FileName>
       <Mode>2</Mode>

--- a/resource/unittestdata/406-1/hdf5-to-tra.nuclearizer.cfg
+++ b/resource/unittestdata/406-1/hdf5-to-tra.nuclearizer.cfg
@@ -2,10 +2,10 @@
   <Version>1</Version>
   <ModuleSequence>
     <ModuleSequenceItem>XmlTagMeasurementLoaderHDF</ModuleSequenceItem>
-    <ModuleSequenceItem>EnergyCalibration</ModuleSequenceItem>
+    <ModuleSequenceItem>XmlTagEnergyCalibration</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagTACcut</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagStripPairingMultiRoundChiSquare</ModuleSequenceItem>
-    <ModuleSequenceItem>DepthCalibration</ModuleSequenceItem>
+    <ModuleSequenceItem>XmlTagDepthCalibration</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagRevan</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagEventSaver</ModuleSequenceItem>
   </ModuleSequence>
@@ -17,22 +17,22 @@
       <FileNameStripMap>$(NUCLEARIZER)/resource/unittestdata/406-1/hp52406-1.stripmap.map</FileNameStripMap>
       <IncludeNearestNeighbor>false</IncludeNearestNeighbor>
     </XmlTagMeasurementLoaderHDF>
-    <EnergyCalibration>
+    <XmlTagEnergyCalibration>
       <FileName>$(NUCLEARIZER)/resource/unittestdata/406-1/hp52406-1.full.ecal</FileName>
       <SlowThresholdCutMode>1</SlowThresholdCutMode>
       <SlowThresholdCutFixedValue>20</SlowThresholdCutFixedValue>
       <SlowThresholdCutThresholdFileName />
       <NearestNeighborCutMode>100</NearestNeighborCutMode>
       <NearestNeighborThreshold>-1000</NearestNeighborThreshold>
-    </EnergyCalibration>
+    </XmlTagEnergyCalibration>
     <XmlTagStripPairingMultiRoundChiSquare />
-    <DepthCalibration>
+    <XmlTagDepthCalibration>
       <CoeffsFileName>$(NUCLEARIZER)/resource/unittestdata/406-1/hp52406-1.coeffs.csv</CoeffsFileName>
       <SplinesFileName>$(NUCLEARIZER)/resource/unittestdata/406-1/hp52406-1.splines.csv</SplinesFileName>
       <MaskMetrology>false</MaskMetrology>
       <MaskMetrologyFileName />
       <UCSDOverride>false</UCSDOverride>
-    </DepthCalibration>
+    </XmlTagDepthCalibration>
     <XmlTagEventSaver>
       <FileName>$(NUCLEARIZER)/resource/unittestdata/406-1/hdf5-to-tra.tra</FileName>
       <Mode>3</Mode>

--- a/resource/unittestdata/542-1/hdf5-to-tra.nuclearizer.cfg
+++ b/resource/unittestdata/542-1/hdf5-to-tra.nuclearizer.cfg
@@ -2,10 +2,10 @@
   <Version>1</Version>
   <ModuleSequence>
     <ModuleSequenceItem>XmlTagMeasurementLoaderHDF</ModuleSequenceItem>
-    <ModuleSequenceItem>EnergyCalibration</ModuleSequenceItem>
+    <ModuleSequenceItem>XmlTagEnergyCalibration</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagTACcut</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagStripPairingMultiRoundChiSquare</ModuleSequenceItem>
-    <ModuleSequenceItem>DepthCalibration</ModuleSequenceItem>
+    <ModuleSequenceItem>XmlTagDepthCalibration</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagRevan</ModuleSequenceItem>
     <ModuleSequenceItem>XmlTagEventSaver</ModuleSequenceItem>
   </ModuleSequence>
@@ -17,22 +17,22 @@
       <FileNameStripMap>$(NUCLEARIZER)/resource/unittestdata/542-1/hp52542-1.stripmap.map</FileNameStripMap>
       <IncludeNearestNeighbor>false</IncludeNearestNeighbor>
     </XmlTagMeasurementLoaderHDF>
-    <EnergyCalibration>
+    <XmlTagEnergyCalibration>
       <FileName>$(NUCLEARIZER)/resource/unittestdata/542-1/hp52542-1.full.ecal</FileName>
       <SlowThresholdCutMode>1</SlowThresholdCutMode>
       <SlowThresholdCutFixedValue>20</SlowThresholdCutFixedValue>
       <SlowThresholdCutThresholdFileName />
       <NearestNeighborCutMode>100</NearestNeighborCutMode>
       <NearestNeighborThreshold>-1000</NearestNeighborThreshold>
-    </EnergyCalibration>
+    </XmlTagEnergyCalibration>
     <XmlTagStripPairingMultiRoundChiSquare />
-    <DepthCalibration>
+    <XmlTagDepthCalibration>
       <CoeffsFileName>$(NUCLEARIZER)/resource/unittestdata/542-1/hp52542-1.coeffs.csv</CoeffsFileName>
       <SplinesFileName>$(NUCLEARIZER)/resource/unittestdata/542-1/hp52542-1.splines.csv</SplinesFileName>
       <MaskMetrology>false</MaskMetrology>
       <MaskMetrologyFileName />
       <UCSDOverride>false</UCSDOverride>
-    </DepthCalibration>
+    </XmlTagDepthCalibration>
     <XmlTagEventSaver>
       <FileName>$(NUCLEARIZER)/resource/unittestdata/542-1/hdf5-to-tra.tra</FileName>
       <Mode>3</Mode>

--- a/src/MModuleDepthCalibration.cxx
+++ b/src/MModuleDepthCalibration.cxx
@@ -59,7 +59,7 @@ MModuleDepthCalibration::MModuleDepthCalibration() : MModule()
   m_Name = "Depth Calibration"; // - Determining the depth of each event (by Sean);
 
   // Set the XML tag --- has to be unique --- no spaces allowed
-  m_XmlTag = "DepthCalibration";
+  m_XmlTag = "XmlTagDepthCalibration";
 
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EnergyCalibration, true);
@@ -142,7 +142,7 @@ bool MModuleDepthCalibration::Initialize()
   }
 
   MSupervisor* S = MSupervisor::GetSupervisor();
-  m_EnergyCalibration = (MModuleEnergyCalibration*) S->GetAvailableModuleByXmlTag("EnergyCalibration");
+  m_EnergyCalibration = (MModuleEnergyCalibration*) S->GetAvailableModuleByXmlTag("XmlTagEnergyCalibration");
   if (m_EnergyCalibration == nullptr) {
     cout << "MModuleDepthCalibration: couldn't resolve pointer to Energy Calibration Module... need access to this module for energy resolution lookup!" << endl;
     return false;

--- a/src/MModuleEnergyCalibration.cxx
+++ b/src/MModuleEnergyCalibration.cxx
@@ -70,7 +70,7 @@ MModuleEnergyCalibration::MModuleEnergyCalibration() : MModule()
   m_Name = "Energy calibrator";
 
   // Set the XML tag --- has to be unique --- no spaces allowed
-  m_XmlTag = "EnergyCalibration";
+  m_XmlTag = "XmlTagEnergyCalibration";
 
   // Set all modules, which have to be done before this module
   AddPreceedingModuleType(MAssembly::c_EventLoader);


### PR DESCRIPTION
Addressing #193:
The renaming of the TAC calibration module in #194 might require folks to update their nuclearizer configuration files, so I would suggest to also tackle updating the XML tags of `EnergyCalibration` and `DepthCalibration` to `XmlTagEnergyCalibration` and `XmlTagDepthCalibration` in the same run, so that the config files only have to be updated once.

I also added a small note to the `CodingConventions.md` that XML tags of `MModules` should start with `XmlTag`.


