### PR TITLE
FIX: Clean up the module ordering for the FITS and L0 savers

### DIFF
--- a/include/MGUIOptionsSaverMeasurementsFITS.h
+++ b/include/MGUIOptionsSaverMeasurementsFITS.h
@@ -74,7 +74,6 @@ class MGUIOptionsSaverMeasurementsFITS : public MGUIOptions
   MGUIEFileSelector* m_FileSelectorFITS;
 
   //! Select output level: L1b or L2
-  TGComboBox* m_OutputDataLevelCombo;
 
 
 

--- a/include/MModuleSaverMeasurementsFITS.h
+++ b/include/MModuleSaverMeasurementsFITS.h
@@ -77,12 +77,6 @@ class MModuleSaverMeasurementsFITS : public MModule
   //! Get the output file name
   MString GetFileName() const { return m_FileName; }
 
-  //! Set the output data level: 0 = L1a, 1 = L1b, 2 = L2
-  void SetOutputDataLevel(int Level) { m_OutputDataLevel = Level; ConfigurePreceedingModules(); }
-  //! Get the output data level: 1 = L1b, 2 = L2
-  int GetOutputDataLevel() const { return m_OutputDataLevel; }
-
-
   // protected methods:
  protected:
   //! Create the FITS file and extensions

--- a/src/MAssembly.cxx
+++ b/src/MAssembly.cxx
@@ -138,7 +138,6 @@ MAssembly::MAssembly()
   
   m_Supervisor->AddAvailableModule(new MModuleEventSaver());
   m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsL0());
-  m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS());
   m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITSL1a", 0, "Save events to L1a FITS"));
   m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITSL1b", 1, "Save events to L1b FITS"));
   m_Supervisor->AddAvailableModule(new MModuleSaverMeasurementsFITS("XmlTagSaverMeasurementsFITSL2", 2, "Save events to L2 FITS"));

--- a/src/MGUIOptionsSaverMeasurementsFITS.cxx
+++ b/src/MGUIOptionsSaverMeasurementsFITS.cxx
@@ -74,18 +74,6 @@ void MGUIOptionsSaverMeasurementsFITS::Create()
   m_FileSelectorFITS->SetFileType("FITS file", "*.fit");
   m_OptionsFrame->AddFrame(m_FileSelectorFITS, LabelLayout);
 
-  // Output level selector: L1b or L2
-  TGLabel* LevelLabel = new TGLabel(m_OptionsFrame, "Output Level:");
-  m_OptionsFrame->AddFrame(LevelLabel, LabelLayout);
-
-  m_OutputDataLevelCombo = new TGComboBox(m_OptionsFrame);
-  m_OutputDataLevelCombo->AddEntry("L1a (raw hits, no calibration)", 0);
-  m_OutputDataLevelCombo->AddEntry("L1b (all events, with QUALITY_FLAG)", 1);
-  m_OutputDataLevelCombo->AddEntry("L2 (screened, no QUALITY_FLAG)", 2);
-  m_OutputDataLevelCombo->Select(dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->GetOutputDataLevel());
-  m_OutputDataLevelCombo->Resize(300, 25);
-  m_OptionsFrame->AddFrame(m_OutputDataLevelCombo, LabelLayout);
-
   PostCreate();
 }
 
@@ -129,7 +117,6 @@ bool MGUIOptionsSaverMeasurementsFITS::OnApply()
   // Modify this to store the data in the module!
 
   dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetFileName(m_FileSelectorFITS->GetFileName());
-  dynamic_cast<MModuleSaverMeasurementsFITS*>(m_Module)->SetOutputDataLevel(m_OutputDataLevelCombo->GetSelected());
 
   return true;
 }

--- a/src/MModuleSaverMeasurementsFITS.cxx
+++ b/src/MModuleSaverMeasurementsFITS.cxx
@@ -79,6 +79,11 @@ MModuleSaverMeasurementsFITS::MModuleSaverMeasurementsFITS(MString XmlTag, int O
   // Set all types this modules handles
   AddModuleType(MAssembly::c_EventSaver);
 
+  AddSucceedingModuleType(MAssembly::c_NoRestriction);
+
+  // Allow multiple savers per sequence
+  SetTypeExclusive(false);
+
   // Set if this module has an options GUI
   m_HasOptionsGUI = true;
 
@@ -125,11 +130,6 @@ bool MModuleSaverMeasurementsFITS::Initialize()
 
   // If output data level is 0, call the external m_L1aWriter
   if (m_OutputDataLevel == 0) {
-    // L1b need strip pairing which is not a requirement for L1a.
-    m_PreceedingModules.clear();
-    m_PreceedingModulesHardRequirement.clear();
-    AddPreceedingModuleType(MAssembly::c_EventLoader);
-
     if (m_L1aWriter.Create(m_FileName) == false) {
       if (g_Verbosity >= c_Error) cout<<m_XmlTag<<": Unable to create L1a FITS file."<<endl;
       return false;
@@ -152,12 +152,18 @@ bool MModuleSaverMeasurementsFITS::Initialize()
 
 void MModuleSaverMeasurementsFITS::ConfigurePreceedingModules()
 {
-  m_PreceedingModules.clear();
-  m_PreceedingModulesHardRequirement.clear();
+  // Start from a clean list
+  ClearPreceedingModuleTypes();
 
-  AddPreceedingModuleType(MAssembly::c_EventLoader);
-  if (m_OutputDataLevel != 0) {
+  // The L1a saver should only be shown right after the measurement loader
+  if (m_OutputDataLevel == 0) {
+    AddPreceedingModuleType(MAssembly::c_EventLoaderMeasurement, true, true);
+  } else if (m_OutputDataLevel == 1 || m_OutputDataLevel == 2) {
+    // For L1b and L2, the saver requires event loader, strip pairing, depth calibration, and event reconstruction
+    AddPreceedingModuleType(MAssembly::c_EventLoader);
     AddPreceedingModuleType(MAssembly::c_StripPairing);
+    AddPreceedingModuleType(MAssembly::c_DepthCorrection);
+    AddPreceedingModuleType(MAssembly::c_EventReconstruction);
   }
 }
 
@@ -692,20 +698,6 @@ bool MModuleSaverMeasurementsFITS::ReadXmlConfiguration(MXmlNode* Node)
   if (FileNameNode != nullptr) {
     m_FileName = FileNameNode->GetValue();
   }
-
-  MXmlNode* OutputLevelNode = Node->GetNode("OutputLevel");
-  if (OutputLevelNode != nullptr) {
-    MString Level = OutputLevelNode->GetValue();
-    if (Level == "L2" || Level == "l2") {
-      m_OutputDataLevel = 2;
-    } else if (Level == "L1a" || Level == "l1a") {
-      m_OutputDataLevel = 0;
-    } else {
-      m_OutputDataLevel = 1;
-    }
-  }
-  ConfigurePreceedingModules();
-
   return true;
 }
 
@@ -720,13 +712,6 @@ MXmlNode* MModuleSaverMeasurementsFITS::CreateXmlConfiguration()
   MXmlNode* Node = new MXmlNode(0, m_XmlTag);
   new MXmlNode(Node, "FileName", m_FileName);
 
-  const char* lvl = "L1b";
-  switch (m_OutputDataLevel) {
-    case 0: lvl = "L1a"; break;
-    case 2: lvl = "L2";  break;
-    default: lvl = "L1b"; break;   // 1 = L1b
-  }
-  new MXmlNode(Node, "OutputLevel", lvl);
 
   return Node;
 }

--- a/src/MModuleSaverMeasurementsL0.cxx
+++ b/src/MModuleSaverMeasurementsL0.cxx
@@ -67,8 +67,9 @@ MModuleSaverMeasurementsL0::MModuleSaverMeasurementsL0() : MModule()
 
   // Set all modules, which have to be done before this module:
   // The L0 saver writes simulated events into a binary file - requires an event loader and the detector effects engine module before it
+  // The DEE must be immediately before it
   AddPreceedingModuleType(MAssembly::c_EventLoader);
-  AddPreceedingModuleType(MAssembly::c_DetectorEffectsEngine);
+  AddPreceedingModuleType(MAssembly::c_DetectorEffectsEngine, true, true);
 
   // Set all types this modules handles
   AddModuleType(MAssembly::c_EventSaver);

--- a/src/MModuleSaverMeasurementsL0.cxx
+++ b/src/MModuleSaverMeasurementsL0.cxx
@@ -65,11 +65,16 @@ MModuleSaverMeasurementsL0::MModuleSaverMeasurementsL0() : MModule()
   // Set the XML tag --- has to be unique --- no spaces allowed
   m_XmlTag = "XmlTagSaverMeasurementsL0";
 
-  // Set all modules, which have to be done before this module
+  // Set all modules, which have to be done before this module:
+  // The L0 saver writes simulated events into a binary file - requires an event loader and the detector effects engine module before it
   AddPreceedingModuleType(MAssembly::c_EventLoader);
+  AddPreceedingModuleType(MAssembly::c_DetectorEffectsEngine);
 
   // Set all types this modules handles
   AddModuleType(MAssembly::c_EventSaver);
+
+  // Allow multiple savers per sequence
+  SetTypeExclusive(false);
 
   // Set if this module has an options GUI
   m_HasOptionsGUI = true;


### PR DESCRIPTION
This PR addresses issues from #198 . I made a few changes to how the module picking behaves:

1. The generic MModuleSaverMeasurementsFITS is removed, since it was redundant. I also removed the m_OutputDataLevelCombo, because it is no longer needed.
2. The L0 saver is now available only after an event loader and the DEE.
3. The L1a saver now needs to immediately follow a measurement loader, so it does not appear after the calibration steps.
4. The L1b and L2 savers come after strip pairing, depth calibration, and event reconstruction.