### PR TITLE
Removed HasTriggered variable from MStripHit

### DIFF
--- a/include/MDEEStripHit.h
+++ b/include/MDEEStripHit.h
@@ -82,6 +82,8 @@ struct MDEEStripHit
   double m_Energy;
   //! The measured ADC value
   unsigned int m_ADC;
+  //! If the strip was a nearest neighbor
+  bool m_IsNearestNeighbor;
   //! If the strip has fast timing
   bool m_HasFastTiming;
   //! The measured TAC value in ADC units

--- a/include/MDEEStripHit.h
+++ b/include/MDEEStripHit.h
@@ -82,8 +82,6 @@ struct MDEEStripHit
   double m_Energy;
   //! The measured ADC value
   unsigned int m_ADC;
-  //! If the strip exceeds thresholds
-  bool m_HasTriggered;
   //! If the strip has fast timing
   bool m_HasFastTiming;
   //! The measured TAC value in ADC units

--- a/include/MStripHit.h
+++ b/include/MStripHit.h
@@ -134,11 +134,6 @@ class MStripHit
   //! Return whether the strip has passed the fast threshold
   bool HasFastTiming() const { return m_HasFastTiming; }
 
-  //! Set whether the strip has triggered (ADC values above slow threshold)
-  void HasTriggered(bool HasTriggered) { m_HasTriggered = HasTriggered; }
-  //! Return whether the strip has triggered (ADC values above slow threshold)
-  bool HasTriggered() const { return m_HasTriggered; }
-
   //! TODO: Rename to HasTiming()
   //! Set the calibrated-timing flag
   void HasCalibratedTiming(bool CalibratedTiming) { m_HasCalibratedTiming = CalibratedTiming; }
@@ -205,8 +200,6 @@ class MStripHit
   bool m_IsGuardRing;
   //! True if the hit is a nearest neighbor hit
   bool m_IsNearestNeighbor;
-  //! True if the strip has triggered
-  bool m_HasTriggered;
   //! True if the hit has fast timing
   bool m_HasFastTiming;
   //! True if the hit has calibrated timing

--- a/src/MDEEStripHit.cxx
+++ b/src/MDEEStripHit.cxx
@@ -44,7 +44,7 @@ ClassImp(MDEEStripHit)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MDEEStripHit::MDEEStripHit() : m_SimulatedEventID(0), m_SimulatedPosition(0,0,0), m_SimulatedPositionInDetector(0,0,0), m_SimulatedRelativeDepth(0), m_SimulatedEnergy(0), m_SimulatedIsGuardRing(false), m_SimulatedHitIndex(0), m_IsGuardRing(false), m_Energy(0), m_ADC(0), m_HasTriggered(false), m_HasFastTiming(false), m_TAC(0)
+MDEEStripHit::MDEEStripHit() : m_SimulatedEventID(0), m_SimulatedPosition(0,0,0), m_SimulatedPositionInDetector(0,0,0), m_SimulatedRelativeDepth(0), m_SimulatedEnergy(0), m_SimulatedIsGuardRing(false), m_SimulatedHitIndex(0), m_IsGuardRing(false), m_Energy(0), m_ADC(0), m_HasFastTiming(false), m_TAC(0)
 {
   // Construct an instance of MDEEStripHit
 }
@@ -61,7 +61,6 @@ MStripHit* MDEEStripHit::Convert()
   SH->SetDetectorID(m_ROE.GetDetectorID());
   SH->SetStripID(m_ROE.GetStripID());
   SH->IsLowVoltageStrip(m_ROE.IsLowVoltageStrip());
-  SH->HasTriggered(m_HasTriggered);
   SH->SetADCUnits(m_ADC);
   SH->SetTAC(m_TAC);
   SH->HasFastTiming(m_HasFastTiming);

--- a/src/MDEEStripHit.cxx
+++ b/src/MDEEStripHit.cxx
@@ -44,7 +44,7 @@ ClassImp(MDEEStripHit)
 ////////////////////////////////////////////////////////////////////////////////
 
 
-MDEEStripHit::MDEEStripHit() : m_SimulatedEventID(0), m_SimulatedPosition(0,0,0), m_SimulatedPositionInDetector(0,0,0), m_SimulatedRelativeDepth(0), m_SimulatedEnergy(0), m_SimulatedIsGuardRing(false), m_SimulatedHitIndex(0), m_IsGuardRing(false), m_Energy(0), m_ADC(0), m_HasFastTiming(false), m_TAC(0)
+MDEEStripHit::MDEEStripHit() : m_SimulatedEventID(0), m_SimulatedPosition(0,0,0), m_SimulatedPositionInDetector(0,0,0), m_SimulatedRelativeDepth(0), m_SimulatedEnergy(0), m_SimulatedIsGuardRing(false), m_SimulatedHitIndex(0), m_IsGuardRing(false), m_Energy(0), m_ADC(0), m_IsNearestNeighbor(true), m_HasFastTiming(false), m_TAC(0)
 {
   // Construct an instance of MDEEStripHit
 }
@@ -64,6 +64,7 @@ MStripHit* MDEEStripHit::Convert()
   SH->SetADCUnits(m_ADC);
   SH->SetTAC(m_TAC);
   SH->HasFastTiming(m_HasFastTiming);
+  SH->IsNearestNeighbor(m_IsNearestNeighbor);
   //SH->AddOrigins();
   SH->IsGuardRing(m_IsGuardRing);
 

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -131,6 +131,7 @@ bool MStripHit::Parse(const MString& Line, int Version)
     SetDetectorID(det_id);
     IsLowVoltageStrip(pos_strip == 'l');
     SetStripID(strip_id);
+    IsNearestNeighbor(has_triggered == 0);
     SetTiming(timing);
     SetADCUnits(adc);
     SetEnergy(energy);
@@ -168,6 +169,7 @@ bool MStripHit::StreamDat(ostream& S, int Version)
    <<m_ReadOutElement->GetDetectorID()<<" "
    <<((m_ReadOutElement->IsLowVoltageStrip() == true) ? "l" : "h")<<" "
    <<m_ReadOutElement->GetStripID()<<" "
+   <<(m_IsNearestNeighbor == false)<<" "
    <<setprecision(9)<<m_Timing<<" "
    <<m_ADCUnits<<" "
    <<m_Energy<<" "

--- a/src/MStripHit.cxx
+++ b/src/MStripHit.cxx
@@ -77,7 +77,6 @@ void MStripHit::Clear()
   // Reset all data
 
   m_ReadOutElement->Clear();
-  m_HasTriggered = false;
   m_ADCUnits = 0;
   m_Energy = 0;
   m_EnergyResolution = 0;
@@ -132,7 +131,6 @@ bool MStripHit::Parse(const MString& Line, int Version)
     SetDetectorID(det_id);
     IsLowVoltageStrip(pos_strip == 'l');
     SetStripID(strip_id);
-    HasTriggered(has_triggered != 0);
     SetTiming(timing);
     SetADCUnits(adc);
     SetEnergy(energy);
@@ -170,7 +168,6 @@ bool MStripHit::StreamDat(ostream& S, int Version)
    <<m_ReadOutElement->GetDetectorID()<<" "
    <<((m_ReadOutElement->IsLowVoltageStrip() == true) ? "l" : "h")<<" "
    <<m_ReadOutElement->GetStripID()<<" "
-   <<m_HasTriggered<<" "
    <<setprecision(9)<<m_Timing<<" "
    <<m_ADCUnits<<" "
    <<m_Energy<<" "

--- a/unittests/TestingConventions.md
+++ b/unittests/TestingConventions.md
@@ -236,9 +236,9 @@ Passed = EvaluateTrue("IsLowVoltageStrip()", "alias true",
                       "IsLowVoltageStrip() returns true after IsXStrip(true)",
                       H.IsLowVoltageStrip() == true) && Passed;
 
-Passed = EvaluateFalse("HasTriggered()", "default",
-                       "Default HasTriggered is false",
-                       H.HasTriggered()) && Passed;
+Passed = EvaluateFalse("HasFastTiming()", "default",
+                       "Default HasFastTiming is false",
+                       H.HasFastTiming()) && Passed;
 ```
 
 Arguments: `Function`, `Input`, `Description`, `bool`.  All four arguments are

--- a/unittests/UTNDEEStripHit.cxx
+++ b/unittests/UTNDEEStripHit.cxx
@@ -89,7 +89,7 @@ bool UTNDEEStripHit::TestDefaultConstruction()
   Passed = EvaluateFalse("MDEEStripHit()", "default guard ring", "Default guard ring flag is false", H.m_IsGuardRing) && Passed;
   Passed = EvaluateNear("MDEEStripHit()", "default measured energy", "Default measured energy is 0", H.m_Energy, 0.0, 1e-12) && Passed;
   Passed = Evaluate("MDEEStripHit()", "default ADC", "Default ADC value is 0", H.m_ADC, (unsigned int) 0) && Passed;
-  Passed = EvaluateFalse("MDEEStripHit()", "default trigger", "Default trigger flag is false", H.m_HasTriggered) && Passed;
+  Passed = EvaluateTrue("MDEEStripHit()", "default nearest neighbor flag", "Default nearest neighbor flag is true", H.m_IsNearestNeighbor) && Passed;
   Passed = EvaluateFalse("MDEEStripHit()", "default fast timing", "Default fast timing is false", H.m_HasFastTiming) && Passed;
   Passed = Evaluate("MDEEStripHit()", "default TAC", "Default TAC value is 0", H.m_TAC, (unsigned int) 0) && Passed;
   Passed = Evaluate("MDEEStripHit()", "default sub strip hits", "Default sub strip hit list is empty", (unsigned int) H.m_SubStripHits.size(), (unsigned int) 0) && Passed;
@@ -111,7 +111,7 @@ bool UTNDEEStripHit::TestConvertRepresentativeValues()
   H.m_ROE.SetDetectorID(7);
   H.m_ROE.SetStripID(41);
   H.m_ROE.IsLowVoltageStrip(false);
-  H.m_HasTriggered = true;
+  H.m_IsNearestNeighbor = false;
   H.m_HasFastTiming = true;
   H.m_ADC = 4053;
   H.m_TAC = 10452;
@@ -125,7 +125,7 @@ bool UTNDEEStripHit::TestConvertRepresentativeValues()
     Passed = Evaluate("Convert()", "representative detector ID", "Convert() transfers detector ID 7", Converted->GetDetectorID(), (unsigned int) 7) && Passed;
     Passed = Evaluate("Convert()", "representative strip ID", "Convert() transfers strip ID 41", Converted->GetStripID(), (unsigned int) 41) && Passed;
     Passed = EvaluateFalse("Convert()", "representative strip side high voltage", "Convert() transfers IsLowVoltageStrip(false) as high-voltage strip", Converted->IsLowVoltageStrip()) && Passed;
-    Passed = EvaluateTrue("Convert()", "representative trigger", "Convert() transfers HasTriggered true", Converted->HasTriggered()) && Passed;
+    Passed = EvaluateFalse("Convert()", "representative nearest neighbor flag", "Convert() transfers IsNearestNeighbor false", Converted->IsNearestNeighbor()) && Passed;
     Passed = EvaluateTrue("Convert()", "representative fast timing", "Convert() transfers HasFastTiming true", Converted->HasFastTiming()) && Passed;
     Passed = EvaluateNear("Convert()", "representative ADC", "Convert() transfers ADC value 4053", Converted->GetADCUnits(), 4053.0, 1e-9) && Passed;
     Passed = EvaluateNear("Convert()", "representative TAC", "Convert() transfers TAC value 10452", Converted->GetTAC(), 10452.0, 1e-9) && Passed;
@@ -150,7 +150,7 @@ bool UTNDEEStripHit::TestConvertFalsePaths()
   H.m_ROE.SetDetectorID(1);
   H.m_ROE.SetStripID(2);
   H.m_ROE.IsLowVoltageStrip(true);
-  H.m_HasTriggered = false;
+  H.m_IsNearestNeighbor = true;
   H.m_HasFastTiming = false;
   H.m_ADC = 0;
   H.m_TAC = 0;
@@ -162,7 +162,7 @@ bool UTNDEEStripHit::TestConvertFalsePaths()
 
   if (Converted != nullptr) {
     Passed = EvaluateTrue("Convert()", "low-voltage strip side", "Convert() transfers IsLowVoltageStrip(true) for low-voltage strips", Converted->IsLowVoltageStrip()) && Passed;
-    Passed = EvaluateFalse("Convert()", "false-path trigger", "Convert() transfers HasTriggered false", Converted->HasTriggered()) && Passed;
+    Passed = EvaluateTrue("Convert()", "false-path nearest neighbor flag", "Convert() transfers IsNearestNeighbor true", Converted->IsNearestNeighbor()) && Passed;
     Passed = EvaluateFalse("Convert()", "false-path fast timing", "Convert() transfers HasFastTiming false", Converted->HasFastTiming()) && Passed;
     Passed = EvaluateFalse("Convert()", "false-path guard ring", "Convert() transfers IsGuardRing false", Converted->IsGuardRing()) && Passed;
     Passed = EvaluateNear("Convert()", "false-path ADC", "Convert() transfers ADC value 0", Converted->GetADCUnits(), 0.0, 1e-12) && Passed;
@@ -187,7 +187,7 @@ bool UTNDEEStripHit::TestConvertLifecycleIndependence()
   H.m_ROE.SetDetectorID(3);
   H.m_ROE.SetStripID(9);
   H.m_ROE.IsLowVoltageStrip(true);
-  H.m_HasTriggered = true;
+  H.m_IsNearestNeighbor = false;
   H.m_HasFastTiming = true;
   H.m_ADC = 100;
   H.m_TAC = 200;

--- a/unittests/UTNStripHit.cxx
+++ b/unittests/UTNStripHit.cxx
@@ -80,7 +80,7 @@ bool UTNStripHit::TestDefaultConstruction()
   Passed = Evaluate("GetDetectorID()", "default", "Default DetectorID is undefined", H.GetDetectorID(), g_UnsignedIntNotDefined) && Passed;
   Passed = Evaluate("GetStripID()", "default", "Default StripID is undefined", H.GetStripID(), g_UnsignedIntNotDefined) && Passed;
   Passed = EvaluateTrue("IsLowVoltageStrip()", "default", "Default strip is on the low voltage side", H.IsLowVoltageStrip()) && Passed;
-  Passed = EvaluateFalse("HasTriggered()", "default", "Default HasTriggered is false", H.HasTriggered()) && Passed;
+  Passed = EvaluateFalse("IsNearestNeighbor()", "default", "Default IsNearestNeighbor is true", H.IsNearestNeighbor()) && Passed;
   Passed = EvaluateNear("GetADCUnits()", "default", "Default ADCUnits is 0", H.GetADCUnits(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetEnergy()", "default", "Default Energy is 0", H.GetEnergy(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("GetEnergyResolution()", "default", "Default EnergyResolution is 0", H.GetEnergyResolution(), 0.0, 1e-12) && Passed;
@@ -97,7 +97,7 @@ bool UTNStripHit::TestDefaultConstruction()
   H.SetDetectorID(5);
   H.SetStripID(12);
   H.IsLowVoltageStrip(true);
-  H.HasTriggered(true);
+  H.IsNearestNeighbor(false);
   H.SetADCUnits(1234.0);
   H.SetEnergy(511.0);
   H.SetTAC(9999.0);
@@ -113,7 +113,7 @@ bool UTNStripHit::TestDefaultConstruction()
   Passed = Evaluate("Clear() DetectorID", "after clear", "Clear() resets DetectorID to undefined", H.GetDetectorID(), g_UnsignedIntNotDefined) && Passed;
   Passed = Evaluate("Clear() StripID", "after clear", "Clear() resets StripID to undefined", H.GetStripID(), g_UnsignedIntNotDefined) && Passed;
   Passed = EvaluateTrue("Clear() IsLowVoltageStrip", "after clear", "Clear() resets IsLowVoltageStrip to true", H.IsLowVoltageStrip()) && Passed;
-  Passed = EvaluateFalse("Clear() HasTriggered", "after clear", "Clear() resets HasTriggered to false", H.HasTriggered()) && Passed;
+  Passed = EvaluateFalse("Clear() IsNearestNeighbor", "after clear", "Clear() resets IsNearestNeighbor to true", H.IsNearestNeighbor()) && Passed;
   Passed = EvaluateNear("Clear() ADCUnits", "after clear", "Clear() resets ADCUnits to 0", H.GetADCUnits(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("Clear() Energy", "after clear", "Clear() resets Energy to 0", H.GetEnergy(), 0.0, 1e-12) && Passed;
   Passed = EvaluateNear("Clear() TAC", "after clear", "Clear() resets TAC to 0", H.GetTAC(), 0.0, 1e-12) && Passed;
@@ -158,11 +158,11 @@ bool UTNStripHit::TestGettersSetters()
   H.IsXStrip(false);
   Passed = EvaluateFalse("IsXStrip(bool)/IsXStrip()", "deprecated false", "IsXStrip() returns false after IsXStrip(false)", H.IsXStrip()) && Passed;
 
-  // HasTriggered
-  H.HasTriggered(true);
-  Passed = EvaluateTrue("HasTriggered(bool)/HasTriggered()", "representative true", "HasTriggered() returns true after HasTriggered(true)", H.HasTriggered()) && Passed;
-  H.HasTriggered(false);
-  Passed = EvaluateFalse("HasTriggered(bool)/HasTriggered()", "representative false", "HasTriggered() returns false after HasTriggered(false)", H.HasTriggered()) && Passed;
+  // IsNearestNeighbor
+  H.IsNearestNeighbor(true);
+  Passed = EvaluateTrue("IsNearestNeighbor(bool)/IsNearestNeighbor()", "representative true", "IsNearestNeighbor() returns true after IsNearestNeighbor(true)", H.IsNearestNeighbor()) && Passed;
+  H.IsNearestNeighbor(false);
+  Passed = EvaluateFalse("IsNearestNeighbor(bool)/IsNearestNeighbor()", "representative false", "IsNearestNeighbor() returns false after IsNearestNeighbor(false)", H.IsNearestNeighbor()) && Passed;
 
   // ADCUnits
   H.SetADCUnits(4095.0);
@@ -370,7 +370,6 @@ bool UTNStripHit::TestStreamDatParse()
   Writer.SetDetectorID(2);
   Writer.IsLowVoltageStrip(true);
   Writer.SetStripID(37);
-  Writer.HasTriggered(true);
   Writer.SetTiming(500.123);
   Writer.SetADCUnits(2950.75);
   Writer.SetEnergy(662.0);
@@ -400,8 +399,6 @@ bool UTNStripHit::TestStreamDatParse()
                     Reader.GetStripID(), 37u) && Passed;
   Passed = EvaluateTrue("Parse()", "IsLowVoltageStrip", "Parse() restores the low-voltage-side flag",
                         Reader.IsLowVoltageStrip() == true) && Passed;
-  Passed = EvaluateTrue("Parse()", "HasTriggered", "Parse() restores the representative HasTriggered flag",
-                        Reader.HasTriggered() == true) && Passed;
   Passed = EvaluateNear("Parse()", "Timing", "Parse() restores the representative Timing value 500.123",
                         Reader.GetTiming(), 500.123, 1e-6) && Passed;
   Passed = EvaluateNear("Parse()", "ADCUnits", "Parse() restores the representative ADCUnits value 2950.75",
@@ -440,13 +437,13 @@ bool UTNStripHit::TestStreamDatParse()
                       (unsigned int) Reused.GetOrigins().size(), (unsigned int) 0) && Passed;
   }
 
-  // High voltage side round-trip: verify 'h' marker and HasTriggered(false) survive StreamDat/Parse
+  // High voltage side round-trip: verify 'h' marker and IsNearestNeighbor(true) survive StreamDat/Parse
   {
     MStripHit WriterHV;
     WriterHV.SetDetectorID(5);
     WriterHV.IsLowVoltageStrip(false);
     WriterHV.SetStripID(18);
-    WriterHV.HasTriggered(false);
+    WriterHV.IsNearestNeighbor(true);
     WriterHV.SetTiming(99.5);
     WriterHV.SetADCUnits(1000.0);
     WriterHV.SetEnergy(356.0);
@@ -459,8 +456,8 @@ bool UTNStripHit::TestStreamDatParse()
                           ReaderHV.Parse(LineHV)) && Passed;
     Passed = EvaluateFalse("Parse()", "HV IsLowVoltageStrip", "Parse() restores IsLowVoltageStrip false for a strip on the high voltage side",
                            ReaderHV.IsLowVoltageStrip()) && Passed;
-    Passed = EvaluateFalse("Parse()", "HV HasTriggered false", "Parse() restores HasTriggered false for the strip on the high voltage side",
-                           ReaderHV.HasTriggered()) && Passed;
+    Passed = EvaluateTrue("Parse()", "HV IsNearestNeighbor true", "Parse() restores IsNearestNeighbor true for the strip on the high voltage side",
+                           ReaderHV.IsNearestNeighbor()) && Passed;
     Passed = EvaluateNear("Parse()", "HV Timing", "Parse() restores Timing 99.5 for the strip on the high voltage side",
                           ReaderHV.GetTiming(), 99.5, 1e-6) && Passed;
   }


### PR DESCRIPTION
As agreed upon in the August 18th CDEE meeting, we're removing the HasTriggered variable from MStripHit. This variable wasn't used in the HDF measurement loader, and it is redundant (but opposite to) IsNearestNeighbor. 

Note that I kept the HasTriggered variable as part of the MShieldCrystalHit and MCrystalHit class (it seems like one of these is a duplicate...)